### PR TITLE
fringematrix5-8rt: Prune stale GalleryGrid ref cache on image array shrink

### DIFF
--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useImperativeHandle, useRef } from 'react';
+import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
 import type { ImageData } from '../types/api';
 
 /** Public API exposed to callers via a ref (useImperativeHandle). */
@@ -46,6 +46,20 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
      * unnecessary churn in `thumbMapRef`.
      */
     const refCallbackCacheRef = useRef<Map<number, (el: HTMLImageElement | null) => void>>(new Map());
+
+    // Prune stale entries from both caches when images array shrinks (e.g. campaign switch).
+    useEffect(() => {
+      for (const key of refCallbackCacheRef.current.keys()) {
+        if (key >= images.length) {
+          refCallbackCacheRef.current.delete(key);
+        }
+      }
+      for (const key of thumbMapRef.current.keys()) {
+        if (key >= images.length) {
+          thumbMapRef.current.delete(key);
+        }
+      }
+    }, [images.length]);
 
     const setThumbRef = useCallback((index: number): (el: HTMLImageElement | null) => void => {
       let cb = refCallbackCacheRef.current.get(index);


### PR DESCRIPTION
## Summary

- Adds a `useEffect` in `GalleryGrid` that prunes stale entries from `refCallbackCacheRef` and `thumbMapRef` whenever `images.length` decreases (e.g. on campaign switch)
- Without this fix, callback closures for old indices accumulate indefinitely in memory across campaign switches
- Also prunes `thumbMapRef` for consistency, since DOM refs for out-of-range indices are no longer valid

## Test plan

- [ ] All existing GalleryGrid tests pass (12 tests in `GalleryGrid.test.tsx`)
- [ ] `npm run test:client` shows no new failures introduced by this change
- [ ] `npm test` passes (3 pre-existing failures in `useCampaignLoader.test.ts` from a separate bead are unrelated)
- [ ] Manual: switch between campaigns of different sizes and verify no stale DOM refs remain accessible via `getThumbElement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)