### PR TITLE
Enable TypeScript strict mode in client and server

### DIFF
--- a/server/test/api.avatars.test.ts
+++ b/server/test/api.avatars.test.ts
@@ -7,7 +7,7 @@ import { jest, describe, it, expect, beforeAll } from '@jest/globals';
 //   - 404 when no matching blob exists
 //   - 503 (or 429) when Vercel Blob is unavailable
 
-const listMock = jest.fn();
+const listMock = jest.fn<() => Promise<unknown>>();
 
 jest.unstable_mockModule('@vercel/blob', () => ({
   list: listMock,

--- a/server/test/api.blob-errors.test.ts
+++ b/server/test/api.blob-errors.test.ts
@@ -5,7 +5,7 @@ import { jest, describe, it, expect, beforeAll } from '@jest/globals';
 // upstream Vercel Blob failures as 503 (or 429 for rate limits) rather than
 // generic 500s or empty 200s, so the client can render an actionable error.
 
-const listMock = jest.fn();
+const listMock = jest.fn<() => Promise<unknown>>();
 
 jest.unstable_mockModule('@vercel/blob', () => ({
   list: listMock,

--- a/server/test/api.cache.test.ts
+++ b/server/test/api.cache.test.ts
@@ -6,7 +6,7 @@ import { jest, describe, it, expect, beforeAll, beforeEach, afterEach } from '@j
 //   2. TTL expiry: re-fetches after TTL elapses
 //   3. LRU eviction: 101st unique key evicts the oldest entry
 
-const listMock = jest.fn();
+const listMock = jest.fn<() => Promise<unknown>>();
 
 jest.unstable_mockModule('@vercel/blob', () => ({
   list: listMock,

--- a/server/test/api.campaign-id-collisions.test.ts
+++ b/server/test/api.campaign-id-collisions.test.ts
@@ -44,8 +44,8 @@ describe('GET /api/campaigns — duplicate campaign id detection', () => {
     expect(typeof res.body.error).toBe('string');
     // The route handler swallows detail into a generic message; the thrown error
     // message should mention "Duplicate" — verify the spy captured it.
-    const errorCalls = consoleSpy.mock.calls.map(args => String(args[0]));
-    const hasDuplicate = errorCalls.some(msg => /duplicate/i.test(msg));
+    const errorCalls = consoleSpy.mock.calls.map((args: unknown[]) => String(args[0]));
+    const hasDuplicate = errorCalls.some((msg: string) => /duplicate/i.test(msg));
     expect(hasDuplicate).toBe(true);
 
     fsSpy.mockRestore();
@@ -67,8 +67,8 @@ describe('GET /api/campaigns — duplicate campaign id detection', () => {
 
     expect(res.status).toBe(500);
     expect(res.body).toHaveProperty('error');
-    const errorCalls = consoleSpy.mock.calls.map(args => String(args[0]));
-    const hasDuplicate = errorCalls.some(msg => /duplicate/i.test(msg));
+    const errorCalls = consoleSpy.mock.calls.map((args: unknown[]) => String(args[0]));
+    const hasDuplicate = errorCalls.some((msg: string) => /duplicate/i.test(msg));
     expect(hasDuplicate).toBe(true);
 
     fsSpy.mockRestore();
@@ -110,11 +110,11 @@ describe('GET /api/campaigns — duplicate campaign id detection', () => {
 
     expect(res.status).toBe(500);
     // The error object passed to console.error should mention the duplicate id
-    const errorMessages = consoleSpy.mock.calls.map(args => {
+    const errorMessages = consoleSpy.mock.calls.map((args: unknown[]) => {
       const arg = args[0];
       return arg instanceof Error ? arg.message : String(arg);
     });
-    const duplicateMsg = errorMessages.find(msg => /duplicate/i.test(msg));
+    const duplicateMsg = errorMessages.find((msg: string) => /duplicate/i.test(msg));
     expect(duplicateMsg).toBeDefined();
     expect(duplicateMsg).toMatch(/collidingtag/i);
 

--- a/server/test/api.campaigns-yaml.test.ts
+++ b/server/test/api.campaigns-yaml.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import fs from 'fs';
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 // Import the Express app without starting the listener
 import app from '../server.ts';

--- a/server/test/api.glyphs.test.ts
+++ b/server/test/api.glyphs.test.ts
@@ -11,7 +11,7 @@ const mockGlyphBlobs = [
 
 // Mock @vercel/blob before importing the server
 jest.unstable_mockModule('@vercel/blob', () => ({
-  list: jest.fn().mockResolvedValue({
+  list: jest.fn<() => Promise<unknown>>().mockResolvedValue({
     blobs: mockGlyphBlobs,
     cursor: undefined,
     hasMore: false,

--- a/server/test/api.test.ts
+++ b/server/test/api.test.ts
@@ -173,7 +173,7 @@ describe('API contract', () => {
     it('returns DEV-LOCAL when build-info.json is missing (dev mode)', async () => {
       const originalExistsSync = fs.existsSync;
       const existsSpy = jest.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => {
-        if (path.resolve(p) === path.resolve(buildInfoPath)) return false;
+        if (path.resolve(p.toString()) === path.resolve(buildInfoPath)) return false;
         return originalExistsSync(p);
       });
       const res = await request(app).get('/api/build-info');


### PR DESCRIPTION
## Summary

Both `client/tsconfig.json` and `server/tsconfig.json` already had `"strict": true` set. Running `tsc --noEmit` directly against the server test files revealed 25 latent type errors that were not caught by the existing `npm run typecheck` script (which only covers the client). This PR fixes all of them.

### Flags already enabled (no changes to tsconfig)
- `strict: true` (subsumes `noImplicitAny`, `strictNullChecks`, `strictFunctionTypes`, etc.)
- `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noImplicitOverride`
- `noPropertyAccessFromIndexSignature`, `noUncheckedIndexedAccess` (server only)

### Fixes made (server test files only)

1. **`jest.fn()` mock typing** (`api.avatars.test.ts`, `api.blob-errors.test.ts`, `api.cache.test.ts`, `api.glyphs.test.ts`) — `jest.fn()` defaults to `Mock<UnknownFunction>` where `ResolveType<UnknownFunction>` is `never`, making `mockResolvedValue`/`mockRejectedValue` reject all arguments. Fixed by typing as `jest.fn<() => Promise<unknown>>()`.

2. **Missing `afterEach` import** (`api.campaigns-yaml.test.ts`) — `afterEach` was used but not imported from `@jest/globals`.

3. **Implicit `any` in callback parameters** (`api.campaign-id-collisions.test.ts`) — Added explicit `(args: unknown[])` and `(msg: string)` types to `.map()` and `.find()` callbacks on `consoleSpy.mock.calls`.

4. **`fs.PathLike` vs `string`** (`api.test.ts`) — `path.resolve()` only accepts `string`, but `fs.PathLike` can be `string | Buffer | URL`. Fixed by calling `.toString()`.

## Test plan
- [x] `npm run typecheck` — zero errors (client)
- [x] `cd server && tsc --noEmit` — zero errors (server)
- [x] `npm run test:server` — 46/46 tests pass
- [x] `npm run test:client` — 291/291 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)