### PR TITLE
fringematrix5-6bu: Add Cache-Control headers to API endpoints

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -395,6 +395,8 @@ app.get('/avatars/*path', async (req: Request, res: Response): Promise<void> => 
 app.get('/api/campaigns', (_req: Request, res: Response): void => {
   try {
     const campaigns = loadCampaigns();
+    res.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
+    res.set('Vary', 'Accept-Encoding');
     res.json({ campaigns });
   } catch (err: unknown) {
     console.error(err);
@@ -445,6 +447,10 @@ app.get('/api/campaigns/:id/images', async (req: Request, res: Response): Promis
 
 // Build info endpoint
 app.get('/api/build-info', (_req: Request, res: Response): void => {
+  // build-info is immutable for the lifetime of this process (written once at
+  // deploy time), so a longer max-age is safe.
+  res.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
+  res.set('Vary', 'Accept-Encoding');
   try {
     if (fs.existsSync(BUILD_INFO_PATH)) {
       const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
@@ -462,16 +468,16 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
       return;
     }
     if (IS_DEV || !HAS_CLIENT_BUILD) {
-      res.json({ 
-        repoUrl: null, 
-        commitHash: 'DEV-LOCAL', 
+      res.json({
+        repoUrl: null,
+        commitHash: 'DEV-LOCAL',
         builtAt: new Date().toISOString()
       });
       return;
     }
-    res.json({ 
-      repoUrl: null, 
-      commitHash: null, 
+    res.json({
+      repoUrl: null,
+      commitHash: null,
       builtAt: null
     });
   } catch (err: unknown) {

--- a/server/server.ts
+++ b/server/server.ts
@@ -447,10 +447,7 @@ app.get('/api/campaigns/:id/images', async (req: Request, res: Response): Promis
 
 // Build info endpoint
 app.get('/api/build-info', (_req: Request, res: Response): void => {
-  // build-info is immutable for the lifetime of this process (written once at
-  // deploy time), so a longer max-age is safe.
-  res.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
-  res.set('Vary', 'Accept-Encoding');
+  const CACHE_HEADERS = 'public, max-age=3600, stale-while-revalidate=86400';
   try {
     if (fs.existsSync(BUILD_INFO_PATH)) {
       const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
@@ -460,6 +457,8 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
       } catch (_) {
         data = {};
       }
+      res.set('Cache-Control', CACHE_HEADERS);
+      res.set('Vary', 'Accept-Encoding');
       res.json({
         repoUrl: data.repoUrl || null,
         commitHash: data.commitHash || null,
@@ -468,6 +467,8 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
       return;
     }
     if (IS_DEV || !HAS_CLIENT_BUILD) {
+      res.set('Cache-Control', CACHE_HEADERS);
+      res.set('Vary', 'Accept-Encoding');
       res.json({
         repoUrl: null,
         commitHash: 'DEV-LOCAL',
@@ -475,6 +476,8 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
       });
       return;
     }
+    res.set('Cache-Control', CACHE_HEADERS);
+    res.set('Vary', 'Accept-Encoding');
     res.json({
       repoUrl: null,
       commitHash: null,

--- a/server/test/api.test.ts
+++ b/server/test/api.test.ts
@@ -35,6 +35,13 @@ describe('API contract', () => {
       }
     });
 
+    it('includes Cache-Control header for CDN/browser caching', async () => {
+      const res = await request(app).get('/api/campaigns');
+      expect(res.status).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600, stale-while-revalidate=86400');
+      expect(res.headers['vary']).toContain('Accept-Encoding');
+    });
+
     it('handles data read failures with 500', async () => {
       const fsSpy = jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
         throw new Error('test read error');
@@ -143,6 +150,13 @@ describe('API contract', () => {
   describe('GET /api/build-info', () => {
     const projectRoot = path.join(__dirname, '..', '..');
     const buildInfoPath = path.join(projectRoot, 'build-info.json');
+
+    it('includes Cache-Control header for CDN/browser caching', async () => {
+      const res = await request(app).get('/api/build-info');
+      expect(res.status).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600, stale-while-revalidate=86400');
+      expect(res.headers['vary']).toContain('Accept-Encoding');
+    });
 
     function withTempFile<T>(filePath: string, content: string, fn: () => Promise<T>): Promise<T> {
       const dir = path.dirname(filePath);


### PR DESCRIPTION
## Summary

- Adds `Cache-Control: public, max-age=3600, stale-while-revalidate=86400` to `GET /api/campaigns` so CDN edges and browsers can cache the static campaign list and skip redundant server hits
- Adds the same header to `GET /api/build-info`, which is immutable for the process lifetime
- Adds `Vary: Accept-Encoding` to both endpoints for correct behavior with gzip-compressed responses
- Adds test assertions in `server/test/api.test.ts` verifying both headers are present on successful responses

## Test plan

- [x] `npm run test:server -- --testPathPattern=api.test.ts` — new Cache-Control assertions pass for both endpoints
- [x] `npm run test:client` — all 335 client tests pass
- [x] `npm run typecheck` — no TypeScript errors
- [x] Pre-existing failures in `api.avatars.test.ts`, `api.cache.test.ts`, and two unrelated `api.test.ts` cases confirmed to be pre-existing (verified by stashing my changes and re-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)