### PR TITLE
Surface invalid blob token as 503 instead of silently returning empty list

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -168,11 +168,6 @@ async function listBlobsWithCache(options: ListBlobsOptions): Promise<{ blobs: L
       }
     }
 
-    if (error.message && error.message.includes('No token found')) {
-      console.log('Blob token missing, returning empty blob list for testing');
-      return { blobs: [] };
-    }
-
     throw new BlobUnavailableError(`Vercel Blob unavailable: ${error.message || error.name || 'unknown error'}`);
   }
 }

--- a/server/test/api.blob-errors.test.ts
+++ b/server/test/api.blob-errors.test.ts
@@ -85,6 +85,24 @@ describe('Blob failure surface', () => {
     consoleLogSpy.mockRestore();
   });
 
+  it('returns 503 when blob throws "No token found" (invalid token should not look like empty gallery)', async () => {
+    listMock.mockReset();
+    listMock.mockRejectedValue(new Error('No token found'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId = campaignsRes.body.campaigns[0].id;
+
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toMatch(/Vercel Blob unavailable/i);
+
+    consoleSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
   it('caches the retry result when first call is rate-limited but retry succeeds', async () => {
     listMock.mockReset();
     const rateLimitErr = Object.assign(new Error('rate limited'), {


### PR DESCRIPTION
## Summary

- Removed the `'No token found'` string-match fallback (lines 171-174) in `listBlobsWithCache` in `server/server.ts`
- The `HAS_BLOB_TOKEN` guard at the top of the function already handles the legitimate no-token scenario (env var not set) by returning an empty list — that path is intentional and unchanged
- The string-match was a second, overlapping fallback that silently swallowed errors from an **invalid** token (token env var set but token value rejected by Vercel). This made a misconfigured production deployment look like an empty gallery, hiding the real problem from operators
- Invalid tokens now propagate as `BlobUnavailableError` and surface as HTTP 503, the same as any other upstream Vercel Blob failure

## Why this matters

A gallery returning 200 with zero images is indistinguishable from a working but empty campaign. A 503 is immediately visible in monitoring/logs and gives operators a clear signal that the token is wrong.

## Test plan

- [x] Added regression test in `server/test/api.blob-errors.test.ts`: mocks `list()` to throw `new Error('No token found')` and asserts `GET /api/campaigns/:id/images` returns 503 (not 200 empty)
- [x] All 46 server tests pass (`npm run test:server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)