### PR TITLE
fringematrix5-2p2: Fix imageCache source guard test after App.tsx refactor

### DIFF
--- a/client/test/imageCache-empty-array.test.js
+++ b/client/test/imageCache-empty-array.test.js
@@ -25,8 +25,8 @@ import path from 'path';
 // ---------------------------------------------------------------------------
 // Read the source once for all source-level assertions
 // ---------------------------------------------------------------------------
-const appSrc = fs.readFileSync(
-  path.resolve(__dirname, '../src/App.tsx'),
+const hookSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/hooks/useCampaignLoader.ts'),
   'utf-8',
 );
 
@@ -34,10 +34,11 @@ const appSrc = fs.readFileSync(
 // 1. Source-level guard
 // ---------------------------------------------------------------------------
 describe('imageCache empty-array — source guard', () => {
-  it('App.tsx uses `id in imageCache` (not a truthy check) for the cache guard', () => {
+  it('useCampaignLoader.ts uses `id in imageCache` (not a truthy check) for the cache guard', () => {
     // The correct form is `if (id in imageCache)`.  A truthy check such as
     // `if (imageCache[id])` would silently skip cached campaigns with [] images.
-    expect(appSrc).toMatch(/if\s*\(\s*id\s+in\s+imageCache\s*\)/);
+    // Note: the imageCache logic moved from App.tsx to useCampaignLoader.ts in PR #117.
+    expect(hookSrc).toMatch(/if\s*\(\s*id\s+in\s+imageCache\s*\)/);
   });
 });
 


### PR DESCRIPTION
## Summary

- The source guard test in `client/test/imageCache-empty-array.test.js` was reading `client/src/App.tsx` to assert that `id in imageCache` exists as the cache guard
- PR #117 (fringematrix5-1yg) moved the imageCache/selectCampaign logic from App.tsx into `client/src/hooks/useCampaignLoader.ts`
- Updated the test to read from `useCampaignLoader.ts` (the correct file) and updated the test description to match

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — all 505 tests (384 client + 66 server + 55 scripts) pass
- [x] The previously-failing source guard test now passes

Fixes: fringematrix5-2p2

🤖 Generated with [Claude Code](https://claude.com/claude-code)