### PR TITLE
Test coverage: /avatars/* redirect route

### DIFF
--- a/server/test/api.avatars.test.ts
+++ b/server/test/api.avatars.test.ts
@@ -1,0 +1,111 @@
+import request from 'supertest';
+import { jest, describe, it, expect, beforeAll } from '@jest/globals';
+
+// This file exercises the /avatars/* redirect route (server.ts:235-267).
+// The route lists blobs, looks for an exact path match, and:
+//   - 302 redirects to blob.url when found
+//   - 404 when no matching blob exists
+//   - 503 (or 429) when Vercel Blob is unavailable
+
+const listMock = jest.fn();
+
+jest.unstable_mockModule('@vercel/blob', () => ({
+  list: listMock,
+  put: jest.fn(),
+  del: jest.fn(),
+  head: jest.fn(),
+}));
+
+let app: any;
+
+beforeAll(async () => {
+  process.env['BLOB_READ_WRITE_TOKEN'] = 'test-token';
+  const serverModule = await import('../server.ts');
+  app = serverModule.default;
+});
+
+describe('/avatars/* redirect route', () => {
+  it('302 redirects to blob CDN URL when blob is found', async () => {
+    listMock.mockReset();
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          pathname: 'avatars/fringematrix5/myavatar.png',
+          url: 'https://cdn.example.com/fringematrix5/myavatar.png',
+          size: 12345,
+        },
+      ],
+    });
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get('/avatars/fringematrix5/myavatar.png');
+
+    expect(res.status).toBe(302);
+    expect(res.headers['location']).toBe(
+      'https://cdn.example.com/fringematrix5/myavatar.png'
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns 404 when no blob matches the requested path', async () => {
+    listMock.mockReset();
+    // Blob listing returns blobs with a different pathname — no exact match
+    listMock.mockResolvedValue({
+      blobs: [
+        {
+          pathname: 'avatars/fringematrix5/other.png',
+          url: 'https://cdn.example.com/fringematrix5/other.png',
+          size: 999,
+        },
+      ],
+    });
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get('/avatars/fringematrix5/missing.png');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns 404 when blob listing is empty', async () => {
+    listMock.mockReset();
+    listMock.mockResolvedValue({ blobs: [] });
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get('/avatars/fringematrix5/nonexistent.png');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns 503 when Vercel Blob is unavailable', async () => {
+    listMock.mockReset();
+    // Simulate a network/connection failure — the server wraps this in
+    // BlobUnavailableError and must respond 503 (not 500).
+    // Use a unique path so the server's blob cache from previous tests does
+    // not short-circuit the mock and return a cached 302.
+    listMock.mockRejectedValue(
+      Object.assign(new Error('connect ECONNREFUSED'), { name: 'TypeError' })
+    );
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const consoleLogSpy = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => {});
+
+    const res = await request(app).get('/avatars/fringematrix5/unavailable-unique-503.png');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toMatch(/Vercel Blob unavailable/i);
+
+    consoleSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `server/test/api.avatars.test.ts` covering the previously-untested `/avatars/*` redirect route (server.ts:235–267)
- Uses the same `jest.unstable_mockModule` pattern established in `api.blob-errors.test.ts`

## Test cases added

- **302 redirect (happy path):** `list` returns a blob with the exact requested `pathname`; response must be a 302 redirect to `blob.url`
- **404 when blob not found:** `list` returns blobs with a different pathname (no exact match); response must be 404 with an `error` body
- **503 when Vercel Blob is unavailable:** `list` rejects with a network-style `TypeError`; `listBlobsWithCache` wraps this in `BlobUnavailableError` and the route handler must surface a 503 (not a generic 500)

> Note: the 503 test uses a unique request path to prevent the server's in-process blob cache from serving a cached 302 from an earlier test in the suite.

Closes issue fringematrix5-6yg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the avatars redirect route, verifying redirect functionality, error handling, and service availability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/46)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->