### PR TITLE
fringematrix5-yvw: Extract timeout middleware to eliminate test duplication

### DIFF
--- a/server/middleware/timeout.ts
+++ b/server/middleware/timeout.ts
@@ -1,0 +1,26 @@
+import type { Request, Response, NextFunction } from 'express';
+
+// Defense-in-depth: send a 503 if an async request handler takes longer than
+// 30 seconds. This handles cases such as an upstream dependency hanging or a
+// very slow network call. Note: a synchronous CPU-blocking operation (e.g. a
+// ReDoS in route matching) cannot be interrupted by a setTimeout callback;
+// protection against that class of attack comes from using a patched
+// path-to-regexp (via Express 5), not from this middleware.
+export const REQUEST_TIMEOUT_MS = 30_000;
+
+export function timeoutMiddleware(_req: Request, res: Response, next: NextFunction): void {
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    if (!res.headersSent) {
+      res.status(503).json({ error: 'Request timeout' });
+    }
+  }, REQUEST_TIMEOUT_MS);
+  // Store the flag on res.locals so downstream handlers can skip writing
+  // their response after the timeout has already fired.
+  res.locals['timedOut'] = () => timedOut;
+  // Clear the timer when the response completes so it doesn't fire late.
+  res.on('finish', () => clearTimeout(timer));
+  res.on('close', () => clearTimeout(timer));
+  next();
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -7,6 +7,7 @@ import { list, ListBlobResultBlob } from '@vercel/blob';
 import { fileURLToPath } from 'url';
 import { VALID_CONTENT_PAGES } from '../shared/types.js';
 import type { ContentPage } from '../shared/types.js';
+import { timeoutMiddleware } from './middleware/timeout.js';
 
 interface Campaign {
   id: string;
@@ -79,29 +80,7 @@ const app: Application = express();
 app.disable('x-powered-by');
 const PORT = process.env['PORT'] || 3000;
 
-// Defense-in-depth: send a 503 if an async request handler takes longer than
-// 30 seconds. This handles cases such as an upstream dependency hanging or a
-// very slow network call. Note: a synchronous CPU-blocking operation (e.g. a
-// ReDoS in route matching) cannot be interrupted by a setTimeout callback;
-// protection against that class of attack comes from using a patched
-// path-to-regexp (via Express 5), not from this middleware.
-const REQUEST_TIMEOUT_MS = 30_000;
-app.use((_req: Request, res: Response, next) => {
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    if (!res.headersSent) {
-      res.status(503).json({ error: 'Request timeout' });
-    }
-  }, REQUEST_TIMEOUT_MS);
-  // Store the flag on res.locals so downstream handlers can skip writing
-  // their response after the timeout has already fired.
-  res.locals['timedOut'] = () => timedOut;
-  // Clear the timer when the response completes so it doesn't fire late.
-  res.on('finish', () => clearTimeout(timer));
-  res.on('close', () => clearTimeout(timer));
-  next();
-});
+app.use(timeoutMiddleware);
 
 // Project root is one level up from this file (which lives in server/)
 const PROJECT_ROOT = path.join(__dirname, '..');

--- a/server/test/api.timeout.test.ts
+++ b/server/test/api.timeout.test.ts
@@ -1,42 +1,13 @@
 import { EventEmitter } from 'events';
 import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+import { timeoutMiddleware, REQUEST_TIMEOUT_MS } from '../middleware/timeout.js';
 
 // Unit tests for the request timeout middleware added in PR #77.
-// The middleware lives at the top of server.ts and:
+// The middleware lives in server/middleware/timeout.ts and:
 //   1. Sets a 30-second setTimeout that sends a 503 if the request is still open.
 //   2. Exposes res.locals['timedOut'] as a closure returning the flag.
 //   3. Clears the timer on res 'finish' or 'close' events.
-//
-// Strategy: extract the middleware under test by re-implementing it as a
-// standalone function (mirroring server.ts exactly) so we can unit-test it
-// without spinning up the full Express app. This lets us use jest fake timers
-// cleanly without the async complications of supertest + hanging routes.
-
-// ─── Middleware under test (mirrors server.ts verbatim) ───────────────────────
-const REQUEST_TIMEOUT_MS = 30_000;
-
-function timeoutMiddleware(
-  _req: unknown,
-  res: {
-    headersSent: boolean;
-    locals: Record<string, unknown>;
-    status(code: number): { json(body: unknown): void };
-    on(event: string, cb: () => void): void;
-  },
-  next: () => void,
-): void {
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    if (!res.headersSent) {
-      res.status(503).json({ error: 'Request timeout' });
-    }
-  }, REQUEST_TIMEOUT_MS);
-  res.locals['timedOut'] = () => timedOut;
-  res.on('finish', () => clearTimeout(timer));
-  res.on('close', () => clearTimeout(timer));
-  next();
-}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -71,7 +42,7 @@ describe('request timeout middleware', () => {
       const res = makeMockRes();
       const next = jest.fn();
 
-      timeoutMiddleware({}, res, next);
+      timeoutMiddleware({} as Request, res as unknown as Response, next as unknown as NextFunction);
 
       // next() must be called synchronously so the request proceeds.
       expect(next).toHaveBeenCalledTimes(1);
@@ -92,7 +63,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       // Advance to just before the threshold.
       jest.advanceTimersByTime(REQUEST_TIMEOUT_MS - 1);
@@ -106,7 +77,7 @@ describe('request timeout middleware', () => {
       const res = makeMockRes();
       res.headersSent = true; // simulate response already completed
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       jest.advanceTimersByTime(REQUEST_TIMEOUT_MS);
 
@@ -124,7 +95,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       const timedOut = res.locals['timedOut'] as () => boolean;
       expect(typeof timedOut).toBe('function');
@@ -138,7 +109,7 @@ describe('request timeout middleware', () => {
       // Prevent .status().json() from throwing when headersSent is false.
       // (The mock already returns a json stub, so this is fine as-is.)
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       jest.advanceTimersByTime(REQUEST_TIMEOUT_MS);
 
@@ -153,7 +124,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       // Simulate the response completing well before the timeout.
       res.headersSent = true;
@@ -171,7 +142,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       res.headersSent = true;
       res.emit('close');
@@ -186,7 +157,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       res.emit('close');
 
@@ -204,7 +175,7 @@ describe('request timeout middleware', () => {
 
       const res = makeMockRes();
 
-      timeoutMiddleware({}, res, jest.fn());
+      timeoutMiddleware({} as Request, res as unknown as Response, jest.fn() as unknown as NextFunction);
 
       res.emit('finish');
 


### PR DESCRIPTION
## Summary

- Extracts the request timeout middleware and `REQUEST_TIMEOUT_MS` constant from `server/server.ts` into a new dedicated module at `server/middleware/timeout.ts`
- Updates `server/server.ts` to import `timeoutMiddleware` from the new module (replacing the inline implementation)
- Updates `server/test/api.timeout.test.ts` to import the real `timeoutMiddleware` and `REQUEST_TIMEOUT_MS` from the module instead of reimplementing them verbatim, eliminating the drift risk where test copies could silently diverge from production code

Closes bead fringematrix5-yvw.

## Test plan

- [x] `npm run test:server` — all 66 server tests pass, `server/middleware/timeout.ts` shows 100% coverage
- [x] `npm run test:client` — all 354 client tests pass
- [x] `npm run typecheck` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)