### PR TITLE
fringematrix5-lpc: Upgrade DOMPurify to 3.4.0 to patch XSS CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@vercel/blob": "^0.23.4",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.3",
         "dotenv": "^17.4.2",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
@@ -3523,9 +3523,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@vercel/blob": "^0.23.4",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.3",
     "dotenv": "^17.4.2",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Summary

- Upgrades DOMPurify from 3.3.1 to 3.4.3 (latest 3.4.x) to patch 7 known CVEs
- Addresses two critical XSS-impact vulnerabilities: GHSA-crv5-9vww-q3g8 (SAFE_FOR_TEMPLATES bypass, CVSS 6.8), GHSA-v9jr-rg53-9pgp (prototype pollution to XSS via CUSTOM_ELEMENT_HANDLING, CVSS 6.9), and GHSA-h8r8-wccr-v5f2 (mutation-XSS via re-contextualization)
- The app uses `dangerouslySetInnerHTML` with DOMPurify-sanitized content in `App.tsx` (line 315); this upgrade is a drop-in fix as the `DOMPurify.sanitize` API is unchanged

## Test plan

- [x] `npm run typecheck` passes — no type errors
- [x] `npm run test:server` passes — 50/50 tests
- [x] `npm run test:client` passes — 335/335 tests
- [x] Verified `package.json` constraint updated to `^3.4.3` and lock file resolves to `3.4.3`

Fixes: fringematrix5-lpc

🤖 Generated with [Claude Code](https://claude.com/claude-code)