### PR TITLE
fringematrix5-6x9: Add orientation comments to animation useEffect and thumbnail fallback

### DIFF
--- a/client/src/hooks/useLightboxAnimations.ts
+++ b/client/src/hooks/useLightboxAnimations.ts
@@ -508,6 +508,7 @@ export function useLightboxAnimations({
         return;
       }
       const startRect = lightboxImg.getBoundingClientRect();
+      // Fallback cascade: live DOM lookup via callback → activeGridThumbRef (last focused thumb) → lastOpenedThumbElRef (original open target).
       let thumbElement = getThumbElement(lightboxIndex) as HTMLElement | null;
       if (!thumbElement && activeGridThumbRef.current && document.body.contains(activeGridThumbRef.current)) {
         thumbElement = activeGridThumbRef.current;
@@ -567,7 +568,9 @@ export function useLightboxAnimations({
     }
   }, [reduceMotion, images, lightboxIndex, getThumbElement, animateLightboxBackdrop, runWireframeAnimation, animateLightboxSidebar, setHideLightboxImage, setIsLightboxOpen]);
 
-  // After mount of lightbox, animate wireframe and backdrop in
+  // After mount of lightbox, animate wireframe and backdrop in.
+  // Four paths: (1) reduceMotion — snap open instantly; (2) no startRect — sidebar+backdrop only (URL-hash open);
+  // (3) zero-dimension rect — thumbnail not measurable, degrade to backdrop+sidebar; (4) full wireframe+backdrop+sidebar.
   useEffect(() => {
     if (!isLightboxOpen) return;
     if (reduceMotion) {


### PR DESCRIPTION
## Summary

- Adds a 3-line orientation comment above the `isLightboxOpen` useEffect naming its four code paths: reduced-motion snap, no-thumbnail-rect (URL-hash open), zero-dimension rect fallback, and full wireframe+backdrop+sidebar animation
- Adds a one-line comment above the 3-tier thumbnail element fallback cascade in `closeLightbox`, explaining the lookup priority: live DOM callback → `activeGridThumbRef` → `lastOpenedThumbElRef`

Both comment insertions are code-comment only; no logic was changed.

Closes bead fringematrix5-6x9.

## Test plan

- [ ] `npm run test:server` passes
- [ ] `npm run test:client` passes (3 pre-existing failures in useCampaignLoader unrelated to this change)
- [ ] No TypeScript errors (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)