### PR TITLE
fringematrix5-qgd: Expand validate-config.js tests for site and non-object sections

### DIFF
--- a/scripts/validate-config.test.mjs
+++ b/scripts/validate-config.test.mjs
@@ -262,12 +262,14 @@ describe('validateConfigObject — site', () => {
     assert.ok(errors.some(e => e.includes('site.url')), `Expected site.url error, got: ${errors}`);
   });
 
-  it('fails when site.url is a non-http protocol', () => {
+  it('passes when site.url is an ftp URL (validator uses URL() with no protocol restriction)', () => {
     const { errors } = validateConfigObject(validConfig({ site: { url: 'ftp://example.com', shareText: 'Check it out' } }));
-    // ftp:// is actually a parseable URL — what matters is the validator catches truly invalid URLs
-    // This test verifies plain invalid strings (no protocol at all) also fail
-    const { errors: errors2 } = validateConfigObject(validConfig({ site: { url: 'just-text-no-protocol', shareText: 'Check it out' } }));
-    assert.ok(errors2.some(e => e.includes('site.url')), `Expected site.url error, got: ${errors2}`);
+    assert.deepEqual(errors, []);
+  });
+
+  it('fails when site.url has no protocol (not parseable by URL())', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'just-text-no-protocol', shareText: 'Check it out' } }));
+    assert.ok(errors.some(e => e.includes('site.url')), `Expected site.url error, got: ${errors}`);
   });
 
   it('fails when site.shareText is an empty string', () => {

--- a/scripts/validate-config.test.mjs
+++ b/scripts/validate-config.test.mjs
@@ -244,6 +244,73 @@ describe('validateConfigObject — lightbox.sidebarAnimation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// validateConfigObject — site section
+// ---------------------------------------------------------------------------
+describe('validateConfigObject — site', () => {
+  it('passes when site.url is a valid https URL', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'https://example.com', shareText: 'Check it out' } }));
+    assert.deepEqual(errors, []);
+  });
+
+  it('passes when site.url is a valid http URL', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'http://example.com', shareText: 'Check it out' } }));
+    assert.deepEqual(errors, []);
+  });
+
+  it('fails when site.url is not a valid URL', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'not-a-url', shareText: 'Check it out' } }));
+    assert.ok(errors.some(e => e.includes('site.url')), `Expected site.url error, got: ${errors}`);
+  });
+
+  it('fails when site.url is a non-http protocol', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'ftp://example.com', shareText: 'Check it out' } }));
+    // ftp:// is actually a parseable URL — what matters is the validator catches truly invalid URLs
+    // This test verifies plain invalid strings (no protocol at all) also fail
+    const { errors: errors2 } = validateConfigObject(validConfig({ site: { url: 'just-text-no-protocol', shareText: 'Check it out' } }));
+    assert.ok(errors2.some(e => e.includes('site.url')), `Expected site.url error, got: ${errors2}`);
+  });
+
+  it('fails when site.shareText is an empty string', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'https://example.com', shareText: '' } }));
+    assert.ok(errors.some(e => e.includes('site.shareText')), `Expected site.shareText error, got: ${errors}`);
+  });
+
+  it('fails when site.shareText is a whitespace-only string', () => {
+    const { errors } = validateConfigObject(validConfig({ site: { url: 'https://example.com', shareText: '   ' } }));
+    assert.ok(errors.some(e => e.includes('site.shareText')), `Expected site.shareText error, got: ${errors}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateConfigObject — non-object section types
+// ---------------------------------------------------------------------------
+describe('validateConfigObject — non-object section types', () => {
+  it('fails when theme section is a string (not an object)', () => {
+    const cfg = validConfig({ theme: 'not-an-object' });
+    const { errors } = validateConfigObject(cfg);
+    assert.ok(errors.some(e => e.includes('theme')), `Expected theme error, got: ${errors}`);
+  });
+
+  it('fails when theme section is a number (not an object)', () => {
+    const cfg = validConfig({ theme: 42 });
+    const { errors } = validateConfigObject(cfg);
+    assert.ok(errors.some(e => e.includes('theme')), `Expected theme error, got: ${errors}`);
+  });
+
+  it('fails when lightbox section is a string (not an object)', () => {
+    const cfg = validConfig({ lightbox: 'not-an-object' });
+    const { errors } = validateConfigObject(cfg);
+    assert.ok(errors.some(e => e.includes('lightbox')), `Expected lightbox error, got: ${errors}`);
+  });
+
+  it('fails when lightbox section is a number (not an object)', () => {
+    const cfg = validConfig({ lightbox: 123 });
+    const { errors } = validateConfigObject(cfg);
+    assert.ok(errors.some(e => e.includes('lightbox')), `Expected lightbox error, got: ${errors}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // validateConfigObject — loadingScreen validation
 // ---------------------------------------------------------------------------
 describe('validateConfigObject — loadingScreen', () => {


### PR DESCRIPTION
## Summary

- Add `site` describe block: tests for `site.url` valid https/http URL passes, invalid URL (no protocol) fails
- Add `site.shareText` tests: empty string and whitespace-only string both rejected
- Add `non-object section types` describe block: `theme` and `lightbox` as string or number both produce errors

## Background

Follow-up from review of fringematrix5-1e5. The validation logic in `scripts/validate-config.js` already handles all these cases; these tests close coverage gaps that were identified during that review.

## Test plan

- [x] All 65 validate-config tests pass (`node --test scripts/validate-config.test.mjs`)
- [x] No regressions in server or client test suites
- [x] TypeScript check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)