### PR TITLE
fringematrix5-y5a: Derive ContentPage type from VALID_CONTENT_PAGES for exhaustiveness

### DIFF
--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -44,8 +44,9 @@ export interface CampaignImagesResponse {
 
 export type BuildInfoResponse = BuildInfo;
 
-// ContentPage is the canonical shared type — do not redefine here.
-// To add a new page: update shared/types.ts and VALID_CONTENT_PAGES in server/server.ts.
+// ContentPage is derived from VALID_CONTENT_PAGES in shared/types.ts.
+// To add a new page: add its slug to VALID_CONTENT_PAGES in shared/types.ts —
+// the type and server validation stay in sync automatically.
 import type { ContentPage } from '../../../shared/types';
 export type { ContentPage };
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -8,6 +8,12 @@ export default {
       useESM: true,
     }],
   },
+  // ts-jest with ESM uses Node's native ESM loader, which keeps the .js
+  // extension in import specifiers (as TypeScript requires for ESM output).
+  // Jest doesn't remap .js → .ts automatically, so we do it here.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   setupFilesAfterEnv: [],
   roots: ['<rootDir>/test'],
   testMatch: ['**/?(*.)+(test).[jt]s?(x)'],

--- a/server/server.ts
+++ b/server/server.ts
@@ -5,6 +5,7 @@ import yaml from 'js-yaml';
 import dotenv from 'dotenv';
 import { list, ListBlobResultBlob } from '@vercel/blob';
 import { fileURLToPath } from 'url';
+import { VALID_CONTENT_PAGES } from '../shared/types.js';
 import type { ContentPage } from '../shared/types.js';
 
 interface Campaign {
@@ -543,12 +544,9 @@ app.get('/api/build-info', (_req: Request, res: Response): void => {
 });
 
 // Content pages (History, Credits, Legal)
-// ContentPage is the canonical type from shared/types.ts.
-// `satisfies readonly ContentPage[]` ensures every entry in this array is a
-// valid ContentPage slug (compile-time check), but does NOT enforce that all
-// ContentPage values appear here. When adding a new page, update both
-// shared/types.ts AND this array — see the comment in shared/types.ts.
-const VALID_CONTENT_PAGES = ['history', 'credits', 'legal'] as const satisfies readonly ContentPage[];
+// VALID_CONTENT_PAGES is imported from shared/types.ts, and ContentPage is
+// derived from it there — so adding a slug to VALID_CONTENT_PAGES in
+// shared/types.ts is the single change needed when adding a new page.
 
 app.get('/api/content/:page', async (req: Request, res: Response): Promise<void> => {
   const page = req.params['page'] as string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3,13 +3,15 @@
  * (client/src/types/api.ts).
  *
  * ADDING A NEW CONTENT PAGE:
- *   1. Add the slug here (e.g. 'about').
- *   2. Add the same slug to VALID_CONTENT_PAGES in server/server.ts.
- *      TypeScript will catch values in VALID_CONTENT_PAGES that are NOT
- *      valid ContentPage slugs, but it will NOT catch slugs that are in
- *      ContentPage but missing from VALID_CONTENT_PAGES — those would cause
- *      the server to return 404 for the new page until step 2 is done.
+ *   1. Add the slug to VALID_CONTENT_PAGES below (e.g. 'about').
+ *   2. ContentPage is derived from VALID_CONTENT_PAGES, so the type stays in
+ *      sync automatically — no separate update needed.
+ *   3. The server imports VALID_CONTENT_PAGES directly and uses it for
+ *      validation, so the new page will be served without any other changes.
  */
 
 // The valid content-page slugs served by GET /api/content/:page.
-export type ContentPage = 'history' | 'credits' | 'legal';
+// ContentPage is derived from this array, ensuring the type and the runtime
+// validation list are always in sync (exhaustiveness guaranteed by derivation).
+export const VALID_CONTENT_PAGES = ['history', 'credits', 'legal'] as const;
+export type ContentPage = (typeof VALID_CONTENT_PAGES)[number];


### PR DESCRIPTION
## Summary

- Moves `VALID_CONTENT_PAGES` from `server/server.ts` into `shared/types.ts` as the single source of truth
- Derives `ContentPage` from `VALID_CONTENT_PAGES` via `typeof VALID_CONTENT_PAGES[number]`, so adding a slug to the array automatically expands the type — the type and runtime validation list are always exhaustive by construction
- Imports `VALID_CONTENT_PAGES` in `server/server.ts` instead of maintaining a parallel local definition
- Adds `moduleNameMapper` to `server/jest.config.js` so the value import (`import { VALID_CONTENT_PAGES }`) resolves correctly under `ts-jest` ESM (`.js` → `.ts` remapping)
- Updates comments in `client/src/types/api.ts` to reflect the new single-step workflow

## Before

```ts
// shared/types.ts — type only
export type ContentPage = 'history' | 'credits' | 'legal';

// server/server.ts — separate runtime array; must be kept in sync manually
const VALID_CONTENT_PAGES = ['history', 'credits', 'legal'] as const satisfies readonly ContentPage[];
```

Adding a new page required updating **both** files; forgetting one caused silent 404s.

## After

```ts
// shared/types.ts — array is source of truth, type derived from it
export const VALID_CONTENT_PAGES = ['history', 'credits', 'legal'] as const;
export type ContentPage = (typeof VALID_CONTENT_PAGES)[number];

// server/server.ts — just imports the shared array
import { VALID_CONTENT_PAGES } from '../shared/types.js';
```

Adding a new page requires updating **only** `shared/types.ts`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:server` — 53 tests pass
- [x] `npm run test:client` — 354 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)