### PR TITLE
fringematrix5-rnj: Add comments explaining src/loadedSrc and latestOpenStateRef patterns

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -225,7 +225,7 @@ export default function App() {
   const scheduledFrameRef = useRef<number | null>(null);
   const latestOpenStateRef = useRef({ isShareOpen: false, isBuildInfoOpen: false });
 
-  // Keep latest open-state in a ref so the handler can be stable
+  // Sync open state into ref so onScrollOrResize can read it without becoming a new function reference that re-triggers addEventListener.
   useEffect(() => {
     latestOpenStateRef.current.isShareOpen = isShareOpen;
   }, [isShareOpen]);

--- a/client/src/hooks/useCampaignLoader.ts
+++ b/client/src/hooks/useCampaignLoader.ts
@@ -99,6 +99,7 @@ export function useCampaignLoader(): CampaignLoaderState {
         return;
       }
 
+      // loadedSrc stays null until preload completes; gallery renders loadedSrc||src so placeholders show nothing while the browser fetches each image.
       const placeholderImages = campaignImages.map((img: ApiImageData) => ({
         fileName: img.fileName,
         originalSrc: img.src,


### PR DESCRIPTION
## Summary

- Adds a one-line WHY comment in `useCampaignLoader.ts` explaining the `src`/`loadedSrc` two-phase model: `loadedSrc` stays `null` until preload completes so the gallery can distinguish "URL known but not yet in browser cache" from "fully preloaded and safe to display"
- Adds a one-line WHY comment in `App.tsx` explaining the `latestOpenStateRef` sync pattern: the ref lets `onScrollOrResize` read current open state without becoming a new function reference that would re-trigger `addEventListener`

Closes bead `fringematrix5-rnj`.

## Test plan

- [ ] No logic changes — comment-only diff
- [ ] `npm test` passes (3 pre-existing failures in `useCampaignLoader.test.ts` re: `imageCache` are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)