### PR TITLE
Clarify/remove activeModalRef guards in openModal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -106,8 +106,6 @@ export default function App() {
   const settingsTriggerRef = useRef<HTMLElement | null>(null);
   const settingsCloseRef = useRef<HTMLButtonElement>(null);
   const settingsModalRef = useRef<HTMLDivElement>(null);
-  // Tracks which modal is loading; ContentModal owns the keyboard/focus trap.
-  const activeModalRef = useRef<ContentPage | null>(null);
   const modalLoadAbortRef = useRef<AbortController | null>(null);
   const modalTriggerRef = useRef<HTMLElement | null>(null);
 
@@ -298,8 +296,6 @@ export default function App() {
     // Focus Contract Item 1: Store the trigger element for focus restoration when modal closes
     modalTriggerRef.current = document.activeElement as HTMLElement;
 
-    // activeModalRef stays as defense in depth alongside abort signal
-    activeModalRef.current = page;
     setActiveModal(page);
     setIsModalLoading(true);
     setModalContent('');
@@ -307,19 +303,15 @@ export default function App() {
     try {
       const data = await fetchJSON<ContentResponse>(`/api/content/${page}`, { signal });
       if (signal.aborted) return;
-      if (activeModalRef.current === page) {
-        // Sanitize HTML to prevent XSS attacks
-        const sanitizedContent = DOMPurify.sanitize(data.content);
-        setModalContent(sanitizedContent);
-      }
+      // Sanitize HTML to prevent XSS attacks
+      const sanitizedContent = DOMPurify.sanitize(data.content);
+      setModalContent(sanitizedContent);
     } catch (e) {
       if (signal.aborted || (e instanceof DOMException && e.name === 'AbortError')) return;
       console.error('Failed to load content:', e);
-      if (activeModalRef.current === page) {
-        setModalContent('<p>Failed to load content. Please try again.</p>');
-      }
+      setModalContent('<p>Failed to load content. Please try again.</p>');
     } finally {
-      if (!signal.aborted && activeModalRef.current === page) {
+      if (!signal.aborted) {
         setIsModalLoading(false);
       }
     }
@@ -330,7 +322,6 @@ export default function App() {
   const closeModal = useCallback(() => {
     modalLoadAbortRef.current?.abort();
     modalLoadAbortRef.current = null;
-    activeModalRef.current = null;
     setActiveModal(null);
     setModalContent('');
     setIsModalLoading(false);


### PR DESCRIPTION
## Summary

- Removes `activeModalRef` from `App.tsx` entirely
- Removes all `activeModalRef.current === page` guards in `openModal` and the `activeModalRef.current = null` reset in `closeModal`

## Decision rationale

The `activeModalRef.current === page` guards were described as "defense in depth" alongside `signal.aborted` checks. After analysis, they are fully redundant:

**The invariant:** Every code path that could modify `activeModalRef.current` also aborts the current controller first:
- A second `openModal(page2)` call → calls `modalLoadAbortRef.current?.abort()` → sets `signal.aborted = true` on the first call's signal → then sets `activeModalRef.current = page2`
- `closeModal()` → calls `modalLoadAbortRef.current?.abort()` → sets `signal.aborted = true` → then sets `activeModalRef.current = null`

In both cases the `if (signal.aborted) return` guards at the top of the try/catch blocks fire before execution ever reaches the ref-equality checks. The ref check can never catch a scenario that the abort signal has not already caught.

The only way `activeModalRef` could provide independent protection is if something changed it *without* also aborting the controller — but no such code path exists.

**Result:** The code is simplified to use only the AbortController pattern consistently, which is the canonical async-cancellation mechanism here.

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm run test:client` — 291/291 tests pass

Resolves fringematrix5-y91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)