### PR TITLE
fringematrix5-6pj: Replace comma operator in useLightboxAnimations with if/else

### DIFF
--- a/client/src/hooks/useLightboxAnimations.ts
+++ b/client/src/hooks/useLightboxAnimations.ts
@@ -624,9 +624,13 @@ export function useLightboxAnimations({
         backdropAnim = animateLightboxBackdrop('in');
         backdropDimmedRef.current = true;
       }
-      const sidebarPromise = sidebarEnteredRef.current
-        ? Promise.resolve()
-        : (sidebarEnteredRef.current = true, animateLightboxSidebar('in'));
+      let sidebarPromise: Promise<unknown>;
+      if (!sidebarEnteredRef.current) {
+        sidebarEnteredRef.current = true;
+        sidebarPromise = animateLightboxSidebar('in');
+      } else {
+        sidebarPromise = Promise.resolve();
+      }
       // Reveal the real lightbox image at the moment the wireframe animation
       // finishes (and before the wireframe is hidden), not after Promise.all
       // resolves. Otherwise a slower sibling animation (sidebar enter) keeps


### PR DESCRIPTION
## Summary

- Replaces the comma operator inside a ternary on line 627 of `useLightboxAnimations.ts` with a straightforward `if/else` block
- The comma operator `(sidebarEnteredRef.current = true, animateLightboxSidebar('in'))` is valid JS but uncommon and hard to read; the explicit form is immediately clear
- Behavior is identical: if sidebar hasn't been entered yet, mark it entered and run the enter animation; otherwise resolve immediately

## Changes

`client/src/hooks/useLightboxAnimations.ts`: Replace one-liner comma-operator ternary with explicit `if/else` block that assigns `sidebarEnteredRef.current = true` before calling `animateLightboxSidebar('in')`.

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Server tests pass (`npm run test:server`)
- [x] Client tests pass (`npm run test:client`)
- [x] Lightbox sidebar animation tests still pass (`test/lightbox-sidebar-fade-once.test.tsx`, `test/lightbox-animation.test.js`)

Closes #fringematrix5-6pj

🤖 Generated with [Claude Code](https://claude.com/claude-code)