### PR TITLE
fringematrix5-d08: Add Permissions-Policy header to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
         {
           "key": "Referrer-Policy",
           "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Adds a `Permissions-Policy` header to the existing security headers block in `vercel.json`
- Explicitly disables browser APIs the app does not use: `camera`, `microphone`, `geolocation`, `payment`, `usb`
- Includes `interest-cohort=()` to opt out of FLoC/Topics API tracking

## Details

This is a defense-in-depth improvement building on the security headers block established in PR #87. Since the gallery app never requests camera, microphone, geolocation, payment, or USB access, explicitly denying these via `Permissions-Policy` prevents accidental or malicious feature usage.

The `interest-cohort=()` directive opts the site out of Google's FLoC/Topics API tracking, which is good privacy practice.

## Test plan

- [ ] Verify `vercel.json` is valid JSON
- [ ] Confirm all existing tests still pass (`npm run typecheck && npm test`)
- [ ] Deploy to preview and check response headers include `Permissions-Policy`

Closes #fringematrix5-d08

🤖 Generated with [Claude Code](https://claude.com/claude-code)