### PR TITLE
fringematrix5-31c: Fix data:any type in build-info handler

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -469,7 +469,7 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
   try {
     if (fs.existsSync(BUILD_INFO_PATH)) {
       const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
-      let data: any;
+      let data: Partial<BuildInfo> & { deployedAt?: string | null };
       try {
         data = JSON.parse(raw);
       } catch (_) {
@@ -480,7 +480,7 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
       res.json({
         repoUrl: data.repoUrl || null,
         commitHash: data.commitHash || null,
-        builtAt: data.builtAt || data.deployedAt || null // backward compatibility
+        builtAt: data.builtAt || data.deployedAt || null // deployedAt was the field name before builtAt was introduced; kept for builds pre-dating the rename
       });
       return;
     }


### PR DESCRIPTION
## Summary

- Replace `let data: any` with `let data: Partial<BuildInfo> & { deployedAt?: string | null }` in the `/api/build-info` handler so all field accesses (`repoUrl`, `commitHash`, `builtAt`) are checked against the `BuildInfo` interface at compile time.
- Expand the `// backward compatibility` comment on the `data.deployedAt` fallback to `// deployedAt was the field name before builtAt was introduced; kept for builds pre-dating the rename`, giving readers context on what was renamed and why the fallback exists.

## Test plan

- [ ] `npm run typecheck` passes (client TS)
- [ ] `npm test` passes (52 server tests, 335 client tests)
- [ ] No new TypeScript errors introduced (pre-existing server TS errors unrelated to this bead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)