### PR TITLE
fringematrix5-h31: Fix useCampaignLoader tests broken by imageCache interface change

### DIFF
--- a/client/test/useCampaignLoader.test.ts
+++ b/client/test/useCampaignLoader.test.ts
@@ -168,8 +168,15 @@ describe('useCampaignLoader — normal load', () => {
       await result.current.loadCampaignImages('ep1', controller.signal);
     });
 
-    expect('ep1' in result.current.imageCache).toBe(true);
-    expect(result.current.imageCache['ep1']).toHaveLength(1);
+    const fetchCallsAfterFirstLoad = fetchSpy.mock.calls.length;
+
+    // Second load of same campaign via selectCampaign — should hit cache, no new fetch
+    await act(async () => {
+      await result.current.selectCampaign('ep1', () => {});
+    });
+
+    expect(fetchSpy.mock.calls.length).toBe(fetchCallsAfterFirstLoad);
+    expect(result.current.currentImages).toHaveLength(1);
   });
 
   it('does not set campaignLoadError when all images load successfully', async () => {
@@ -257,7 +264,15 @@ describe('useCampaignLoader — empty image response', () => {
       await result.current.loadCampaignImages('ep-empty', controller.signal);
     });
 
-    expect('ep-empty' in result.current.imageCache).toBe(false);
+    const fetchCallsAfterFirstLoad = fetchSpy.mock.calls.length;
+
+    // Second visit — empty was not cached, so a new fetch MUST be triggered
+    fetchSpy.mockResolvedValueOnce(makeImagesResponse([]));
+    await act(async () => {
+      await result.current.selectCampaign('ep-empty', () => {});
+    });
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(fetchCallsAfterFirstLoad);
   });
 });
 
@@ -603,7 +618,6 @@ describe('useCampaignLoader — selectCampaign cache-hit (renderHook)', () => {
       await result.current.selectCampaign('ep1', () => {});
     });
 
-    expect('ep1' in result.current.imageCache).toBe(true);
     const fetchCallsAfterFirstLoad = fetchSpy.mock.calls.length;
 
     // Second visit — should hit cache, no fetch


### PR DESCRIPTION
## Summary

- Three tests in `client/test/useCampaignLoader.test.ts` referenced `result.current.imageCache` which was removed from the hook's public interface in PR #126
- Replaced `imageCache` assertions with observable-state checks (fetch call counts, `currentImages` length) that verify the same caching behavior without accessing internal state

## Changes

1. **"caches the fully-loaded images under the campaign id"**: After loading `ep1`, calls `selectCampaign('ep1')` again and asserts no new fetch was triggered
2. **"does NOT cache the campaign when image list is empty"**: After loading an empty response, calls `selectCampaign('ep-empty')` and asserts a new fetch IS triggered (empty results are not cached)
3. **"serves images from cache without calling fetch a second time"**: Removed the `expect('ep1' in result.current.imageCache).toBe(true)` line — the subsequent fetch count check already verifies caching

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (438 client tests, 66 server tests, 10 test suites all green)
- All three previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)