### PR TITLE
fringematrix5-9ng: Remove unused imageCache from useCampaignLoader interface

### DIFF
--- a/client/src/hooks/useCampaignLoader.ts
+++ b/client/src/hooks/useCampaignLoader.ts
@@ -51,7 +51,6 @@ async function preloadCampaignImages(
 
 export interface CampaignLoaderState {
   currentImages: ImageData[];
-  imageCache: Record<string, ImageData[]>;
   isCampaignLoading: boolean;
   campaignLoadProgress: number;
   campaignLoadTotal: number;
@@ -166,7 +165,6 @@ export function useCampaignLoader(): CampaignLoaderState {
 
   return {
     currentImages,
-    imageCache,
     isCampaignLoading,
     campaignLoadProgress,
     campaignLoadTotal,


### PR DESCRIPTION
## Summary

- `imageCache` was included in `CampaignLoaderState` (the hook's public interface) but no external consumer ever used it — `App.tsx` did not destructure it from the hook return value
- Removed `imageCache` from the `CampaignLoaderState` interface and from the hook's `return` object
- The internal `imageCache` state and `setImageCache` remain unchanged — they are still used by `selectCampaign` for cache-hit short-circuiting

## Test plan

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] All server tests pass (66 tests)
- [x] All client tests pass (384 tests)
- [x] All script tests pass (55 tests)
- No behavior change — this is purely a dead-field removal from a TypeScript interface

Closes fringematrix5-9ng

🤖 Generated with [Claude Code](https://claude.com/claude-code)