### PR TITLE
fringematrix5-h1f: Cache build-info.json parse at server startup

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -136,6 +136,16 @@ function cacheBlobResult(key: string, result: BlobListResult): void {
 // for the lifetime of the process. campaigns.yaml never changes at runtime.
 let campaignsCache: Campaign[] | null = null;
 
+// Module-level build-info cache — populated once on first request and reused
+// for the lifetime of the process. build-info.json is generated at build time
+// and never changes while the server is running.
+interface BuildInfoResponse {
+  repoUrl: string | null;
+  commitHash: string | null;
+  builtAt: string | null;
+}
+let buildInfoCache: BuildInfoResponse | null = null;
+
 // Shape of the rate-limit error thrown by the @vercel/blob SDK.
 interface BlobRateLimitedError extends Error {
   name: 'BlobServiceRateLimited';
@@ -382,6 +392,47 @@ function ensureDevBuildInfo(): void {
 
 ensureDevBuildInfo();
 
+/**
+ * Reads and parses build-info.json, returning a normalized response object.
+ * Falls back to a DEV-LOCAL object when the file is absent in dev mode,
+ * or to all-nulls in production without a client build.
+ */
+function loadBuildInfo(): BuildInfoResponse {
+  if (fs.existsSync(BUILD_INFO_PATH)) {
+    const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
+    let data: Partial<BuildInfo> & { deployedAt?: string | null };
+    try {
+      data = JSON.parse(raw);
+    } catch (_) {
+      data = {};
+    }
+    return {
+      repoUrl: data.repoUrl || null,
+      commitHash: data.commitHash || null,
+      builtAt: data.builtAt || data.deployedAt || null // deployedAt was the field name before builtAt was introduced; kept for builds pre-dating the rename
+    };
+  }
+  if (IS_DEV || !HAS_CLIENT_BUILD) {
+    return {
+      repoUrl: null,
+      commitHash: 'DEV-LOCAL',
+      builtAt: new Date().toISOString()
+    };
+  }
+  return { repoUrl: null, commitHash: null, builtAt: null };
+}
+
+/**
+ * Returns the build-info, loading and caching it on the first call.
+ * build-info.json is immutable for the process lifetime (generated at build time).
+ */
+function getBuildInfo(): BuildInfoResponse {
+  if (buildInfoCache === null) {
+    buildInfoCache = loadBuildInfo();
+  }
+  return buildInfoCache;
+}
+
 // Log blob functionality status
 if (HAS_BLOB_TOKEN) {
   console.log('🔵 Blob API: Enabled (token found)');
@@ -483,40 +534,10 @@ app.get('/api/campaigns/:id/images', async (req: Request, res: Response): Promis
 app.get('/api/build-info', (_req: Request, res: Response): void => {
   const CACHE_HEADERS = 'public, max-age=3600, stale-while-revalidate=86400';
   try {
-    if (fs.existsSync(BUILD_INFO_PATH)) {
-      const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
-      let data: Partial<BuildInfo> & { deployedAt?: string | null };
-      try {
-        data = JSON.parse(raw);
-      } catch (_) {
-        data = {};
-      }
-      res.set('Cache-Control', CACHE_HEADERS);
-      res.set('Vary', 'Accept-Encoding');
-      res.json({
-        repoUrl: data.repoUrl || null,
-        commitHash: data.commitHash || null,
-        builtAt: data.builtAt || data.deployedAt || null // deployedAt was the field name before builtAt was introduced; kept for builds pre-dating the rename
-      });
-      return;
-    }
-    if (IS_DEV || !HAS_CLIENT_BUILD) {
-      res.set('Cache-Control', CACHE_HEADERS);
-      res.set('Vary', 'Accept-Encoding');
-      res.json({
-        repoUrl: null,
-        commitHash: 'DEV-LOCAL',
-        builtAt: new Date().toISOString()
-      });
-      return;
-    }
+    const info = getBuildInfo();
     res.set('Cache-Control', CACHE_HEADERS);
     res.set('Vary', 'Accept-Encoding');
-    res.json({
-      repoUrl: null,
-      commitHash: null,
-      builtAt: null
-    });
+    res.json(info);
   } catch (err: unknown) {
     console.error(err);
     res.status(500).json({ error: 'Failed to load build info' });
@@ -640,4 +661,13 @@ export { blobCache, CACHE_TTL, BLOB_CACHE_MAX, MAX_BLOB_ITEMS };
  */
 export function resetCampaignsCache(): void {
   campaignsCache = null;
+}
+
+/**
+ * Resets the module-level build-info cache.
+ * Exported for test isolation only — call before each test that writes or mocks
+ * build-info.json to ensure getBuildInfo() re-reads from the updated file.
+ */
+export function resetBuildInfoCache(): void {
+  buildInfoCache = null;
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -139,12 +139,7 @@ let campaignsCache: Campaign[] | null = null;
 // Module-level build-info cache — populated once on first request and reused
 // for the lifetime of the process. build-info.json is generated at build time
 // and never changes while the server is running.
-interface BuildInfoResponse {
-  repoUrl: string | null;
-  commitHash: string | null;
-  builtAt: string | null;
-}
-let buildInfoCache: BuildInfoResponse | null = null;
+let buildInfoCache: BuildInfo | null = null;
 
 // Shape of the rate-limit error thrown by the @vercel/blob SDK.
 interface BlobRateLimitedError extends Error {
@@ -393,11 +388,12 @@ function ensureDevBuildInfo(): void {
 ensureDevBuildInfo();
 
 /**
- * Reads and parses build-info.json, returning a normalized response object.
- * Falls back to a DEV-LOCAL object when the file is absent in dev mode,
- * or to all-nulls in production without a client build.
+ * Reads and parses build-info.json, returning a normalized BuildInfo object.
+ * When the file is present it is parsed and returned directly.
+ * When the file is absent: returns a DEV-LOCAL object in dev mode or when there
+ * is no client build, and returns all-nulls only in production with a client build.
  */
-function loadBuildInfo(): BuildInfoResponse {
+function loadBuildInfo(): BuildInfo {
   if (fs.existsSync(BUILD_INFO_PATH)) {
     const raw = fs.readFileSync(BUILD_INFO_PATH, 'utf8');
     let data: Partial<BuildInfo> & { deployedAt?: string | null };
@@ -426,7 +422,7 @@ function loadBuildInfo(): BuildInfoResponse {
  * Returns the build-info, loading and caching it on the first call.
  * build-info.json is immutable for the process lifetime (generated at build time).
  */
-function getBuildInfo(): BuildInfoResponse {
+function getBuildInfo(): BuildInfo {
   if (buildInfoCache === null) {
     buildInfoCache = loadBuildInfo();
   }

--- a/server/test/api.test.ts
+++ b/server/test/api.test.ts
@@ -2,13 +2,13 @@ import request from 'supertest';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import the Express app without starting the listener
-import app, { resetCampaignsCache } from '../server.ts';
+import app, { resetCampaignsCache, resetBuildInfoCache } from '../server.ts';
 
 interface Campaign {
   id: string;
@@ -157,6 +157,12 @@ describe('API contract', () => {
     const projectRoot = path.join(__dirname, '..', '..');
     const buildInfoPath = path.join(projectRoot, 'build-info.json');
 
+    // Reset the module-level cache before each test so that file or mock
+    // changes made within a test are picked up by getBuildInfo().
+    beforeEach(() => {
+      resetBuildInfoCache();
+    });
+
     it('includes Cache-Control header for CDN/browser caching', async () => {
       const res = await request(app).get('/api/build-info');
       expect(res.status).toBe(200);
@@ -168,9 +174,11 @@ describe('API contract', () => {
       const dir = path.dirname(filePath);
       if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
       const existed = fs.existsSync(filePath);
-      const backup = `${filePath}.bak.test`; 
+      const backup = `${filePath}.bak.test`;
       if (existed) fs.copyFileSync(filePath, backup);
       fs.writeFileSync(filePath, content);
+      // Reset the cache after writing the temp file so getBuildInfo() reads it.
+      resetBuildInfoCache();
       return fn()
         .finally(() => {
           if (existed) {


### PR DESCRIPTION
## Summary

- Moves `fs.existsSync` + `fs.readFileSync` + `JSON.parse` for `build-info.json` out of the per-request handler and into a lazy module-level cache (`buildInfoCache`)
- Adds `loadBuildInfo()` (contains all the existing parse logic) and `getBuildInfo()` (cache wrapper), following the same pattern as the existing `campaignsCache` / `getCampaigns()`
- Adds `resetBuildInfoCache()` export for test isolation — called in `beforeEach` in `api.test.ts` and inside `withTempFile` so each test sees the correct file state

## Motivation

`build-info.json` is generated at build time and never changes while the server process is running. Re-reading it on every `/api/build-info` request is unnecessary I/O and JSON parsing work.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:server` — all 52 server tests pass (including the three `/api/build-info` tests)
- [x] `npm run test:client` — all 335 client tests pass
- [x] Existing tests for "file present" and "file missing / DEV-LOCAL" scenarios continue to pass because `resetBuildInfoCache()` is called before each test

🤖 Generated with [Claude Code](https://claude.com/claude-code)