### PR TITLE
fringematrix5-boo: Memoize gallery grid to prevent re-renders on loadingDots tick

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import LoadingManager from './components/LoadingManager';
 import CampaignNavigation from './components/CampaignNavigation';
 import ContentModal from './components/ContentModal';
 import LightboxContainer from './components/LightboxContainer';
+import GalleryGrid from './components/GalleryGrid';
 import type {
   Campaign,
   ImageData,
@@ -661,36 +662,11 @@ export default function App() {
           )}
         </section>
 
-        <section id="gallery" className={`gallery-grid${activeCampaign && currentImages.length === 0 ? ' empty' : ''}`} aria-live="polite">
-          {activeCampaign && currentImages.length === 0 ? (
-            <div className="empty-state" role="status" aria-live="polite">
-              <div className="empty-emoji" aria-hidden>🖼️</div>
-              <div className="empty-title">No Images In Campaign</div>
-              <div className="empty-desc">This campaign has no uploaded images yet.</div>
-            </div>
-          ) : (
-            currentImages.map((img, i) => (
-              <div className="card" key={`${img.src}-${i}`}>
-                {img.isLoading ? (
-                  <div className="image-placeholder">
-                    <div className="placeholder-content">
-                      <div className="placeholder-icon">📷</div>
-                      <div className="placeholder-text">Loading...</div>
-                    </div>
-                  </div>
-                ) : (
-                  <img 
-                    src={img.loadedSrc || img.src || ''} 
-                    alt={img.fileName} 
-                    loading="lazy" 
-                    onClick={(e) => openLightbox(i, e.currentTarget)} 
-                  />
-                )}
-                <div className="filename">{img.fileName}</div>
-              </div>
-            ))
-          )}
-        </section>
+        <GalleryGrid
+          images={currentImages}
+          hasCampaign={!!activeCampaign}
+          onImageClick={openLightbox}
+        />
       </main>
 
       {/* Build info popover */}

--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { ImageData } from '../types/api';
+
+interface GalleryGridProps {
+  images: ImageData[];
+  /** Whether an active campaign is selected (used to show the empty state) */
+  hasCampaign: boolean;
+  /** Stable callback — receives the image index and the thumbnail element */
+  onImageClick: (index: number, thumbEl: HTMLImageElement) => void;
+}
+
+/**
+ * Memoized gallery grid.
+ *
+ * App re-renders at 2.5 Hz while loadingDots ticks during image preload.
+ * Wrapping this section in React.memo prevents the entire N-card VDOM diff
+ * from running on every tick — it only re-renders when images, hasCampaign,
+ * or onImageClick actually change.
+ */
+const GalleryGrid = React.memo(function GalleryGrid({
+  images,
+  hasCampaign,
+  onImageClick,
+}: GalleryGridProps) {
+  const isEmpty = hasCampaign && images.length === 0;
+
+  return (
+    <section
+      id="gallery"
+      className={`gallery-grid${isEmpty ? ' empty' : ''}`}
+      aria-live="polite"
+    >
+      {isEmpty ? (
+        <div className="empty-state" role="status" aria-live="polite">
+          <div className="empty-emoji" aria-hidden>🖼️</div>
+          <div className="empty-title">No Images In Campaign</div>
+          <div className="empty-desc">This campaign has no uploaded images yet.</div>
+        </div>
+      ) : (
+        images.map((img, i) => (
+          <div className="card" key={`${img.src}-${i}`}>
+            {img.isLoading ? (
+              <div className="image-placeholder">
+                <div className="placeholder-content">
+                  <div className="placeholder-icon">📷</div>
+                  <div className="placeholder-text">Loading...</div>
+                </div>
+              </div>
+            ) : (
+              <img
+                src={img.loadedSrc || img.src || ''}
+                alt={img.fileName}
+                loading="lazy"
+                onClick={(e) => onImageClick(i, e.currentTarget)}
+              />
+            )}
+            <div className="filename">{img.fileName}</div>
+          </div>
+        ))
+      )}
+    </section>
+  );
+});
+
+export default GalleryGrid;


### PR DESCRIPTION
## Summary

- Extracts the inline gallery grid JSX from `App.tsx` into a new `GalleryGrid` component in `client/src/components/GalleryGrid.tsx`
- Wraps the component with `React.memo` so it only re-renders when `images`, `hasCampaign`, or `onImageClick` actually change
- `openLightbox` (passed as `onImageClick`) is already a stable `useCallback` from `useLightboxAnimations`, making the memo comparison effective
- During initial preload, `App` re-renders at 2.5 Hz due to the `loadingDots` ticker — for a 50-image campaign this previously triggered ~12 unnecessary N-card VDOM diffs over ~5 seconds; memoization eliminates all of them

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:server` — all 53 tests pass
- [x] `npm run test:client` — all 342 tests pass
- [ ] Manual smoke test: gallery renders, images are clickable, lightbox opens correctly
- [ ] Empty campaign state shows "No Images In Campaign"
- [ ] Campaign switch triggers re-render of gallery (new `images` array reference)

Closes bead: fringematrix5-boo

🤖 Generated with [Claude Code](https://claude.com/claude-code)