### PR TITLE
fringematrix5-3d8: Extract repeated data.campaigns expression in App.tsx

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -407,14 +407,15 @@ export default function App() {
 
         const data = await fetchJSON<CampaignsResponse>('/api/campaigns');
         if (!isMounted) return;
-        setCampaigns(data.campaigns || []);
+        const campaignList = data.campaigns || [];
+        setCampaigns(campaignList);
 
         // Update loading screen with campaign count
-        setLoadingCampaignCount((data.campaigns || []).length);
+        setLoadingCampaignCount(campaignList.length);
 
         // Choose initial campaign and load its images
         const hash = window.location.hash.replace('#', '');
-        const initial = (data.campaigns || []).find((c: Campaign) => c.id === hash) || (data.campaigns || [])[0];
+        const initial = campaignList.find((c: Campaign) => c.id === hash) || campaignList[0];
         
         if (initial) {
           // Mount-time initial campaign load. Shares campaignLoadAbortRef so a


### PR DESCRIPTION
## Summary

- Extracts `const campaignList = data.campaigns || []` before the initial campaign selection block in `App.tsx`
- Eliminates 4 repetitions of `data.campaigns || []` in 7 lines (lines ~410–417), reducing noise and making the fallback logic explicit in one place
- Pure readability refactor — no behavioral change

## Bead

fringematrix5-3d8

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (all 354 client tests, 66 server tests, 55 script tests)
- No logic change, so no new test coverage needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)