### PR TITLE
Guard localStorage access for SSR safety

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -118,6 +118,7 @@ export default function App() {
 
   // Load accessibility settings from localStorage on mount
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     try {
       const saved = localStorage.getItem('fringematrix-a11y');
       if (saved) {
@@ -133,6 +134,7 @@ export default function App() {
     const root = document.documentElement;
     root.classList.toggle('reduce-motion', reduceMotion);
     root.classList.toggle('reduce-effects', reduceEffects);
+    if (typeof window === 'undefined') return;
     try {
       localStorage.setItem('fringematrix-a11y', JSON.stringify({ reduceMotion, reduceEffects }));
     } catch { /* ignore storage errors */ }


### PR DESCRIPTION
## Summary

- Added `typeof window !== 'undefined'` guard before `localStorage.getItem` in the accessibility settings load effect (line ~122)
- Added `typeof window !== 'undefined'` guard before `localStorage.setItem` in the accessibility settings persist effect (line ~137)
- Both calls are inside `useEffect` so they never run in the current CSR-only build, but the guards make the code safe for future SSR without any behaviour change today

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run test:client` — 282 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)