### PR TITLE
Clear modalLoadAbortRef.current after abort in closeModal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -327,6 +327,7 @@ export default function App() {
   // Focus Contract Items 5-6: Restores focus to trigger, safely handles null trigger
   const closeModal = useCallback(() => {
     modalLoadAbortRef.current?.abort();
+    modalLoadAbortRef.current = null;
     activeModalRef.current = null;
     setActiveModal(null);
     setModalContent('');


### PR DESCRIPTION
After calling `modalLoadAbortRef.current?.abort()` in `closeModal`, the ref was left pointing at the now-aborted controller until the next `openModal` call overwrote it. This patch sets the ref to `null` immediately after aborting, matching the cleanup pattern already used for `activeModalRef` and `modalTriggerRef` in the same function and eliminating the minor code-smell of holding a stale reference to a spent controller.