### PR TITLE
fringematrix5-1jh: tests for unified lightbox panel animation

### DIFF
--- a/client/test/animateLightboxPanel.test.ts
+++ b/client/test/animateLightboxPanel.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Unit tests for the `animateLightboxPanel` exported function and the three
+ * panel-animation wrappers (sidebar, nav toolbar, image frame) that live
+ * inside useLightboxAnimations.
+ *
+ * Coverage:
+ *  - Reduce-motion early-return: options.reduceMotion flag
+ *  - Reduce-motion early-return: html.reduce-motion / html.reduce-effects classes
+ *  - Reduce-motion early-return: prefers-reduced-motion media query
+ *  - Null-element guard: resolves without throwing
+ *  - Config values read from LIGHTBOX_PANEL_ANIMATION
+ *  - COLLAPSED_CLIP inline style applied at phase 0 (direction='in')
+ *  - element.animate is called when all guards are clear
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { animateLightboxPanel } from '../src/hooks/useLightboxAnimations';
+import { LIGHTBOX_PANEL_ANIMATION } from '../src/config/lightbox';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Create a minimal HTMLElement with a spy on .animate() */
+function makeEl(): HTMLElement {
+  const el = document.createElement('div');
+  // jsdom does not implement Web Animations API — install a stub that
+  // returns an Animation-like object the function can await on.
+  Object.defineProperty(el, 'animate', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => ({
+      finished: Promise.resolve(),
+      cancel: () => {},
+      currentTime: 0,
+    })),
+  });
+  return el;
+}
+
+/** Minimal cfg for reduce-motion tests where we bail before reading cfg. */
+const DUMMY_CFG = LIGHTBOX_PANEL_ANIMATION;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reduce-motion guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('animateLightboxPanel — reduce-motion early returns', () => {
+  afterEach(() => {
+    // Clean up any classes added to <html>
+    document.documentElement.classList.remove('reduce-motion', 'reduce-effects');
+  });
+
+  it('resolves immediately when options.reduceMotion is true', async () => {
+    const el = makeEl();
+    await animateLightboxPanel(el, 'in', DUMMY_CFG, { reduceMotion: true });
+    // animate must NOT have been called — we bailed out before touching the element
+    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately when html has class reduce-motion', async () => {
+    document.documentElement.classList.add('reduce-motion');
+    const el = makeEl();
+    await animateLightboxPanel(el, 'in', DUMMY_CFG);
+    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately when html has class reduce-effects', async () => {
+    document.documentElement.classList.add('reduce-effects');
+    const el = makeEl();
+    await animateLightboxPanel(el, 'in', DUMMY_CFG);
+    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('resolves immediately when prefers-reduced-motion media query matches', async () => {
+    // Override window.matchMedia to return matches:true for the relevant query
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) => {
+      if (query === '(prefers-reduced-motion: reduce)') {
+        return { matches: true, media: query, addListener: () => {}, removeListener: () => {}, addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false, onchange: null } as MediaQueryList;
+      }
+      return originalMatchMedia(query);
+    };
+    const el = makeEl();
+    await animateLightboxPanel(el, 'in', DUMMY_CFG);
+    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('resolves immediately with direction=out when options.reduceMotion is true', async () => {
+    const el = makeEl();
+    await animateLightboxPanel(el, 'out', DUMMY_CFG, { reduceMotion: true });
+    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Null-element guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('animateLightboxPanel — null element guard', () => {
+  it('resolves without throwing when element is null (direction=in)', async () => {
+    await expect(
+      animateLightboxPanel(null, 'in', DUMMY_CFG, { reduceMotion: false })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without throwing when element is null (direction=out)', async () => {
+    await expect(
+      animateLightboxPanel(null, 'out', DUMMY_CFG, { reduceMotion: false })
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves without throwing when element is null and reduce-motion class is absent', async () => {
+    // Ensure guards pass so we reach the null-element check
+    document.documentElement.classList.remove('reduce-motion', 'reduce-effects');
+    await expect(
+      animateLightboxPanel(null, 'in', DUMMY_CFG)
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config values read from LIGHTBOX_PANEL_ANIMATION
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('animateLightboxPanel — reads resolved config', () => {
+  it('LIGHTBOX_PANEL_ANIMATION exposes all required timing fields', () => {
+    const cfg = LIGHTBOX_PANEL_ANIMATION;
+    const fields = [
+      'enterDurationMs',
+      'exitDurationMs',
+      'lineHoldMs',
+      'lineBlinkCount',
+      'lineBlinkIntervalMs',
+      'contentFadeInDelayMs',
+    ] as const;
+    for (const field of fields) {
+      expect(typeof cfg[field]).toBe('number');
+      expect(Number.isFinite(cfg[field])).toBe(true);
+    }
+  });
+
+  it('passes enterDurationMs from cfg to the expand animation', async () => {
+    const el = makeEl();
+    const child = document.createElement('span');
+    el.appendChild(child);
+    // child also needs animate stub
+    Object.defineProperty(child, 'animate', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({ finished: Promise.resolve(), cancel: () => {}, currentTime: 0 })),
+    });
+
+    const fastCfg = { ...DUMMY_CFG, enterDurationMs: 100, lineHoldMs: 0, lineBlinkCount: 0 };
+    await animateLightboxPanel(el, 'in', fastCfg, { reduceMotion: false });
+
+    // el.animate should have been called (for the expand phase at minimum)
+    const animateSpy = el.animate as ReturnType<typeof vi.fn>;
+    expect(animateSpy).toHaveBeenCalled();
+    // The expand call uses duration = enterDurationMs - lineHoldMs = 100 - 0 = 100
+    const lastCall = animateSpy.mock.calls[animateSpy.mock.calls.length - 1];
+    const options = lastCall[1] as KeyframeAnimationOptions;
+    expect(options.duration).toBe(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 0: COLLAPSED_CLIP applied as inline style
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('animateLightboxPanel — phase 0 collapsed clip style', () => {
+  it('sets clipPath to COLLAPSED_CLIP inline at phase 0 on direction=in', async () => {
+    const el = makeEl();
+    const COLLAPSED_CLIP = 'inset(calc(50% - 1px) 0 calc(50% - 1px) 0)';
+
+    let capturedClipPath: string | null = null;
+    const originalAnimate = el.animate;
+    // Intercept the FIRST animate call (blink or expand) to capture the style
+    // that was applied synchronously BEFORE any animate was called.
+    (el as unknown as { animate: typeof el.animate }).animate = vi.fn(function (
+      this: HTMLElement,
+      ...args: Parameters<typeof el.animate>
+    ) {
+      if (capturedClipPath === null) {
+        capturedClipPath = this.style.clipPath;
+      }
+      return originalAnimate.call(this, ...args);
+    }) as unknown as typeof el.animate;
+
+    const cfg = { ...DUMMY_CFG, lineBlinkCount: 0, lineHoldMs: 0, enterDurationMs: 50 };
+    await animateLightboxPanel(el, 'in', cfg, { reduceMotion: false });
+
+    expect(capturedClipPath).toBe(COLLAPSED_CLIP);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Direction=out path calls animate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('animateLightboxPanel — direction=out', () => {
+  it('calls el.animate for the collapse phases', async () => {
+    const el = makeEl();
+    await animateLightboxPanel(el, 'out', DUMMY_CFG, { reduceMotion: false });
+    const animateSpy = el.animate as ReturnType<typeof vi.fn>;
+    expect(animateSpy).toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source-level: three wrapper functions exist and call animateLightboxPanel
+// ─────────────────────────────────────────────────────────────────────────────
+
+import fs from 'fs';
+import path from 'path';
+
+const hookSrc = fs.readFileSync(
+  path.resolve(__dirname, '../src/hooks/useLightboxAnimations.ts'),
+  'utf-8',
+);
+
+describe('useLightboxAnimations — panel animation wrappers (source-level)', () => {
+  it('animateLightboxSidebar wrapper queries .lightbox-details', () => {
+    expect(hookSrc).toMatch(/\.lightbox-details/);
+    expect(hookSrc).toMatch(/animateLightboxSidebar/);
+  });
+
+  it('animateLightboxNavToolbar wrapper queries .lightbox-nav-toolbar', () => {
+    expect(hookSrc).toMatch(/\.lightbox-nav-toolbar/);
+    expect(hookSrc).toMatch(/animateLightboxNavToolbar/);
+  });
+
+  it('animateLightboxImageFrame wrapper queries .lightbox-image-wrap', () => {
+    expect(hookSrc).toMatch(/\.lightbox-image-wrap/);
+    expect(hookSrc).toMatch(/animateLightboxImageFrame/);
+  });
+
+  it('all three wrappers delegate to animateLightboxPanel with LIGHTBOX_PANEL_ANIMATION', () => {
+    // Each wrapper must call animateLightboxPanel — count the call sites inside wrappers
+    const sidebarBlock = hookSrc.match(/const animateLightboxSidebar[\s\S]*?}, \[reduceMotion\]\)/);
+    expect(sidebarBlock).not.toBeNull();
+    expect(sidebarBlock![0]).toMatch(/animateLightboxPanel/);
+    expect(sidebarBlock![0]).toMatch(/LIGHTBOX_PANEL_ANIMATION/);
+
+    const toolbarBlock = hookSrc.match(/const animateLightboxNavToolbar[\s\S]*?}, \[reduceMotion\]\)/);
+    expect(toolbarBlock).not.toBeNull();
+    expect(toolbarBlock![0]).toMatch(/animateLightboxPanel/);
+    expect(toolbarBlock![0]).toMatch(/LIGHTBOX_PANEL_ANIMATION/);
+
+    const frameBlock = hookSrc.match(/const animateLightboxImageFrame[\s\S]*?}, \[reduceMotion\]\)/);
+    expect(frameBlock).not.toBeNull();
+    expect(frameBlock![0]).toMatch(/animateLightboxPanel/);
+    expect(frameBlock![0]).toMatch(/LIGHTBOX_PANEL_ANIMATION/);
+  });
+
+  it('animateLightboxImageFrame adds a delay for direction=in (wireframe-tail sync)', () => {
+    const frameBlock = hookSrc.match(/const animateLightboxImageFrame[\s\S]*?}, \[reduceMotion\]\)/);
+    expect(frameBlock).not.toBeNull();
+    // The frame delay is derived from LIGHTBOX_ANIM_MS * 0.35
+    expect(frameBlock![0]).toMatch(/frameDelay/);
+    expect(frameBlock![0]).toMatch(/LIGHTBOX_ANIM_MS.*0\.35|0\.35.*LIGHTBOX_ANIM_MS/);
+  });
+
+  it('animateLightboxImageFrame accepts and checks an AbortSignal', () => {
+    const frameBlock = hookSrc.match(/const animateLightboxImageFrame[\s\S]*?}, \[reduceMotion\]\)/);
+    expect(frameBlock).not.toBeNull();
+    expect(frameBlock![0]).toMatch(/signal\?\.aborted/);
+  });
+
+  it('animateLightboxPanel is exported from the module', () => {
+    expect(hookSrc).toMatch(/export\s+async\s+function\s+animateLightboxPanel/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CSS reduce-motion guards for all three panels
+// ─────────────────────────────────────────────────────────────────────────────
+
+const cssContent = fs.readFileSync(
+  path.resolve(__dirname, '../src/styles.css'),
+  'utf-8',
+);
+
+describe('CSS reduce-motion guards for all three panels', () => {
+  it('html.reduce-motion resets clip-path on .lightbox-details', () => {
+    expect(cssContent).toMatch(/html\.reduce-motion[\s\S]*?\.lightbox-details[\s\S]*?clip-path/);
+  });
+
+  it('html.reduce-effects resets clip-path on .lightbox-details', () => {
+    expect(cssContent).toMatch(/html\.reduce-effects[\s\S]*?\.lightbox-details[\s\S]*?clip-path/);
+  });
+
+  it('html.reduce-motion resets clip-path on .lightbox-nav-toolbar', () => {
+    expect(cssContent).toMatch(/html\.reduce-motion[\s\S]*?\.lightbox-nav-toolbar[\s\S]*?clip-path/);
+  });
+
+  it('html.reduce-effects resets clip-path on .lightbox-nav-toolbar', () => {
+    expect(cssContent).toMatch(/html\.reduce-effects[\s\S]*?\.lightbox-nav-toolbar[\s\S]*?clip-path/);
+  });
+
+  it('html.reduce-motion resets clip-path on .lightbox-image-wrap', () => {
+    expect(cssContent).toMatch(/html\.reduce-motion[\s\S]*?\.lightbox-image-wrap[\s\S]*?clip-path/);
+  });
+
+  it('html.reduce-effects resets clip-path on .lightbox-image-wrap', () => {
+    expect(cssContent).toMatch(/html\.reduce-effects[\s\S]*?\.lightbox-image-wrap[\s\S]*?clip-path/);
+  });
+});

--- a/client/test/animateLightboxPanel.test.ts
+++ b/client/test/animateLightboxPanel.test.ts
@@ -12,7 +12,9 @@
  *  - COLLAPSED_CLIP inline style applied at phase 0 (direction='in')
  *  - element.animate is called when all guards are clear
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { animateLightboxPanel } from '../src/hooks/useLightboxAnimations';
 import { LIGHTBOX_PANEL_ANIMATION } from '../src/config/lightbox';
 
@@ -72,7 +74,8 @@ describe('animateLightboxPanel — reduce-motion early returns', () => {
   });
 
   it('resolves immediately when prefers-reduced-motion media query matches', async () => {
-    // Override window.matchMedia to return matches:true for the relevant query
+    // Override window.matchMedia to return matches:true for the relevant query.
+    // Restore via afterEach so cleanup runs even if the test body throws.
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = (query: string) => {
       if (query === '(prefers-reduced-motion: reduce)') {
@@ -80,10 +83,13 @@ describe('animateLightboxPanel — reduce-motion early returns', () => {
       }
       return originalMatchMedia(query);
     };
-    const el = makeEl();
-    await animateLightboxPanel(el, 'in', DUMMY_CFG);
-    expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
-    window.matchMedia = originalMatchMedia;
+    try {
+      const el = makeEl();
+      await animateLightboxPanel(el, 'in', DUMMY_CFG);
+      expect((el.animate as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it('resolves immediately with direction=out when options.reduceMotion is true', async () => {
@@ -210,9 +216,6 @@ describe('animateLightboxPanel — direction=out', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // Source-level: three wrapper functions exist and call animateLightboxPanel
 // ─────────────────────────────────────────────────────────────────────────────
-
-import fs from 'fs';
-import path from 'path';
 
 const hookSrc = fs.readFileSync(
   path.resolve(__dirname, '../src/hooks/useLightboxAnimations.ts'),

--- a/e2e/lightbox-panel-animation.spec.ts
+++ b/e2e/lightbox-panel-animation.spec.ts
@@ -21,7 +21,10 @@ async function openLightbox(page: Page) {
   const firstCard = page.locator('.gallery-grid .card').first();
   const hasCard = await firstCard.isVisible().catch(() => false);
   if (!hasCard) {
+    // test.skip() throws internally to abort the test; the return guards
+    // against any future refactor that might not throw.
     test.skip(true, 'No images available — skipping lightbox panel animation test');
+    return;
   }
   await firstCard.click();
   await expect(page.locator('#lightbox')).toBeVisible();

--- a/e2e/lightbox-panel-animation.spec.ts
+++ b/e2e/lightbox-panel-animation.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * E2E smoke tests for the unified lightbox panel animation (animateLightboxPanel).
+ *
+ * Coverage:
+ *  - Normal motion: lightbox opens and closes; sidebar, image-frame, and nav toolbar
+ *    are visible while lightbox is open and hidden after close.
+ *  - Reduce-motion (html.reduce-motion class): panels appear and disappear
+ *    instantly without clip-path animation.
+ *  - Reduce-effects (html.reduce-effects class): same instant-transition guarantee.
+ *  - prefers-reduced-motion emulation: same instant-transition guarantee.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+async function waitForLoaderToFinish(page: Page) {
+  const loader = page.getByRole('dialog', { name: 'Loading' });
+  const visible = await loader.isVisible().catch(() => false);
+  if (visible) await loader.waitFor({ state: 'detached' });
+}
+
+async function openLightbox(page: Page) {
+  const firstCard = page.locator('.gallery-grid .card').first();
+  const hasCard = await firstCard.isVisible().catch(() => false);
+  if (!hasCard) {
+    test.skip(true, 'No images available — skipping lightbox panel animation test');
+  }
+  await firstCard.click();
+  await expect(page.locator('#lightbox')).toBeVisible();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Normal-motion smoke test
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Lightbox panel animation — normal motion', () => {
+  test.beforeEach(async ({ page }) => {
+    // Ensure reduce-motion is off
+    await page.addInitScript(() => {
+      localStorage.removeItem('fringematrix-a11y');
+    });
+    await page.goto('/');
+    await waitForLoaderToFinish(page);
+  });
+
+  test('sidebar, image frame, and nav toolbar are visible while lightbox is open', async ({ page }) => {
+    await openLightbox(page);
+
+    // After open animation settles, the three panels should be present in DOM
+    // and not visually clipped to nothing.
+    const sidebar = page.locator('.lightbox-details');
+    const imageWrap = page.locator('.lightbox-image-wrap');
+    const navToolbar = page.locator('.lightbox-nav-toolbar');
+
+    await expect(sidebar).toBeAttached();
+    await expect(imageWrap).toBeAttached();
+    await expect(navToolbar).toBeAttached();
+
+    // Panels should not have a clip-path that collapses them to a line after
+    // the enter animation completes. The function clears inline overrides at the
+    // end of direction='in', so computed clip-path should be none or a full-reveal value.
+    const sidebarClip = await sidebar.evaluate((el) => getComputedStyle(el).clipPath);
+    // Accept 'none', empty string, or an inset that is NOT the collapsed midline value.
+    // The collapsed sentinel is `inset(calc(50% - 1px) 0 calc(50% - 1px) 0)`.
+    // After animation settles the inline style is cleared so computed falls back to CSS (none).
+    const COLLAPSED = 'inset(calc(50% - 1px) 0 calc(50% - 1px) 0)';
+    expect(sidebarClip).not.toBe(COLLAPSED);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#lightbox')).toBeHidden();
+  });
+
+  test('lightbox can be opened and closed without JS errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (err) => errors.push(err.message));
+
+    await openLightbox(page);
+
+    // Navigate a few images
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowLeft');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#lightbox')).toBeHidden();
+
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reduce-motion guard: html.reduce-motion class
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Lightbox panel animation — reduce-motion class guard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('fringematrix-a11y');
+    });
+    await page.goto('/');
+    await waitForLoaderToFinish(page);
+  });
+
+  test('panels appear without animation when html.reduce-motion is set', async ({ page }) => {
+    // Force the reduce-motion class before opening the lightbox
+    await page.evaluate(() => {
+      document.documentElement.classList.add('reduce-motion');
+    });
+
+    await openLightbox(page);
+
+    // With reduce-motion on, animateLightboxPanel bails out before calling
+    // element.animate. The panels should be visible (not stuck clipped).
+    const sidebar = page.locator('.lightbox-details');
+    await expect(sidebar).toBeAttached();
+
+    // Verify the panel is NOT stuck in the collapsed-line state (clip-path sentinel).
+    // The CSS reduce-motion rule resets clip-path to none/initial.
+    const sidebarClip = await sidebar.evaluate((el) => getComputedStyle(el).clipPath);
+    const COLLAPSED = 'inset(calc(50% - 1px) 0 calc(50% - 1px) 0)';
+    expect(sidebarClip).not.toBe(COLLAPSED);
+
+    // Verify element.animate was NOT called on the sidebar (animation skipped).
+    // We do this by checking that no WAAPI animations are running on the sidebar.
+    const sidebarAnimCount = await sidebar.evaluate((el) => el.getAnimations().length);
+    expect(sidebarAnimCount).toBe(0);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#lightbox')).toBeHidden();
+
+    // Also verify no animations ran during close
+    const afterCloseAnimCount = await page.evaluate(() => {
+      const el = document.querySelector('.lightbox-details');
+      return el ? el.getAnimations().length : 0;
+    });
+    expect(afterCloseAnimCount).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reduce-motion guard: html.reduce-effects class
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Lightbox panel animation — reduce-effects class guard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.removeItem('fringematrix-a11y');
+    });
+    await page.goto('/');
+    await waitForLoaderToFinish(page);
+  });
+
+  test('panels appear without clip-path animation when html.reduce-effects is set', async ({ page }) => {
+    await page.evaluate(() => {
+      document.documentElement.classList.add('reduce-effects');
+    });
+
+    await openLightbox(page);
+
+    const sidebar = page.locator('.lightbox-details');
+    await expect(sidebar).toBeAttached();
+
+    const sidebarClip = await sidebar.evaluate((el) => getComputedStyle(el).clipPath);
+    const COLLAPSED = 'inset(calc(50% - 1px) 0 calc(50% - 1px) 0)';
+    expect(sidebarClip).not.toBe(COLLAPSED);
+
+    const sidebarAnimCount = await sidebar.evaluate((el) => el.getAnimations().length);
+    expect(sidebarAnimCount).toBe(0);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#lightbox')).toBeHidden();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reduce-motion guard: prefers-reduced-motion media emulation
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Lightbox panel animation — prefers-reduced-motion emulation', () => {
+  test('panels appear instantly when prefers-reduced-motion: reduce is emulated', async ({ browser }) => {
+    // Create a new context with prefers-reduced-motion: reduce
+    const context = await browser.newContext({
+      reducedMotion: 'reduce',
+    });
+    const page = await context.newPage();
+
+    await page.addInitScript(() => {
+      localStorage.removeItem('fringematrix-a11y');
+    });
+    await page.goto('/');
+    await waitForLoaderToFinish(page);
+
+    const firstCard = page.locator('.gallery-grid .card').first();
+    const hasCard = await firstCard.isVisible().catch(() => false);
+    if (!hasCard) {
+      await context.close();
+      test.skip(true, 'No images available');
+    }
+
+    await firstCard.click();
+    await expect(page.locator('#lightbox')).toBeVisible();
+
+    const sidebar = page.locator('.lightbox-details');
+    await expect(sidebar).toBeAttached();
+
+    // With prefers-reduced-motion: reduce, animateLightboxPanel bails before
+    // calling element.animate. The sidebar should have no running WAAPI animations.
+    const sidebarAnimCount = await sidebar.evaluate((el) => el.getAnimations().length);
+    expect(sidebarAnimCount).toBe(0);
+
+    // Clip-path should not be stuck in the collapsed state
+    const sidebarClip = await sidebar.evaluate((el) => getComputedStyle(el).clipPath);
+    const COLLAPSED = 'inset(calc(50% - 1px) 0 calc(50% - 1px) 0)';
+    expect(sidebarClip).not.toBe(COLLAPSED);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#lightbox')).toBeHidden();
+
+    await context.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `client/test/animateLightboxPanel.test.ts` (25 unit tests via Vitest) covering all reduce-motion early-return paths, null-element guard, phase-0 COLLAPSED_CLIP style, direction='out' animation path, resolved config from `LIGHTBOX_PANEL_ANIMATION`, and source-level assertions on all three panel wrapper functions.
- Adds `e2e/lightbox-panel-animation.spec.ts` (5 Playwright tests) covering normal-motion open/close smoke test, reduce-motion class guard, reduce-effects class guard, and prefers-reduced-motion media emulation.
- Cleans up files created during development in the main repo path.

## Test plan

- [x] `npm run test:client` — all 493 tests pass (25 new in animateLightboxPanel.test.ts)
- [x] `npm run typecheck` — clean
- [x] `npm run test:e2e -- lightbox-panel-animation` — 5 tests skipped in dev (no images) matching existing lightbox e2e skip pattern; will run in CI with real data
- [x] Reduce-motion guard covered by unit tests (3 code paths) and e2e tests (reduce-motion class, reduce-effects class, prefers-reduced-motion emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)