### PR TITLE
fringematrix5-8oa: Wrap LightboxDetails in React.memo

### DIFF
--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -29,8 +29,12 @@ function Row({ label, children }: RowProps) {
  *
  * If no active campaign is available the component renders a single
  * empty-state line so the sidebar is not a confusing blank panel.
+ *
+ * Wrapped in React.memo so that both instances rendered by LightboxContainer
+ * (inline sidebar + mobile drawer) skip re-computation when the campaign prop
+ * hasn't changed — e.g. during prev/next image navigation.
  */
-export default function LightboxDetails({ campaign }: Props) {
+function LightboxDetails({ campaign }: Props) {
   if (!campaign) {
     return (
       <>
@@ -69,3 +73,5 @@ export default function LightboxDetails({ campaign }: Props) {
     </>
   );
 }
+
+export default React.memo(LightboxDetails);


### PR DESCRIPTION
## Summary

- Wrap `LightboxDetails` in `React.memo` to prevent redundant re-renders and re-computation of `parseEpisodeId`/`extractImdbId` on every lightbox navigation action.
- `LightboxContainer` renders two instances of `LightboxDetails` (inline sidebar + mobile drawer). Both recomputed on every `nextImage`/`prevImage` call even though the `campaign` prop is unchanged during navigation.
- The `activeCampaign` prop is derived via `useMemo` in `App.tsx` (stable reference across image navigation), so `React.memo` will be effective at skipping re-renders.
- Inner function renamed from exported default to named `function LightboxDetails`; `React.memo(LightboxDetails)` is the new default export — no change to callers.

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Server tests pass (`npm run test:server`)
- [x] Client unit tests pass, including `LightboxDetails.test.tsx` (`npm run test:client`)
- [ ] Manual smoke: open lightbox, navigate prev/next — IMAGE DETAILS sidebar shows correct campaign info throughout

Closes fringematrix5-8oa

🤖 Generated with [Claude Code](https://claude.com/claude-code)