### PR TITLE
fringematrix5-xjh: Add thumbnailSizeIndex state to App.tsx with localStorage persistence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { closeSubwindowsState } from './utils/closeSubwindowsState';
 import { isSafeUrl } from './utils/isSafeUrl';
 import { applyTheme } from './config/theme';
 import { SITE_URL, SITE_SHARE_TEXT } from './config/site';
+import { GALLERY_DEFAULT_SIZE_INDEX, GALLERY_THUMBNAIL_SIZES } from './config/gallery';
 import LoadingManager from './components/LoadingManager';
 import CampaignNavigation from './components/CampaignNavigation';
 import BuildInfoPopover from './components/BuildInfoPopover';
@@ -66,6 +67,7 @@ export default function App() {
   const [isSettingsOpen, setIsSettingsOpen] = useState<boolean>(false);
   const [reduceMotion, setReduceMotion] = useState<boolean>(false);
   const [reduceEffects, setReduceEffects] = useState<boolean>(false);
+  const [thumbnailSizeIndex, setThumbnailSizeIndex] = useState<number>(GALLERY_DEFAULT_SIZE_INDEX);
   // Settings modal: trigger ref for focus restoration on close
   const settingsTriggerRef = useRef<HTMLElement | null>(null);
   const modalLoadAbortRef = useRef<AbortController | null>(null);
@@ -85,6 +87,17 @@ export default function App() {
         const parsed = JSON.parse(saved);
         if (typeof parsed.reduceMotion === 'boolean') setReduceMotion(parsed.reduceMotion);
         if (typeof parsed.reduceEffects === 'boolean') setReduceEffects(parsed.reduceEffects);
+        // Clamp the saved index to the current sizes array in case the
+        // config changed between sessions (e.g. sizes array shrank).
+        if (
+          typeof parsed.thumbnailSizeIndex === 'number'
+          && Number.isFinite(parsed.thumbnailSizeIndex)
+          && Number.isInteger(parsed.thumbnailSizeIndex)
+        ) {
+          const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
+          const clamped = Math.max(0, Math.min(maxIndex, parsed.thumbnailSizeIndex));
+          setThumbnailSizeIndex(clamped);
+        }
       }
     } catch { /* ignore corrupt localStorage */ }
   }, []);
