### PR TITLE
Extract swipe and animation magic numbers to named constants

### DIFF
--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -2,9 +2,11 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import type { ImageData } from '../types/api';
 
-// Swipe thresholds tuned to feel responsive without firing on incidental drags.
+/** Minimum horizontal travel (px) required for a touch to count as a swipe. */
 const SWIPE_MIN_HORIZONTAL_PX = 50;
+/** Maximum vertical drift (px) allowed before a gesture is treated as a scroll. */
 const SWIPE_MAX_VERTICAL_PX = 75;
+/** Maximum gesture duration (ms); longer presses are not counted as swipes. */
 const SWIPE_MAX_DURATION_MS = 500;
 
 interface Props {


### PR DESCRIPTION
## Summary

Closes fringematrix5-1h4. Replaces a single block comment covering all three swipe constants in `LightboxContainer.tsx` with individual JSDoc comments that explain each constant's role:

- **`SWIPE_MIN_HORIZONTAL_PX = 50`** — Minimum horizontal travel (px) required for a touch to count as a swipe.
- **`SWIPE_MAX_VERTICAL_PX = 75`** — Maximum vertical drift (px) allowed before a gesture is treated as a scroll.
- **`SWIPE_MAX_DURATION_MS = 500`** — Maximum gesture duration (ms); longer presses are not counted as swipes.

The `useLightboxAnimations.ts` constants (`LAYOUT_RETRY_LIMIT = 3`, `LAYOUT_RETRY_TIMEOUT_MS = 500`) already had per-constant JSDoc comments from the App.tsx decomposition in PR #39, so no changes are needed there.

## Test plan
- [x] `npm run typecheck` — passes with no errors
- [x] `npm run test:client` — 291 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)