### PR TITLE
Resolve disabled-vs-abort inconsistency in campaign switch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -207,6 +207,13 @@ export default function App() {
   }, []);
 
   const selectCampaign = useCallback(async (id: string) => {
+    // All nav buttons are disabled while isCampaignLoading is true, so
+    // user-triggered calls to selectCampaign cannot overlap with an ongoing
+    // user-triggered load. The abort here is intentionally kept for one real
+    // race: the initial mount-load (which runs before buttons are rendered)
+    // overlapping with the first user click once the loading screen clears.
+    // Removing the abort would leave that mount → user-click transition
+    // unguarded, so we keep it even though it is a no-op for all other paths.
     campaignLoadAbortRef.current?.abort();
     const controller = new AbortController();
     campaignLoadAbortRef.current = controller;


### PR DESCRIPTION
## Summary

- **Decision: Keep `disabled`, keep the abort, add clarifying comment.**
- Nav buttons (`Home`, `Campaigns`, nav arrows, sidebar items) stay `disabled={isCampaignLoading}` — this prevents mid-load jumping and matches the visible progress bar UX.
- The `campaignLoadAbortRef.current?.abort()` call at the top of `selectCampaign` is **not** dead code: it guards one real race — the initial mount-load overlapping with the first user click once the loading screen finishes. Without it, a slow initial fetch could continue populating images for the wrong campaign after the user has already navigated away.
- A comment is added explaining why the abort is kept even though user-triggered button clicks cannot reach `selectCampaign` while `isCampaignLoading` is true.

## Why not "drop disabled, rely on abort"?

The gallery shows a visible progress bar and a `Loading Images...` indicator while a campaign loads. Allowing users to switch mid-load would make that UI misleading and would cause the image grid to jump partway through loading. The disabled approach is the cleaner contract: finish loading, then allow navigation.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:client` — 291 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)