### PR TITLE
Extract useFocusTrap hook from ContentModal and settings modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { useLightboxAnimations } from './hooks/useLightboxAnimations';
+import { useFocusTrap } from './hooks/useFocusTrap';
 import { fetchJSON } from './utils/fetchJSON';
 import { formatTimePacific } from './utils/formatTimePacific';
 import { gitRemoteToHttps } from './utils/gitRemoteToHttps';
@@ -480,7 +481,10 @@ export default function App() {
     settingsTriggerRef.current = null;
   }, []);
 
-  // Settings modal keyboard handler and focus management
+  // Settings modal: trap Tab and handle Escape via shared hook
+  useFocusTrap(isSettingsOpen, settingsModalRef, closeSettings);
+
+  // Settings modal: focus the close button on open
   useEffect(() => {
     if (!isSettingsOpen) return;
 
@@ -488,39 +492,10 @@ export default function App() {
       settingsCloseRef.current?.focus();
     }, 0);
 
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        closeSettings();
-        return;
-      }
-
-      if (e.key === 'Tab' && settingsModalRef.current) {
-        const focusableElements = settingsModalRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement?.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement?.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener('keydown', onKey);
     return () => {
       clearTimeout(focusTimer);
-      document.removeEventListener('keydown', onKey);
     };
-  }, [isSettingsOpen, closeSettings]);
+  }, [isSettingsOpen]);
 
   return (
     <div id="app">

--- a/client/src/components/ContentModal.tsx
+++ b/client/src/components/ContentModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { ContentPage } from '../types/api';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 // =============================================================================
 // Focus Management Contract (ContentModal):
@@ -26,6 +27,9 @@ export default function ContentModal({ activeModal, content, isLoading, onClose 
   const modalRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
 
+  // Focus Contract Item 3 & 4: trap Tab and handle Escape via shared hook
+  useFocusTrap(!!activeModal, modalRef, onClose);
+
   useEffect(() => {
     if (!activeModal) return;
 
@@ -34,41 +38,10 @@ export default function ContentModal({ activeModal, content, isLoading, onClose 
       closeRef.current?.focus();
     }, 0);
 
-    const onKey = (e: KeyboardEvent) => {
-      // Focus Contract Item 4: Escape closes
-      if (e.key === 'Escape') {
-        onClose();
-        return;
-      }
-
-      // Focus Contract Item 3: trap Tab inside the modal
-      if (e.key === 'Tab' && modalRef.current) {
-        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement?.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement?.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener('keydown', onKey);
     return () => {
       clearTimeout(focusTimer);
-      document.removeEventListener('keydown', onKey);
     };
-  }, [activeModal, onClose]);
+  }, [activeModal]);
 
   if (!activeModal) return null;
 

--- a/client/src/hooks/useFocusTrap.ts
+++ b/client/src/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps keyboard focus inside `modalRef` while `active` is true.
+ *
+ * Behaviour:
+ * - Escape key → calls `onClose`
+ * - Tab on the last focusable element wraps to the first
+ * - Shift+Tab on the first focusable element wraps to the last
+ * - Cleans up the keydown listener on deactivation / unmount
+ */
+export function useFocusTrap(
+  active: boolean,
+  modalRef: React.RefObject<HTMLElement | null>,
+  onClose: () => void
+): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          FOCUSABLE_SELECTOR
+        );
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement?.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement?.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [active, modalRef, onClose]);
+}


### PR DESCRIPTION
## Summary

- Extracted a new `useFocusTrap(active, modalRef, onClose)` hook into `client/src/hooks/useFocusTrap.ts`
- The hook centralises the three behaviours that were duplicated verbatim in `ContentModal.tsx` and the settings-modal `useEffect` in `App.tsx`: Escape key → `onClose`, Tab/Shift+Tab cycling among focusable elements (using the shared selector `button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])`), and keydown listener cleanup on deactivation/unmount
- Each call-site retains only its own one-liner `setTimeout` to focus the close button on open, since that references a component-local ref and is not part of the shared logic
- Closes issue fringematrix5-56j

## Test plan

- [x] `npm run typecheck` — passes with no errors
- [x] `npm run test:client` — all 291 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)