### PR TITLE
fringematrix5-0q7: Fix imageCache lookup — use 'id in imageCache' not truthy check

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -227,7 +227,7 @@ export default function App() {
     setActiveCampaignId(id);
     window.history.replaceState({}, '', `#${id}`);
 
-    if (imageCache[id]) {
+    if (id in imageCache) {
       setCurrentImages(imageCache[id]);
       setCampaignLoadProgress(0);
       setCampaignLoadTotal(0);


### PR DESCRIPTION
## Summary

- Fixes a bug in `selectCampaign` (App.tsx) where `if (imageCache[id])` incorrectly treated a cached empty array as a cache miss
- Changed to `if (id in imageCache)` so campaigns with zero images are correctly served from cache without triggering a redundant re-fetch
- This was flagged as a low-confidence issue by Copilot on PR #99 (originally using `imagesByCampaign[id]` before the rename to `imageCache`)

## Test plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] All server tests pass (53 tests)
- [x] All client tests pass (342 tests)
- [x] No behavior change for campaigns with images — `id in imageCache` is truthy whenever `imageCache[id]` would be truthy for non-empty arrays
- [x] Campaigns with zero images now correctly use the cached empty result instead of re-fetching on every visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)