### PR TITLE
fringematrix5-4uc: Move hardcoded site URL to client/config.yaml

### DIFF
--- a/client/config.yaml
+++ b/client/config.yaml
@@ -14,6 +14,12 @@ theme:
   # Format: CSS hex color (e.g., "#00D4FF")
   accentColor: "#00D4FF"
 
+site:
+  # Canonical production URL used for share links (e.g. Threads)
+  url: "https://fringematrix.art"
+  # Default text prepended to share links
+  shareText: "Check out Fringe Matrix"
+
 lightbox:
   # Sidebar enter/exit animation for the zoomed-in image view.
   # On open the IMAGE DETAILS sidebar expands from a thin blinking horizontal

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { formatTimePacific } from './utils/formatTimePacific';
 import { gitRemoteToHttps } from './utils/gitRemoteToHttps';
 import { closeSubwindowsState } from './utils/closeSubwindowsState';
 import { applyTheme } from './config/theme';
+import { SITE_URL, SITE_SHARE_TEXT } from './config/site';
 import LoadingManager from './components/LoadingManager';
 import CampaignNavigation from './components/CampaignNavigation';
 import ContentModal from './components/ContentModal';
@@ -388,9 +389,7 @@ export default function App() {
   }, [onScrollOrResize]);
 
   const threadsShareUrl = useMemo(() => {
-    const text = 'Check out Fringe Matrix';
-    const url = 'https://fringematrix.art';
-    return `https://www.threads.net/intent/post?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+    return `https://www.threads.net/intent/post?text=${encodeURIComponent(SITE_SHARE_TEXT)}&url=${encodeURIComponent(SITE_URL)}`;
   }, []);
 
   // Handler for when user dismisses the loading screen

--- a/client/src/config/site.ts
+++ b/client/src/config/site.ts
@@ -1,0 +1,33 @@
+/**
+ * Site Configuration
+ *
+ * Loads site-level settings from client/config.yaml under the `site` key.
+ * Provides the canonical production URL and default share text used in
+ * share links (e.g. Threads).
+ */
+
+import type { AppConfig } from '../types/appConfig';
+import configYaml from '../../config.yaml';
+
+const config = configYaml as AppConfig;
+
+const DEFAULT_SITE_URL = 'https://fringematrix.art';
+const DEFAULT_SHARE_TEXT = 'Check out Fringe Matrix';
+
+/**
+ * The canonical site URL used for share links.
+ * Falls back to the production URL if not set in config.yaml.
+ */
+export const SITE_URL: string =
+  typeof config.site?.url === 'string' && config.site.url.trim().length > 0
+    ? config.site.url
+    : DEFAULT_SITE_URL;
+
+/**
+ * Default share text prepended to Threads (and similar) share links.
+ * Falls back to the default if not set in config.yaml.
+ */
+export const SITE_SHARE_TEXT: string =
+  typeof config.site?.shareText === 'string' && config.site.shareText.trim().length > 0
+    ? config.site.shareText
+    : DEFAULT_SHARE_TEXT;

--- a/client/src/types/appConfig.ts
+++ b/client/src/types/appConfig.ts
@@ -23,6 +23,11 @@ export interface LightboxConfig {
   sidebarAnimation?: LightboxSidebarAnimationConfig;
 }
 
+export interface SiteConfig {
+  url?: string;
+  shareText?: string;
+}
+
 export interface AppConfig {
   loadingScreen?: {
     type?: LoadingScreenType;
@@ -30,4 +35,5 @@ export interface AppConfig {
   };
   theme?: ThemeConfig;
   lightbox?: LightboxConfig;
+  site?: SiteConfig;
 }

--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -141,6 +141,31 @@ function validateConfig() {
     }
   }
 
+  // ── site ────────────────────────────────────────────────────────────────
+  if (config.site !== undefined) {
+    const { site } = config;
+    if (typeof site !== 'object' || site === null) {
+      error('site must be a mapping');
+    } else {
+      if (site.url !== undefined) {
+        if (typeof site.url !== 'string' || site.url.trim().length === 0) {
+          error('site.url must be a non-empty string');
+        } else {
+          try {
+            new URL(site.url);
+          } catch {
+            error(`site.url must be a valid URL. Got: "${site.url}"`);
+          }
+        }
+      }
+      if (site.shareText !== undefined) {
+        if (typeof site.shareText !== 'string' || site.shareText.trim().length === 0) {
+          error('site.shareText must be a non-empty string');
+        }
+      }
+    }
+  }
+
   // ── lightbox.sidebarAnimation ────────────────────────────────────────────
   if (config.lightbox !== undefined) {
     const { lightbox } = config;


### PR DESCRIPTION
## Summary

- Add `site.url` and `site.shareText` keys to `client/config.yaml` so the Threads share link can be overridden per environment (staging/preview) without code changes
- Introduce `client/src/config/site.ts` following the existing config module pattern (`theme.ts`, `lightbox.ts`) — exports `SITE_URL` and `SITE_SHARE_TEXT` with safe fallbacks
- Update `AppConfig` type in `client/src/types/appConfig.ts` to include the new `SiteConfig` interface
- Replace the two hardcoded strings in `App.tsx` (`threadsShareUrl` memo) with imports from the new module
- Add `site` section validation to `scripts/validate-config.js` (URL format check via `new URL()`, non-empty string check for `shareText`)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run validate:config` passes
- [x] `npm run test:server` — 52 tests pass
- [x] `npm run test:client` — 335 tests pass
- [ ] Verify the Threads share button still generates the correct URL in a browser build

🤖 Generated with [Claude Code](https://claude.com/claude-code)