### PR TITLE
fringematrix5-ksf: Fix loadingDots animation frozen on campaign switch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -445,12 +445,12 @@ export default function App() {
     };
   }, [loadCampaignImages]); // On mount: loadCampaignImages is a stable useCallback([]) so this runs once
 
-  // Animated dots for the CRT loader
+  // Animated dots for the CRT loader and campaign-switch progress bar
   useEffect(() => {
-    if (!isPreloading) return;
+    if (!isPreloading && !isCampaignLoading) return;
     const id = setInterval(() => setLoadingDots((d) => (d + 1) % 4), 400);
     return () => clearInterval(id);
-  }, [isPreloading]);
+  }, [isPreloading, isCampaignLoading]);
 
   // Lightbox animations are provided by the useLightboxAnimations hook
   const { openLightbox, closeLightbox, isAnimatingRef } = useLightboxAnimations({


### PR DESCRIPTION
## Summary

- **Bug**: `loadingDots` setInterval was driven by `isPreloading` only, but the animated dots are also rendered in the campaign-switch progress bar controlled by `isCampaignLoading`. After initial page load, `isPreloading` becomes false and the interval stops — so when a user switches campaigns, the dot animation is visually frozen.
- **Fix**: Changed the `useEffect` dependency from `[isPreloading]` to `[isPreloading, isCampaignLoading]` and updated the guard condition to `if (!isPreloading && !isCampaignLoading) return`. This ensures the interval runs during both the initial preload and any subsequent campaign switches.
- **Scope**: Single-line logic change in `client/src/App.tsx`, no new state, no tests broken.

Fixes: fringematrix5-ksf

## Test plan

- [ ] All 335 client unit tests pass (`npm run test:client`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Manually verify: on campaign switch, the "Loading Images..." dots animate instead of freezing

🤖 Generated with [Claude Code](https://claude.com/claude-code)