### PR TITLE
fringematrix5-n4q + fringematrix5-3m1: Clean up site.test.js

### DIFF
--- a/client/src/config/site.ts
+++ b/client/src/config/site.ts
@@ -11,8 +11,8 @@ import configYaml from '../../config.yaml';
 
 const config = configYaml as AppConfig;
 
-const DEFAULT_SITE_URL = 'https://fringematrix.art';
-const DEFAULT_SHARE_TEXT = 'Check out Fringe Matrix';
+export const SITE_URL_DEFAULT = 'https://fringematrix.art';
+export const SITE_SHARE_TEXT_DEFAULT = 'Check out Fringe Matrix';
 
 /**
  * The canonical site URL used for share links.
@@ -21,7 +21,7 @@ const DEFAULT_SHARE_TEXT = 'Check out Fringe Matrix';
 export const SITE_URL: string =
   typeof config.site?.url === 'string' && config.site.url.trim().length > 0
     ? config.site.url
-    : DEFAULT_SITE_URL;
+    : SITE_URL_DEFAULT;
 
 /**
  * Default share text prepended to Threads (and similar) share links.
@@ -30,4 +30,4 @@ export const SITE_URL: string =
 export const SITE_SHARE_TEXT: string =
   typeof config.site?.shareText === 'string' && config.site.shareText.trim().length > 0
     ? config.site.shareText
-    : DEFAULT_SHARE_TEXT;
+    : SITE_SHARE_TEXT_DEFAULT;

--- a/client/test/site.test.js
+++ b/client/test/site.test.js
@@ -8,10 +8,8 @@
  * each test group a fresh module with its own config mock. This is the same
  * approach used in theme.test.js to avoid YAML import issues in the test env.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-
-const DEFAULT_SITE_URL = 'https://fringematrix.art';
-const DEFAULT_SHARE_TEXT = 'Check out Fringe Matrix';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SITE_URL_DEFAULT, SITE_SHARE_TEXT_DEFAULT } from '../src/config/site.ts';
 
 /**
  * Helper: mocks config.yaml with the given config object, then
@@ -59,40 +57,40 @@ describe('site.ts — valid config values', () => {
 describe('site.ts — SITE_URL fallback', () => {
   it('falls back to default when config.site is undefined (site key missing)', async () => {
     const mod = await importSiteWithConfig({});
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 
   it('falls back to default when config.site.url is undefined', async () => {
     const mod = await importSiteWithConfig({ site: { shareText: 'Hello' } });
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 
   it('falls back to default when config.site.url is an empty string', async () => {
     const mod = await importSiteWithConfig({
       site: { url: '', shareText: 'Hello' },
     });
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 
   it('falls back to default when config.site.url is a whitespace-only string', async () => {
     const mod = await importSiteWithConfig({
       site: { url: '   ', shareText: 'Hello' },
     });
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 
   it('falls back to default when config.site.url is a number (not a string)', async () => {
     const mod = await importSiteWithConfig({
       site: { url: 42, shareText: 'Hello' },
     });
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 
   it('falls back to default when config.site.url is null', async () => {
     const mod = await importSiteWithConfig({
       site: { url: null, shareText: 'Hello' },
     });
-    expect(mod.SITE_URL).toBe(DEFAULT_SITE_URL);
+    expect(mod.SITE_URL).toBe(SITE_URL_DEFAULT);
   });
 });
 
@@ -102,39 +100,39 @@ describe('site.ts — SITE_URL fallback', () => {
 describe('site.ts — SITE_SHARE_TEXT fallback', () => {
   it('falls back to default when config.site is undefined (site key missing)', async () => {
     const mod = await importSiteWithConfig({});
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 
   it('falls back to default when config.site.shareText is undefined', async () => {
     const mod = await importSiteWithConfig({ site: { url: 'https://example.com' } });
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 
   it('falls back to default when config.site.shareText is an empty string', async () => {
     const mod = await importSiteWithConfig({
       site: { url: 'https://example.com', shareText: '' },
     });
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 
   it('falls back to default when config.site.shareText is a whitespace-only string', async () => {
     const mod = await importSiteWithConfig({
       site: { url: 'https://example.com', shareText: '   ' },
     });
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 
   it('falls back to default when config.site.shareText is a number (not a string)', async () => {
     const mod = await importSiteWithConfig({
       site: { url: 'https://example.com', shareText: 99 },
     });
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 
   it('falls back to default when config.site.shareText is null', async () => {
     const mod = await importSiteWithConfig({
       site: { url: 'https://example.com', shareText: null },
     });
-    expect(mod.SITE_SHARE_TEXT).toBe(DEFAULT_SHARE_TEXT);
+    expect(mod.SITE_SHARE_TEXT).toBe(SITE_SHARE_TEXT_DEFAULT);
   });
 });


### PR DESCRIPTION
## Summary

- **n4q**: Remove unused `beforeEach` from the vitest import in `client/test/site.test.js` — it was imported but never used
- **3m1**: Export `SITE_URL_DEFAULT` and `SITE_SHARE_TEXT_DEFAULT` from `client/src/config/site.ts`, then import and use them in `site.test.js` instead of local duplicate constants — prevents the test silently diverging if defaults change in the source

## Test plan

- [x] All 14 `site.test.js` tests pass (verified locally)
- [x] No new test failures introduced (3 pre-existing `useCampaignLoader.test.ts` failures are unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)