### PR TITLE
Page through all blobs instead of capping at limit: 1000

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -33,8 +33,15 @@ interface BlobCacheEntry {
 
 interface ListBlobsOptions {
   prefix?: string;
+  /** When set, fetch only a single page capped at this limit (no pagination loop). */
   limit?: number;
 }
+
+// Maximum total blobs collected across all pages in a single paginated fetch.
+// Guards against runaway memory usage if a prefix contains an unexpectedly
+// large number of items. At ~1 KB per blob metadata entry, 10 000 entries
+// is about 10 MB — well within acceptable server memory for a response.
+const MAX_BLOB_ITEMS = 10_000;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -121,6 +128,20 @@ const contentCache = new Map<string, ContentCacheEntry>();
 const CONTENT_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const CONTENT_CACHE_MAX = 16;
 
+/**
+ * Fetches blobs from Vercel Blob, with in-memory caching and optional cursor
+ * pagination.
+ *
+ * When `options.limit` is omitted (the default), the function pages through
+ * ALL results using the cursor returned by each `list()` call, accumulating
+ * blobs until `hasMore` is false or `MAX_BLOB_ITEMS` is reached. This
+ * replaces the old single-call `limit: 1000` approach and ensures campaigns
+ * with thousands of images are fully returned without silently truncating.
+ *
+ * When `options.limit` is provided, a single `list()` call is made (no
+ * pagination loop). This is used by the `/avatars/*` redirect route which
+ * only needs the first matching blob.
+ */
 async function listBlobsWithCache(options: ListBlobsOptions): Promise<{ blobs: ListBlobResultBlob[] }> {
   // If no blob token is available (e.g., in CI), return empty results
   if (!HAS_BLOB_TOKEN) {
@@ -130,13 +151,49 @@ async function listBlobsWithCache(options: ListBlobsOptions): Promise<{ blobs: L
 
   const cacheKey = JSON.stringify(options);
   const cached = blobCache.get(cacheKey);
-  
+
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     return cached.data;
   }
-  
+
+  // Helper: fetch all pages for a prefix, accumulating up to MAX_BLOB_ITEMS.
+  // Only used when no explicit limit is supplied.
+  async function fetchAllPages(): Promise<{ blobs: ListBlobResultBlob[] }> {
+    const accumulated: ListBlobResultBlob[] = [];
+    let cursor: string | undefined = undefined;
+
+    do {
+      const page = await list({
+        prefix: options.prefix,
+        limit: 1000, // per-page size; Vercel Blob's documented max per call
+        ...(cursor ? { cursor } : {}),
+      });
+
+      accumulated.push(...page.blobs);
+
+      if (!page.hasMore || accumulated.length >= MAX_BLOB_ITEMS) {
+        if (accumulated.length >= MAX_BLOB_ITEMS) {
+          console.warn(
+            `listBlobsWithCache: reached MAX_BLOB_ITEMS (${MAX_BLOB_ITEMS}) for prefix "${options.prefix ?? ''}". ` +
+            'Some blobs may have been omitted. Consider splitting this campaign into sub-folders.'
+          );
+        }
+        break;
+      }
+
+      cursor = page.cursor;
+    } while (cursor);
+
+    return { blobs: accumulated };
+  }
+
   try {
-    const result = await list(options);
+    // Single-page fetch when an explicit limit was requested (e.g. exact-match
+    // lookups in the /avatars/* redirect route).
+    const result = options.limit !== undefined
+      ? await list(options)
+      : await fetchAllPages();
+
     // Evict oldest entry when at capacity (Map preserves insertion order).
     // Delete-before-set so a re-cached key moves to the tail of iteration order.
     blobCache.delete(cacheKey);
@@ -158,7 +215,9 @@ async function listBlobsWithCache(options: ListBlobsOptions): Promise<{ blobs: L
       console.log(`Rate limited, retrying in ${retryAfter} seconds...`);
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
       try {
-        const retryResult = await list(options);
+        const retryResult = options.limit !== undefined
+          ? await list(options)
+          : await fetchAllPages();
         blobCache.delete(cacheKey);
         if (blobCache.size >= BLOB_CACHE_MAX) {
           const oldest = blobCache.keys().next().value;
@@ -330,10 +389,9 @@ app.get('/api/campaigns/:id/images', async (req: Request, res: Response): Promis
     const campaignPath = campaign.icon_path || '';
     const blobPrefix = campaignPath ? `avatars/${campaignPath}/` : 'avatars/';
 
-    // List blobs with the campaign prefix
+    // List blobs with the campaign prefix (no limit = paginate through all pages)
     const { blobs } = await listBlobsWithCache({
       prefix: blobPrefix,
-      limit: 1000, // Adjust as needed for your image collection size
     });
 
     // Filter for image files and format response
@@ -500,4 +558,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export default app;
 
 // Exported for tests only – do not use in application code
-export { blobCache, CACHE_TTL, BLOB_CACHE_MAX };
+export { blobCache, CACHE_TTL, BLOB_CACHE_MAX, MAX_BLOB_ITEMS };

--- a/server/test/api.blob-pagination.test.ts
+++ b/server/test/api.blob-pagination.test.ts
@@ -1,0 +1,136 @@
+import request from 'supertest';
+import { jest, describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
+
+// Verifies that listBlobsWithCache pages through all results rather than
+// truncating at limit: 1000.  The @vercel/blob list() API returns
+// { blobs, hasMore, cursor } and this test drives the pagination loop.
+
+const listMock = jest.fn();
+
+jest.unstable_mockModule('@vercel/blob', () => ({
+  list: listMock,
+  put: jest.fn(),
+  del: jest.fn(),
+  head: jest.fn(),
+}));
+
+let app: any;
+let blobCache: Map<string, { data: any; timestamp: number }>;
+let MAX_BLOB_ITEMS: number;
+
+beforeAll(async () => {
+  process.env['BLOB_READ_WRITE_TOKEN'] = 'test-token';
+  const serverModule = await import('../server.ts');
+  app = serverModule.default;
+  blobCache = (serverModule as any).blobCache;
+  MAX_BLOB_ITEMS = (serverModule as any).MAX_BLOB_ITEMS;
+});
+
+beforeEach(() => {
+  blobCache.clear();
+  listMock.mockReset();
+});
+
+// Build a fake blob with a unique pathname and URL.
+function makeBlob(name: string) {
+  const iconPath = 'testcampaign';
+  return {
+    pathname: `avatars/${iconPath}/${name}.png`,
+    url: `https://cdn/${name}.png`,
+    size: 100,
+    downloadUrl: `https://cdn/${name}.png?download=1`,
+    uploadedAt: new Date().toISOString(),
+  };
+}
+
+describe('blob cursor pagination', () => {
+  it('makes a single list() call when hasMore is false', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const blobs = [makeBlob('a'), makeBlob('b')];
+    listMock.mockResolvedValueOnce({ blobs, hasMore: false });
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId = campaignsRes.body.campaigns[0].id;
+
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(200);
+    // list() should be called exactly once (no next page)
+    expect(listMock).toHaveBeenCalledTimes(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('follows cursor pages and merges all blobs', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Simulate two pages of results
+    const page1 = [makeBlob('img-1'), makeBlob('img-2'), makeBlob('img-3')];
+    const page2 = [makeBlob('img-4'), makeBlob('img-5')];
+
+    listMock
+      .mockResolvedValueOnce({ blobs: page1, hasMore: true, cursor: 'cursor-abc' })
+      .mockResolvedValueOnce({ blobs: page2, hasMore: false });
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId = campaignsRes.body.campaigns[0].id;
+
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(200);
+    // Both pages should have been fetched
+    expect(listMock).toHaveBeenCalledTimes(2);
+    // The cursor from page 1 must be passed to the second call
+    expect(listMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: 'cursor-abc' }));
+    // All 5 images from both pages should appear in the response
+    expect(res.body.images).toHaveLength(5);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles three or more pages and accumulates all blobs', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    listMock
+      .mockResolvedValueOnce({ blobs: [makeBlob('p1')], hasMore: true, cursor: 'cur-1' })
+      .mockResolvedValueOnce({ blobs: [makeBlob('p2')], hasMore: true, cursor: 'cur-2' })
+      .mockResolvedValueOnce({ blobs: [makeBlob('p3')], hasMore: false });
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId = campaignsRes.body.campaigns[0].id;
+
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledTimes(3);
+    expect(res.body.images).toHaveLength(3);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('caches the merged multi-page result and does not re-fetch on second request', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const page1 = [makeBlob('cached-1'), makeBlob('cached-2')];
+    const page2 = [makeBlob('cached-3')];
+
+    listMock
+      .mockResolvedValueOnce({ blobs: page1, hasMore: true, cursor: 'c1' })
+      .mockResolvedValueOnce({ blobs: page2, hasMore: false });
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId = campaignsRes.body.campaigns[0].id;
+
+    // First request: should fetch both pages (2 list() calls)
+    const res1 = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res1.status).toBe(200);
+    expect(res1.body.images).toHaveLength(3);
+    expect(listMock).toHaveBeenCalledTimes(2);
+
+    // Second request within TTL: should come entirely from cache (no extra list() calls)
+    const res2 = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res2.status).toBe(200);
+    expect(res2.body.images).toHaveLength(3);
+    expect(listMock).toHaveBeenCalledTimes(2); // still only 2 calls total
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the single `list({ limit: 1000 })` call in `GET /api/campaigns/:id/images` with a cursor-based pagination loop that fetches **all pages** until `hasMore` is false
- Adds a `MAX_BLOB_ITEMS = 10_000` safety cap to guard against runaway memory usage if a prefix unexpectedly contains a very large number of entries; a `console.warn` is emitted if the cap is hit
- Routes that legitimately need only a single page (`/avatars/*` redirect uses `limit: 1`, `/api/glyphs` uses `limit: 100`) pass an explicit `limit` and continue to take the single-page path — no behaviour change for them
- The full merged result is cached under the same cache key as before, so cache TTL and LRU eviction work unchanged

## Approach

`listBlobsWithCache` now contains an inner `fetchAllPages()` helper that loops:
```
do {
  page = list({ prefix, limit: 1000, cursor? })
  accumulated.push(...page.blobs)
  if (!page.hasMore || cap reached) break
  cursor = page.cursor
} while (cursor)
```
When `options.limit` is explicitly provided the old single `list(options)` call is used instead (no loop), preserving the existing behaviour for callers that intentionally cap results.

## Tests

Added `server/test/api.blob-pagination.test.ts` with 4 new tests:
- Single page (`hasMore: false`) — only one `list()` call is made
- Two-page scenario — cursor is forwarded and both pages are merged
- Three-page scenario — all pages accumulated correctly
- Cache hit after multi-page fetch — second request within TTL serves from cache without extra `list()` calls

All 50 server tests and 291 client tests pass.

## Test plan
- [ ] `npm run test:server` — 50 tests pass
- [ ] `npm run test:client` — 291 tests pass
- [ ] Verify that campaigns with >1000 images now return all images in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)