@@ -96,9 +109,12 @@ export default function App() {
     root.classList.toggle('reduce-effects', reduceEffects);
     if (typeof window === 'undefined') return;
     try {
-      localStorage.setItem('fringematrix-a11y', JSON.stringify({ reduceMotion, reduceEffects }));
+      localStorage.setItem(
+        'fringematrix-a11y',
+        JSON.stringify({ reduceMotion, reduceEffects, thumbnailSizeIndex }),
+      );
     } catch { /* ignore storage errors */ }
-  }, [reduceMotion, reduceEffects]);
+  }, [reduceMotion, reduceEffects, thumbnailSizeIndex]);
 
   const activeCampaign = useMemo(
     () => campaigns.find((c) => c.id === activeCampaignId) || null,
@@ -584,6 +600,8 @@ export default function App() {
         isReduceEffects={reduceEffects}
         onToggleReduceMotion={() => setReduceMotion(v => !v)}
         onToggleReduceEffects={() => setReduceEffects(v => !v)}
+        thumbnailSizeIndex={thumbnailSizeIndex}
+        onChangeThumbnailSizeIndex={setThumbnailSizeIndex}
       />
 
       <ContentModal

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -21,6 +21,13 @@ interface Props {
   isReduceEffects: boolean;
   onToggleReduceMotion: () => void;
   onToggleReduceEffects: () => void;
+  /**
+   * Current index into GALLERY_THUMBNAIL_SIZES (guaranteed in range by App).
+   * Wired in fringematrix5-xjh ahead of the slider UI widget — the slider
+   * itself will be added in a follow-up bead that consumes these props.
+   */
+  thumbnailSizeIndex: number;
+  onChangeThumbnailSizeIndex: (index: number) => void;
 }
 
 export default function SettingsModal({
@@ -30,6 +37,10 @@ export default function SettingsModal({
   isReduceEffects,
   onToggleReduceMotion,
   onToggleReduceEffects,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  thumbnailSizeIndex: _thumbnailSizeIndex,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onChangeThumbnailSizeIndex: _onChangeThumbnailSizeIndex,
 }: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);

--- a/client/test/SettingsModal.test.tsx
+++ b/client/test/SettingsModal.test.tsx
@@ -11,6 +11,8 @@ function renderModal(overrides: Partial<React.ComponentProps<typeof SettingsModa
     isReduceEffects: false,
     onToggleReduceMotion: vi.fn(),
     onToggleReduceEffects: vi.fn(),
+    thumbnailSizeIndex: 1,
+    onChangeThumbnailSizeIndex: vi.fn(),
     ...overrides,
   };
   return { ...render(<SettingsModal {...props} />), props };

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -289,6 +289,41 @@ describe('Accessibility Settings Logic', () => {
     expect(parsed.reduceEffects).toBe(false);
   });
 
+  it('localStorage should serialize thumbnailSizeIndex alongside a11y settings', () => {
+    const settings = { reduceMotion: false, reduceEffects: true, thumbnailSizeIndex: 2 };
+    const parsed = JSON.parse(JSON.stringify(settings));
+    expect(parsed.thumbnailSizeIndex).toBe(2);
+    expect(parsed.reduceMotion).toBe(false);
+    expect(parsed.reduceEffects).toBe(true);
+  });
+
+  it('thumbnailSizeIndex clamping keeps in-range values unchanged', () => {
+    const sizesLength = 4; // matches GALLERY_THUMBNAIL_SIZES default
+    const maxIndex = sizesLength - 1;
+    const clamp = (n) => Math.max(0, Math.min(maxIndex, n));
+    expect(clamp(0)).toBe(0);
+    expect(clamp(1)).toBe(1);
+    expect(clamp(3)).toBe(3);
+  });
+
+  it('thumbnailSizeIndex clamping pulls out-of-range values into range', () => {
+    const sizesLength = 4;
+    const maxIndex = sizesLength - 1;
+    const clamp = (n) => Math.max(0, Math.min(maxIndex, n));
+    // Saved value larger than the current sizes array (e.g. config shrank)
+    expect(clamp(7)).toBe(3);
+    // Negative saved value (corrupt or downgraded)
+    expect(clamp(-1)).toBe(0);
+  });
+
+  it('rejects non-integer thumbnailSizeIndex (App validates type before clamping)', () => {
+    // App.tsx requires Number.isInteger; non-integers are ignored entirely
+    expect(Number.isInteger(1.5)).toBe(false);
+    expect(Number.isInteger(NaN)).toBe(false);
+    expect(Number.isInteger(Infinity)).toBe(false);
+    expect(Number.isInteger(2)).toBe(true);
+  });
+
   it('should handle corrupt localStorage gracefully', () => {
     expect(() => {
       const val = 'not-json';


### PR DESCRIPTION
## Bead
fringematrix5-xjh

Depends on fringematrix5-b5l (closed). Blocks fringematrix5-z6x.

## Summary
- Adds `thumbnailSizeIndex` state to `App.tsx`, defaulting to `GALLERY_DEFAULT_SIZE_INDEX` from `client/src/config/gallery.ts`.
- Extends the existing `fringematrix-a11y` localStorage key to also persist `thumbnailSizeIndex` alongside `reduceMotion` / `reduceEffects`.
- On mount, the persisted value is type-checked (`Number.isInteger`) and clamped to `[0, GALLERY_THUMBNAIL_SIZES.length - 1]` so a config change between sessions can never produce an out-of-range index.
- `SettingsModal` accepts `thumbnailSizeIndex` and `onChangeThumbnailSizeIndex` props so the upcoming slider widget can consume them without further App-level changes. The slider UI itself is intentionally out of scope and tracked separately.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:client` — 525 passing (includes new clamping + serialization tests in `accessibility.test.js` and updated `SettingsModal.test.tsx` props)
- [x] `npm run test:server` — 66 passing
- [x] `npm run build` — clean (config validation + Vite build)
- [ ] Manual sanity: open Settings; thumbnailSizeIndex round-trips via localStorage across reloads (will be testable end-to-end once the slider lands)

## Follow-ups
- The slider widget that consumes these props will be filed as a follow-up bead after merge.
- fringematrix5-z6x (replace hardcoded grid `minmax` with `--thumbnail-min-size` CSS variable) is now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thumbnail size selection is now available in accessibility settings. Your chosen size preference will be automatically saved and restored whenever you return to the application.

* **Tests**
  * Comprehensive test coverage has been added to ensure thumbnail size preferences are correctly validated, stored, and retrieved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->