### PR TITLE
fringematrix5-m89: Replace tautological cleanup test assertions with real checks

### DIFF
--- a/client/test/FringeGlyphLoadingSpinner.test.jsx
+++ b/client/test/FringeGlyphLoadingSpinner.test.jsx
@@ -368,40 +368,61 @@ describe('FringeGlyphLoadingSpinner - Shuffle Behavior', () => {
 
 describe('FringeGlyphLoadingSpinner - Cleanup', () => {
   it('should not throw after unmount during fetch', async () => {
+    // Spy on setInterval before rendering to capture any call made after unmount
+    // (e.g. if a pending setTimeout fires after cleanup and tries to start cycling).
+    const setIntervalSpy = vi.spyOn(window, 'setInterval');
+
     const { unmount } = render(<FringeGlyphLoadingSpinner />);
-    
-    // Unmount before operations complete
+
+    // Unmount before fetch/preload completes — the component never reaches the
+    // cycling stage, so no interval should ever be created.
     unmount();
-    
-    // Advance timers - should not throw
+
+    // Advance timers past the full startup sequence to let any orphaned callbacks fire.
     await act(async () => {
       vi.advanceTimersByTime(500);
       await Promise.resolve();
     });
-    
-    // If we get here without errors, cleanup worked
-    expect(true).toBe(true);
+
+    // No interval should have been created because the component was torn down
+    // before it became visible.
+    expect(setIntervalSpy).not.toHaveBeenCalled();
   });
 
   it('should clear timers on unmount', async () => {
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout');
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
     const { unmount } = render(
-      <FringeGlyphLoadingSpinner 
-        displayDuration={100} 
-        crossDissolveDuration={50} 
+      <FringeGlyphLoadingSpinner
+        displayDuration={100}
+        crossDissolveDuration={50}
       />
     );
-    
+
+    // Let the component fully initialise and start cycling.
     await flushPromisesAndTimers();
-    
+
+    // Reset spy counts so we only observe calls that happen during unmount.
+    clearTimeoutSpy.mockClear();
+    clearIntervalSpy.mockClear();
+
     unmount();
-    
-    // Advance timers well past cycle time - should not throw
+
+    // After unmount the cleanup effect must have called clearTimeout and/or
+    // clearInterval to cancel the pending display-duration timer and the cycling
+    // interval (whichever are active at the moment of teardown).
+    const cleanupCleared =
+      clearTimeoutSpy.mock.calls.length > 0 || clearIntervalSpy.mock.calls.length > 0;
+    expect(cleanupCleared).toBe(true);
+
+    // Verify no further image cycling occurs after unmount.
+    const setIntervalAfterUnmount = vi.spyOn(window, 'setInterval');
     await act(async () => {
       vi.advanceTimersByTime(1000);
       await Promise.resolve();
     });
-    
-    expect(true).toBe(true);
+    expect(setIntervalAfterUnmount).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Two tests in the `FringeGlyphLoadingSpinner - Cleanup` describe block used `expect(true).toBe(true)` as their only assertion, meaning they would pass even if cleanup was completely broken.

This PR replaces those no-op assertions with spy-based checks that actually verify the cleanup behavior:

- **Test 1** (`should not throw after unmount during fetch`): Now spies on `window.setInterval` and asserts it was never called. If the component unmounts during the fetch/preload phase, the cycling interval must never be created. A dangling interval after teardown would be caught.

- **Test 2** (`should clear timers on unmount`): Now spies on `clearTimeout`/`clearInterval` and asserts at least one was called during unmount (verifying the cleanup effect ran and cancelled pending timers). Additionally asserts that no new `setInterval` is created after unmount completes.

The approach follows the same spy-based pattern used in the early-unmount regression test (PR #83 / the `Early Unmount` describe block in the same file).

## Test plan

- [x] `npm run test:client` — all 354 tests pass
- [x] `npm run test:server` — all 66 tests pass
- [x] `npm run typecheck` — no TypeScript errors
- [x] Both refactored tests (`Cleanup` describe block) pass and verify real behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the loading spinner component to verify proper cleanup during unmounting and timer management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->