### PR TITLE
fringematrix5-x0p: apply panel animation to lightbox nav toolbar

### DIFF
--- a/client/src/hooks/useLightboxAnimations.ts
+++ b/client/src/hooks/useLightboxAnimations.ts
@@ -425,6 +425,21 @@ export function useLightboxAnimations({
     return animateLightboxPanel(sidebar, direction, LIGHTBOX_PANEL_ANIMATION, { reduceMotion });
   }, [reduceMotion]);
 
+  /**
+   * Animate the NAV TOOLBAR on lightbox open/close.
+   *
+   * Thin wrapper: looks up the `.lightbox-nav-toolbar` element and delegates
+   * all choreography to the generic `animateLightboxPanel` primitive above.
+   *
+   * Returns a Promise that resolves when the animation completes (or
+   * immediately if WAAPI is unavailable / toolbar is not in the DOM, or any
+   * reduce-motion/reduce-effects mode is active).
+   */
+  const animateLightboxNavToolbar = useCallback(async (direction: 'in' | 'out'): Promise<void> => {
+    const toolbar = document.querySelector('.lightbox-nav-toolbar') as HTMLElement | null;
+    return animateLightboxPanel(toolbar, direction, LIGHTBOX_PANEL_ANIMATION, { reduceMotion });
+  }, [reduceMotion]);
+
   const animateLightboxBackdrop = useCallback((direction: 'in' | 'out') => {
     const el = document.getElementById('lightbox');
     if (!el) return { finished: Promise.resolve() };
@@ -541,6 +556,7 @@ export function useLightboxAnimations({
         await Promise.all([
           (backdropAnim?.finished || Promise.resolve()).catch(() => {}),
           animateLightboxSidebar('out'),
+          animateLightboxNavToolbar('out'),
         ]);
         backdropDimmedRef.current = false;
         setIsLightboxOpen(false);
@@ -554,6 +570,7 @@ export function useLightboxAnimations({
         await Promise.all([
           (backdropAnim?.finished || Promise.resolve()).catch(() => {}),
           animateLightboxSidebar('out'),
+          animateLightboxNavToolbar('out'),
         ]);
         backdropDimmedRef.current = false;
         return;
@@ -566,6 +583,7 @@ export function useLightboxAnimations({
         runWireframeAnimation(startRect, endRect, img.src || undefined, 'close'),
         (backdropAnim?.finished || Promise.resolve()).catch(() => {}),
         animateLightboxSidebar('out'),
+        animateLightboxNavToolbar('out'),
       ]);
       backdropDimmedRef.current = false;
     } finally {
@@ -586,7 +604,7 @@ export function useLightboxAnimations({
         lastOpenedThumbElRef.current = null;
       }
     }
-  }, [reduceMotion, images, lightboxIndex, getThumbElement, animateLightboxBackdrop, runWireframeAnimation, animateLightboxSidebar, setHideLightboxImage, setIsLightboxOpen]);
+  }, [reduceMotion, images, lightboxIndex, getThumbElement, animateLightboxBackdrop, runWireframeAnimation, animateLightboxSidebar, animateLightboxNavToolbar, setHideLightboxImage, setIsLightboxOpen]);
 
   // After mount of lightbox, animate wireframe and backdrop in.
   // Four paths: (1) reduceMotion -- snap open instantly; (2) no startRect -- sidebar+backdrop only (URL-hash open);
@@ -605,13 +623,14 @@ export function useLightboxAnimations({
     const imgSrc = pendingOpenImgSrcRef.current;
     const needBackdropIn = !backdropDimmedRef.current;
     if (!startRect) {
-      // Open the sidebar even when there is no thumbnail rect to animate
-      // from (e.g. lightbox opened via direct link / URL hash).
+      // Open the sidebar and toolbar even when there is no thumbnail rect to
+      // animate from (e.g. lightbox opened via direct link / URL hash).
       // Only on the FIRST run of this effect per open session -- see
       // sidebarEnteredRef comment.
       if (!sidebarEnteredRef.current) {
         sidebarEnteredRef.current = true;
         animateLightboxSidebar('in');
+        animateLightboxNavToolbar('in');
       }
       if (needBackdropIn) {
         const anim = animateLightboxBackdrop('in');
@@ -647,6 +666,7 @@ export function useLightboxAnimations({
         if (!sidebarEnteredRef.current) {
           sidebarEnteredRef.current = true;
           animateLightboxSidebar('in');
+          animateLightboxNavToolbar('in');
         }
         lightboxImg.style.opacity = '';
         setHideLightboxImage(false);
@@ -663,11 +683,14 @@ export function useLightboxAnimations({
         backdropDimmedRef.current = true;
       }
       let sidebarPromise: Promise<unknown>;
+      let toolbarPromise: Promise<unknown>;
       if (!sidebarEnteredRef.current) {
         sidebarEnteredRef.current = true;
         sidebarPromise = animateLightboxSidebar('in');
+        toolbarPromise = animateLightboxNavToolbar('in');
       } else {
         sidebarPromise = Promise.resolve();
+        toolbarPromise = Promise.resolve();
       }
       // Reveal the real lightbox image at the moment the wireframe animation
       // finishes (and before the wireframe is hidden), not after Promise.all
@@ -682,6 +705,7 @@ export function useLightboxAnimations({
         runWireframeAnimation(startRect, endRect, imgSrc || undefined, 'open', revealLightboxImage),
         (backdropAnim?.finished || Promise.resolve()).catch(() => {}),
         sidebarPromise,
+        toolbarPromise,
       ]);
       // Bail out if the effect was cleaned up during the animation.
       if (abortCtrl.signal.aborted) return;
@@ -694,7 +718,7 @@ export function useLightboxAnimations({
       isAnimatingRef.current = false;
     });
     return () => { cancelAnimationFrame(rAF); abortCtrl.abort(); };
-  }, [isLightboxOpen, lightboxIndex, reduceMotion, animateLightboxBackdrop, runWireframeAnimation, animateLightboxSidebar, setHideLightboxImage]);
+  }, [isLightboxOpen, lightboxIndex, reduceMotion, animateLightboxBackdrop, runWireframeAnimation, animateLightboxSidebar, animateLightboxNavToolbar, setHideLightboxImage]);
 
   // Keep grid thumbs in sync during lightbox navigation
   useEffect(() => {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1779,6 +1779,24 @@ html.reduce-effects .lightbox-details-drawer {
   animation: none !important;
   transition: none !important;
 }
+
+/* Lightbox nav toolbar: force visible immediately, no expand/collapse animation.
+   The JS animation hook also short-circuits in these modes, but inline
+   styles set during a mid-animation toggle (e.g. user enables reduce-motion
+   while the lightbox is open) need to be neutralised by !important. */
+html.reduce-motion .lightbox-nav-toolbar,
+html.reduce-effects .lightbox-nav-toolbar {
+  clip-path: none !important;
+  opacity: 1 !important;
+  animation: none !important;
+  transition: none !important;
+}
+html.reduce-motion .lightbox-nav-toolbar > *,
+html.reduce-effects .lightbox-nav-toolbar > * {
+  opacity: 1 !important;
+  animation: none !important;
+  transition: none !important;
+}
 @media (prefers-reduced-motion: reduce) {
   .lightbox-details {
     clip-path: none !important;
@@ -1787,6 +1805,17 @@ html.reduce-effects .lightbox-details-drawer {
     transition: none !important;
   }
   .lightbox-details > * {
+    opacity: 1 !important;
+    animation: none !important;
+    transition: none !important;
+  }
+  .lightbox-nav-toolbar {
+    clip-path: none !important;
+    opacity: 1 !important;
+    animation: none !important;
+    transition: none !important;
+  }
+  .lightbox-nav-toolbar > * {
     opacity: 1 !important;
     animation: none !important;
     transition: none !important;


### PR DESCRIPTION
## Summary

- Adds `animateLightboxNavToolbar` — a thin wrapper around `animateLightboxPanel` that queries `.lightbox-nav-toolbar` by class name, mirroring the existing `animateLightboxSidebar` pattern.
- Wires the toolbar into all open/close `Promise.all` blocks alongside the sidebar, so it plays the line→expand enter animation on open and the collapse exit animation on close.
- Adds CSS reduce-motion / reduce-effects / `prefers-reduced-motion` guards for `.lightbox-nav-toolbar` and its children, matching the existing `.lightbox-details` rules at lines ~1764-1780 of `styles.css`.

No changes to `LightboxContainer.tsx` were needed — the toolbar is reached via DOM query (same pattern as sidebar), so no ref plumbing was required.

## Test plan

- [ ] Lightbox opens: nav toolbar plays line→expand animation in sync with sidebar
- [ ] Lightbox closes: nav toolbar plays collapse animation in sync with sidebar
- [ ] Nav toolbar buttons (PREVIOUS, DOWNLOAD, SHARE, NEXT) are clickable after animation completes
- [ ] With `prefers-reduced-motion: reduce`: toolbar appears/disappears instantly
- [ ] With `.reduce-motion` or `.reduce-effects` class on `<html>`: toolbar appears/disappears instantly
- [ ] Initial focus on close button (`✕`) is unchanged
- [ ] Tab focus trap works during and after animation
- [ ] Swipe gestures and Escape-to-close are unchanged
- [ ] All CI checks pass: typecheck + tests

Closes fringematrix5-x0p

🤖 Generated with [Claude Code](https://claude.com/claude-code)