### PR TITLE
fringematrix5-4uw: Move FOCUSABLE_SELECTOR to module scope and deduplicate

### DIFF
--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Campaign, ImageData } from '../types/api';
 import LightboxDetails from './LightboxDetails';
+import { FOCUSABLE_SELECTOR } from '../utils/focusable';
 
 /** Minimum horizontal travel (px) required for a touch to count as a swipe. */
 const SWIPE_MIN_HORIZONTAL_PX = 50;
@@ -40,8 +41,6 @@ export default function LightboxContainer({
   const drawerRef = useRef<HTMLDivElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = useState<boolean>(false);
-  const FOCUSABLE_SELECTOR =
-    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
   const nextImage = useCallback((delta: number) => {
     setLightboxIndex((idx) => (images.length === 0 ? 0 : (idx + delta + images.length) % images.length));

--- a/client/src/hooks/useFocusTrap.ts
+++ b/client/src/hooks/useFocusTrap.ts
@@ -1,7 +1,5 @@
 import { useEffect } from 'react';
-
-const FOCUSABLE_SELECTOR =
-  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+import { FOCUSABLE_SELECTOR } from '../utils/focusable';
 
 /**
  * Traps keyboard focus inside `modalRef` while `active` is true.

--- a/client/src/utils/focusable.ts
+++ b/client/src/utils/focusable.ts
@@ -1,0 +1,14 @@
+/**
+ * CSS selector that matches all focusable elements, excluding disabled ones.
+ *
+ * Use this when you need to enumerate interactive elements in a container
+ * (e.g. focus traps, roving focus) and want to skip over elements the user
+ * cannot actually interact with because they are disabled.
+ *
+ * Note: the original `useFocusTrap` selector omitted `:not([disabled])` guards.
+ * The version below is strictly more correct — disabled form controls are
+ * unreachable via keyboard by default, so including them in a focusable list
+ * would produce dead Tab stops.  Both selectors have been unified here.
+ */
+export const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';


### PR DESCRIPTION
## Summary

- Extracts a shared `client/src/utils/focusable.ts` constant (`FOCUSABLE_SELECTOR`) that both `LightboxContainer` and `useFocusTrap` now import from.
- Eliminates the per-render re-declaration in `LightboxContainer` (previously defined inside the function body on every render).
- Unifies the two previously divergent selector strings: `useFocusTrap` was missing `:not([disabled])` guards on `button`, `input`, `select`, and `textarea`, which could produce dead Tab stops on disabled form controls. The shared constant uses the more correct version with the guards.
- The shared file includes a JSDoc comment explaining why `:not([disabled])` guards are needed and documents that the two variants have been unified.

## Test plan

- [ ] `npm run typecheck` passes — no TypeScript errors
- [ ] `npm run test:server` passes — all 52 server tests pass
- [ ] `npm run test:client` passes — all 335 client tests pass
- [ ] Lightbox keyboard focus trap still works: open lightbox, Tab through interactive elements, verify focus wraps and Escape closes
- [ ] Verify disabled buttons (if any) are not included in the Tab cycle inside the lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)