### PR TITLE
fringematrix5-luy: Reset campaign state on cache-hit path

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -225,6 +225,9 @@ export default function App() {
 
     if (imagesByCampaign[id]) {
       setImages(imagesByCampaign[id]);
+      setCampaignLoadProgress(0);
+      setCampaignLoadTotal(0);
+      setCampaignLoadError(false);
       setIsCampaignLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary

- Fixes stale `campaignLoadError`, `campaignLoadProgress`, and `campaignLoadTotal` state persisting when navigating back to a cached campaign
- In `selectCampaign`, the cache-hit branch only called `setIsCampaignLoading(false)` but omitted resets for progress/total/error state
- This caused the "Some images failed to load" error banner to appear for campaigns that had actually loaded successfully on a prior visit

## Changes

In `client/src/App.tsx`, added three state resets in the cache-hit early-return branch of `selectCampaign`:
- `setCampaignLoadProgress(0)`
- `setCampaignLoadTotal(0)`
- `setCampaignLoadError(false)`

These are added before the existing `setIsCampaignLoading(false)` call.

## Test plan

- [ ] Run `npm run typecheck` — passes
- [ ] Run `npm run test:server` — 50 tests pass
- [ ] Run `npm run test:client` — 335 tests pass
- [ ] Manual: Load two campaigns, trigger an error on the second (e.g. network offline), then navigate back to the first — confirm error banner does NOT appear

Closes #fringematrix5-luy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper loading state when switching campaigns. Campaign image loading indicators and error states now properly reset when re-selecting campaigns with previously cached images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->