### PR TITLE
fringematrix5-bt4: Extract ImageCard as memoized component from GalleryGrid

### DIFF
--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
 import type { ImageData } from '../types/api';
+import ImageCard from './ImageCard';
 
 /** Public API exposed to callers via a ref (useImperativeHandle). */
 export interface GalleryGridHandle {
@@ -47,7 +48,15 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
      */
     const refCallbackCacheRef = useRef<Map<number, (el: HTMLImageElement | null) => void>>(new Map());
 
-    // Prune stale entries from both caches when images array shrinks (e.g. campaign switch).
+    /**
+     * Cache of per-index click handlers so that the same function reference is
+     * passed to each ImageCard across renders. This is what makes React.memo on
+     * ImageCard effective — without stable references the memo check would fail
+     * on every render.
+     */
+    const clickCallbackCacheRef = useRef<Map<number, (e: React.MouseEvent<HTMLImageElement>) => void>>(new Map());
+
+    // Prune stale entries from all caches when images array shrinks (e.g. campaign switch).
     useEffect(() => {
       for (const key of refCallbackCacheRef.current.keys()) {
         if (key >= images.length) {
@@ -57,6 +66,11 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
       for (const key of thumbMapRef.current.keys()) {
         if (key >= images.length) {
           thumbMapRef.current.delete(key);
+        }
+      }
+      for (const key of clickCallbackCacheRef.current.keys()) {
+        if (key >= images.length) {
+          clickCallbackCacheRef.current.delete(key);
         }
       }
     }, [images.length]);
@@ -76,6 +90,29 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
       return cb;
     }, []);
 
+    /**
+     * Returns a stable per-index click handler that forwards to the parent's
+     * onImageClick. Because onImageClick may change identity (e.g. on re-render),
+     * we capture it via a ref so the cached closure always calls the latest version
+     * without itself needing to change.
+     */
+    const onImageClickRef = useRef(onImageClick);
+    onImageClickRef.current = onImageClick;
+
+    const getClickCallback = useCallback(
+      (index: number): ((e: React.MouseEvent<HTMLImageElement>) => void) => {
+        let cb = clickCallbackCacheRef.current.get(index);
+        if (!cb) {
+          cb = (e: React.MouseEvent<HTMLImageElement>) => {
+            onImageClickRef.current(index, e.currentTarget);
+          };
+          clickCallbackCacheRef.current.set(index, cb);
+        }
+        return cb;
+      },
+      [],
+    );
+
     const isEmpty = hasCampaign && images.length === 0;
 
     return (
@@ -92,25 +129,12 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
           </div>
         ) : (
           images.map((img, i) => (
-            <div className="card" key={`${img.src}-${i}`}>
-              {img.isLoading ? (
-                <div className="image-placeholder">
-                  <div className="placeholder-content">
-                    <div className="placeholder-icon">📷</div>
-                    <div className="placeholder-text">Loading...</div>
-                  </div>
-                </div>
-              ) : (
-                <img
-                  ref={setThumbRef(i)}
-                  src={img.loadedSrc || img.src || ''}
-                  alt={img.fileName}
-                  loading="lazy"
-                  onClick={(e) => onImageClick(i, e.currentTarget)}
-                />
-              )}
-              <div className="filename">{img.fileName}</div>
-            </div>
+            <ImageCard
+              key={`${img.src}-${i}`}
+              image={img}
+              imgRef={setThumbRef(i)}
+              onClick={getClickCallback(i)}
+            />
           ))
         )}
       </section>

--- a/client/src/components/ImageCard.tsx
+++ b/client/src/components/ImageCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import type { ImageData } from '../types/api';
+
+interface ImageCardProps {
+  image: ImageData;
+  /** Stable callback — called when the card's image is clicked */
+  onClick: (e: React.MouseEvent<HTMLImageElement>) => void;
+  /** Ref callback for the <img> element (used by GalleryGrid to populate thumbMapRef) */
+  imgRef?: (el: HTMLImageElement | null) => void;
+}
+
+/**
+ * Memoized image card rendered inside GalleryGrid.
+ *
+ * Wrapping with React.memo means that as long as the image data and onClick
+ * callback reference are the same between renders, React skips re-diffing this
+ * card entirely — eliminating per-card VDOM work during App-level re-renders.
+ */
+const ImageCard = React.memo(function ImageCard({ image, onClick, imgRef }: ImageCardProps) {
+  return (
+    <div className="card">
+      {image.isLoading ? (
+        <div className="image-placeholder">
+          <div className="placeholder-content">
+            <div className="placeholder-icon">📷</div>
+            <div className="placeholder-text">Loading...</div>
+          </div>
+        </div>
+      ) : (
+        <img
+          ref={imgRef}
+          src={image.loadedSrc || image.src || ''}
+          alt={image.fileName}
+          loading="lazy"
+          onClick={onClick}
+        />
+      )}
+      <div className="filename">{image.fileName}</div>
+    </div>
+  );
+});
+
+export default ImageCard;


### PR DESCRIPTION
## Summary

- Extracts inline image card JSX from `GalleryGrid` into a dedicated `client/src/components/ImageCard.tsx` wrapped with `React.memo`
- Adds a per-index click callback cache (`clickCallbackCacheRef`) in `GalleryGrid` — identical pattern to the existing `refCallbackCacheRef` — so stable function references are passed to each `ImageCard`, making `React.memo` comparisons effective
- Uses a `onImageClickRef` indirection so cached click closures always invoke the latest `onImageClick` prop without needing to be re-created when the prop identity changes
- All 27 existing `GalleryGrid` tests pass unchanged

## Test plan

- [x] `npm run test:client` — all 453 client tests pass, including full `GalleryGrid.test.tsx` suite
- [x] `npm run test:server` — all 66 server tests pass
- [x] `npm run test:scripts` — all 66 script tests pass
- [ ] E2E: Playwright gallery rendering and click-through tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced image gallery performance through optimized component rendering and lazy image loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->