### PR TITLE
fringematrix5-l0v: Memoize CampaignNavigation to prevent unnecessary re-renders

### DIFF
--- a/client/src/components/CampaignNavigation.tsx
+++ b/client/src/components/CampaignNavigation.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { Campaign } from '../types/api';
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
   onClose: () => void;
 }
 
-export default function CampaignNavigation({
+function CampaignNavigation({
   campaigns,
   activeCampaignId,
   isOpen,
@@ -48,3 +49,5 @@ export default function CampaignNavigation({
     </>
   );
 }
+
+export default React.memo(CampaignNavigation);


### PR DESCRIPTION
## Summary

- Wraps `CampaignNavigation` in `React.memo()` to prevent it from re-rendering on every loading animation tick
- During the loading screen, `loadingDots` state updates every ~500ms causing the entire App to re-render; without memoization, `CampaignNavigation` re-renders unnecessarily each time
- Both callback props (`selectCampaign` and `closeSidebar`) are already stabilized with `useCallback` in `App.tsx`, so `React.memo` will work correctly and prevent the spurious re-renders

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] All server tests pass (`npm run test:server`)
- [ ] All client tests pass (`npm run test:client`)
- [ ] CampaignNavigation sidebar still opens/closes correctly in the browser
- [ ] Campaign selection still works correctly

Closes #fringematrix5-l0v

🤖 Generated with [Claude Code](https://claude.com/claude-code)