### PR TITLE
fringematrix5-z6x: Replace hardcoded grid minmax with --thumbnail-min-size CSS variable

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -116,6 +116,19 @@ export default function App() {
     } catch { /* ignore storage errors */ }
   }, [reduceMotion, reduceEffects, thumbnailSizeIndex]);
 
+  // Apply the resolved thumbnail size to the --thumbnail-min-size CSS variable
+  // so styles.css `.gallery-grid` minmax() picks up the user's selected size.
+  // GALLERY_THUMBNAIL_SIZES are in device pixels; divide by devicePixelRatio
+  // to get CSS pixels for the grid track minimum.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    const devicePx = GALLERY_THUMBNAIL_SIZES[thumbnailSizeIndex];
+    if (typeof devicePx !== 'number' || !Number.isFinite(devicePx)) return;
+    const dpr = window.devicePixelRatio > 0 ? window.devicePixelRatio : 1;
+    const cssSize = devicePx / dpr;
+    document.documentElement.style.setProperty('--thumbnail-min-size', `${cssSize}px`);
+  }, [thumbnailSizeIndex]);
+
   const activeCampaign = useMemo(
     () => campaigns.find((c) => c.id === activeCampaignId) || null,
     [campaigns, activeCampaignId]

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -352,7 +352,7 @@ footer.navbar {
 
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--thumbnail-min-size, 160px), 1fr));
   gap: var(--grid-gap);
   margin: 18px 0 80px;
 }
@@ -689,11 +689,6 @@ footer.navbar {
   background: rgba(0,0,0,0.4);
   z-index: 23;
 }
-
-@media (min-width: 900px) {
-  .gallery-grid { grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
-}
-
 
 /* Top toolbar row */
 .toolbar {
@@ -1696,11 +1691,6 @@ body::before {
 @media (min-width: 768px) and (max-width: 1023px) {
   body::before { opacity: 0.3; }
   .lightbox img { animation: none; }
-}
-
-/* Large desktop: enhanced grid */
-@media (min-width: 1440px) {
-  .gallery-grid { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
 }
 
 /* =============================================================================

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -188,8 +188,26 @@ describe('Responsive Breakpoints', () => {
     expect(cssContent).toMatch(/@media\s*\(min-width:\s*768px\)\s*and\s*\(max-width:\s*1023px\)/);
   });
 
-  it('should have large desktop breakpoint (1440px)', () => {
-    expect(cssContent).toMatch(/@media\s*\(min-width:\s*1440px\)/);
+  it('gallery grid should use the --thumbnail-min-size CSS variable for column sizing', () => {
+    // The gallery grid sizes are now driven by a CSS variable (set from
+    // the user's thumbnail-size selection) instead of hardcoded breakpoint
+    // overrides at 900px / 1440px. Verify the variable is wired into the
+    // grid-template-columns rule with a sensible fallback.
+    expect(cssContent).toMatch(
+      /\.gallery-grid\s*\{[^}]*grid-template-columns:\s*repeat\(\s*auto-fill\s*,\s*minmax\(\s*var\(--thumbnail-min-size,\s*160px\)\s*,\s*1fr\s*\)\s*\)/s,
+    );
+  });
+
+  it('gallery grid should not have per-breakpoint column-width overrides', () => {
+    // After moving to a CSS variable, the 900px and 1440px @media overrides
+    // for .gallery-grid grid-template-columns must be gone so the variable
+    // controls sizing uniformly across viewport widths.
+    expect(cssContent).not.toMatch(
+      /@media\s*\(min-width:\s*900px\)\s*\{[^}]*\.gallery-grid\s*\{[^}]*grid-template-columns/s,
+    );
+    expect(cssContent).not.toMatch(
+      /@media\s*\(min-width:\s*1440px\)\s*\{[^}]*\.gallery-grid\s*\{[^}]*grid-template-columns/s,
+    );
   });
 });
 


### PR DESCRIPTION
## Bead

fringematrix5-z6x (P2, depends on fringematrix5-xjh which is closed; unblocks fringematrix5-6yt — slider UI).

## Summary

Wire the `.gallery-grid` column-track minimum to a CSS variable controlled from React, so the thumbnail-size selection from `thumbnailSizeIndex` actually drives the rendered grid.

- `client/src/styles.css`:
  - Replace `grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))` on `.gallery-grid` with `minmax(var(--thumbnail-min-size, 160px), 1fr)`.
  - Remove the two per-breakpoint overrides: `@media (min-width: 900px)` (220px) and `@media (min-width: 1440px)` (240px). The variable now governs sizing uniformly across viewport widths.
- `client/src/App.tsx`:
  - Add a `useEffect` keyed on `thumbnailSizeIndex` that computes `cssSize = GALLERY_THUMBNAIL_SIZES[thumbnailSizeIndex] / window.devicePixelRatio` and calls `document.documentElement.style.setProperty('--thumbnail-min-size', cssSize + 'px')`. SSR-guarded; falls back gracefully if `devicePixelRatio` is non-positive.
- `client/test/accessibility.test.js`:
  - Replace the now-obsolete "1440px breakpoint" assertion with two new assertions: (1) the variable is wired into the `.gallery-grid` rule with a `160px` fallback, and (2) there are no per-breakpoint `.gallery-grid grid-template-columns` overrides at 900px or 1440px.

Out of scope: building the slider widget itself (that is fringematrix5-6yt, which this PR unblocks).

## Test plan

- [x] `npm run typecheck` — passes (client TS strict).
- [x] `npm test` — 526/526 unit tests pass across 28 test files (server + client).
- [x] `npm run build` — production client build succeeds.
- [ ] Manual smoke (reviewer): launch dev server, open DevTools, set `localStorage['fringematrix-a11y']` to vary `thumbnailSizeIndex`, reload, and confirm gallery columns resize accordingly without breakpoint discontinuities at 900px / 1440px.

## Follow-ups

- fringematrix5-6yt — Create ThumbnailSizeSlider React component (now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)