### PR TITLE
fringematrix5-s7s: Cache campaigns.yaml parse at server startup

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -103,6 +103,10 @@ const CACHE_TTL = 30000; // 30 seconds cache during development/testing
 const BLOB_CACHE_MAX = 100; // Maximum number of unique cache entries (LRU eviction)
 const HAS_BLOB_TOKEN = !!process.env['BLOB_READ_WRITE_TOKEN'];
 
+// Module-level campaigns cache — populated once on first request and reused
+// for the lifetime of the process. campaigns.yaml never changes at runtime.
+let campaignsCache: Campaign[] | null = null;
+
 // Shape of the rate-limit error thrown by the @vercel/blob SDK.
 interface BlobRateLimitedError extends Error {
   name: 'BlobServiceRateLimited';
@@ -314,6 +318,19 @@ function loadCampaigns(): Campaign[] {
   return mapped;
 }
 
+/**
+ * Returns the campaigns list, loading and caching it on the first call.
+ * The data comes from campaigns.yaml which never changes during process
+ * lifetime, so parsing once at module level is safe and avoids repeated
+ * blocking FS reads + YAML parses on every hot-path request.
+ */
+function getCampaigns(): Campaign[] {
+  if (campaignsCache === null) {
+    campaignsCache = loadCampaigns();
+  }
+  return campaignsCache;
+}
+
 function slugify(str: string): string {
   return String(str)
     .trim()
@@ -394,7 +411,7 @@ app.get('/avatars/*path', async (req: Request, res: Response): Promise<void> => 
 // API endpoints
 app.get('/api/campaigns', (_req: Request, res: Response): void => {
   try {
-    const campaigns = loadCampaigns();
+    const campaigns = getCampaigns();
     res.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
     res.set('Vary', 'Accept-Encoding');
     res.json({ campaigns });
@@ -406,7 +423,7 @@ app.get('/api/campaigns', (_req: Request, res: Response): void => {
 
 app.get('/api/campaigns/:id/images', async (req: Request, res: Response): Promise<void> => {
   try {
-    const campaigns = loadCampaigns();
+    const campaigns = getCampaigns();
     const campaign = campaigns.find((c) => c.id === req.params['id']);
     if (!campaign) {
       res.status(404).json({ error: 'Campaign not found' });
@@ -594,3 +611,12 @@ export default app;
 
 // Exported for tests only – do not use in application code
 export { blobCache, CACHE_TTL, BLOB_CACHE_MAX, MAX_BLOB_ITEMS };
+
+/**
+ * Resets the module-level campaigns cache.
+ * Exported for test isolation only — call before each test that mocks
+ * fs.readFileSync to ensure getCampaigns() re-reads from the mock.
+ */
+export function resetCampaignsCache(): void {
+  campaignsCache = null;
+}

--- a/server/test/api.campaign-id-collisions.test.ts
+++ b/server/test/api.campaign-id-collisions.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 // Import the Express app without starting the listener
-import app from '../server.ts';
+import app, { resetCampaignsCache } from '../server.ts';
 
 // ---------------------------------------------------------------------------
 // Tests for duplicate campaign id detection in loadCampaigns().
@@ -18,6 +18,7 @@ let consoleSpy: ReturnType<typeof jest.spyOn>;
 
 beforeEach(() => {
   consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  resetCampaignsCache();
 });
 
 afterEach(() => {

--- a/server/test/api.campaigns-yaml.test.ts
+++ b/server/test/api.campaigns-yaml.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 // Import the Express app without starting the listener
-import app from '../server.ts';
+import app, { resetCampaignsCache } from '../server.ts';
 
 // ---------------------------------------------------------------------------
 // Tests for malformed / missing data/campaigns.yaml
@@ -18,6 +18,7 @@ let consoleSpy: ReturnType<typeof jest.spyOn>;
 
 beforeEach(() => {
   consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  resetCampaignsCache();
 });
 
 afterEach(() => {

--- a/server/test/api.test.ts
+++ b/server/test/api.test.ts
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import the Express app without starting the listener
-import app from '../server.ts';
+import app, { resetCampaignsCache } from '../server.ts';
 
 interface Campaign {
   id: string;
@@ -43,6 +43,7 @@ describe('API contract', () => {
     });
 
     it('handles data read failures with 500', async () => {
+      resetCampaignsCache();
       const fsSpy = jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
         throw new Error('test read error');
       });
@@ -55,6 +56,7 @@ describe('API contract', () => {
     });
 
     it('returns 500 when a campaign has no usable identifier', async () => {
+      resetCampaignsCache();
       const malformed = 'campaigns:\n  - episode: "Lonely entry with no id"\n';
       const fsSpy = jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => malformed);
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -69,6 +71,7 @@ describe('API contract', () => {
       // id/hashtag/icon_path are truthy strings but contain no alphanumerics,
       // so slugify() collapses them all to ''. Must fail loudly rather than
       // produce a campaign with id: '' that would shadow other entries.
+      resetCampaignsCache();
       const noSlugifiable =
         'campaigns:\n' +
         '  - id: "@@@"\n' +
@@ -86,6 +89,7 @@ describe('API contract', () => {
     it('falls through to hashtag when id is present but slugifies to empty', async () => {
       // id is a non-empty string but produces an empty slug — should fall
       // through to hashtag rather than throwing.
+      resetCampaignsCache();
       const fallthrough =
         'campaigns:\n' +
         '  - id: "@@@"\n' +
@@ -99,6 +103,7 @@ describe('API contract', () => {
     });
 
     it('uses explicit id from yaml when provided', async () => {
+      resetCampaignsCache();
       const yamlWithIds =
         'campaigns:\n' +
         '  - id: "my-explicit-id"\n' +
@@ -114,6 +119,7 @@ describe('API contract', () => {
 
   describe('GET /api/campaigns/:id/images', () => {
     it('returns images for a known campaign when present', async () => {
+      resetCampaignsCache();
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       const campaignsRes = await request(app).get('/api/campaigns');
       expect(campaignsRes.status).toBe(200);


### PR DESCRIPTION
## Summary

- Adds a module-level `campaignsCache` variable populated on first call to `getCampaigns()`
- Replaces both `loadCampaigns()` calls in route handlers with `getCampaigns()`, eliminating a blocking `fs.readFileSync` + YAML parse + duplicate-ID sweep on every request to `GET /api/campaigns` and `GET /api/campaigns/:id/images`
- Exports `resetCampaignsCache()` for test isolation; updates three test files to call it before each test that mocks `fs.readFileSync`

## Test plan

- [x] All 52 server tests pass (`npm run test:server`)
- [x] All 335 client tests pass (`npm run test:client`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Existing tests that mock `fs.readFileSync` still work correctly via `resetCampaignsCache()` called at the start of each such test

Closes bead fringematrix5-s7s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)