### PR TITLE
Add loadCampaignImages to mount effect deps array

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -439,7 +439,7 @@ export default function App() {
       isMounted = false;
       campaignLoadAbortRef.current?.abort();
     };
-  }, []); // On mount: initializes app state, fetches campaigns and images, handles errors, and manages per-campaign loading state
+  }, [loadCampaignImages]); // On mount: loadCampaignImages is a stable useCallback([]) so this runs once
 
   // Animated dots for the CRT loader
   useEffect(() => {


### PR DESCRIPTION
`loadCampaignImages` is defined with `useCallback(async (...) => { ... }, [])`, making it referentially stable across renders. Adding it to the mount effect's dependency array satisfies `react-hooks/exhaustive-deps` without changing runtime behavior — the effect still runs exactly once on mount, but the code is now lint-clean and resilient to any future lint configuration changes.