### PR TITLE
fringematrix5-6yt: Create ThumbnailSizeSlider React component

### DIFF
--- a/client/src/components/ThumbnailSizeSlider.tsx
+++ b/client/src/components/ThumbnailSizeSlider.tsx
@@ -1,9 +1,15 @@
-import type { ChangeEvent } from 'react';
+import { useId, type ChangeEvent } from 'react';
 
 interface ThumbnailSizeSliderProps {
   /** Current step index (0-based, controlled). */
   value: number;
-  /** Total number of discrete size steps. Must be >= 1. */
+  /**
+   * Total number of discrete size steps.
+   *
+   * Conceptually expected to be >= 1. The component tolerates `steps <= 1`
+   * by rendering the input with `max=0` and `disabled`, so there is nothing
+   * to slide. Consumers should pass `steps >= 2` for a usable slider.
+   */
   steps: number;
   /** Called with the new step index whenever the user changes the slider. */
   onChange: (index: number) => void;
@@ -13,8 +19,14 @@ interface ThumbnailSizeSliderProps {
  * Stateless controlled slider for selecting a thumbnail size step.
  *
  * Renders a discrete range input with step=1, min=0, max=steps-1, plus a
- * compact "THUMBNAIL SIZE" label above the track. The input carries
- * ARIA attributes so assistive technology announces the current step.
+ * compact "THUMBNAIL SIZE" label above the track. The label is
+ * programmatically associated with the input via `htmlFor`/`id` so screen
+ * readers announce the visible text and click-to-focus works.
+ *
+ * Accessibility: this component relies on the native semantics of
+ * `<input type="range">` for `aria-valuenow`/`aria-valuemin`/`aria-valuemax`;
+ * those attributes are intentionally not set manually because the browser
+ * derives them from `value`/`min`/`max`.
  *
  * When the document root has the `reduce-motion` class, CSS transitions on
  * the slider thumb are suppressed (see styles.css for the scoped rules).
@@ -28,7 +40,9 @@ export default function ThumbnailSizeSlider({
   steps,
   onChange,
 }: ThumbnailSizeSliderProps) {
+  const inputId = useId();
   const max = Math.max(0, steps - 1);
+  const disabled = steps <= 1;
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     onChange(parseInt(e.target.value, 10));
@@ -36,18 +50,18 @@ export default function ThumbnailSizeSlider({
 
   return (
     <div className="thumbnail-size-slider">
-      <div className="thumbnail-size-slider-label">THUMBNAIL SIZE</div>
+      <label htmlFor={inputId} className="thumbnail-size-slider-label">
+        THUMBNAIL SIZE
+      </label>
       <input
+        id={inputId}
         type="range"
         min={0}
         max={max}
         step={1}
         value={value}
         onChange={handleChange}
-        aria-label="Thumbnail size"
-        aria-valuenow={value}
-        aria-valuemin={0}
-        aria-valuemax={max}
+        disabled={disabled}
       />
     </div>
   );

--- a/client/src/components/ThumbnailSizeSlider.tsx
+++ b/client/src/components/ThumbnailSizeSlider.tsx
@@ -1,0 +1,54 @@
+import type { ChangeEvent } from 'react';
+
+interface ThumbnailSizeSliderProps {
+  /** Current step index (0-based, controlled). */
+  value: number;
+  /** Total number of discrete size steps. Must be >= 1. */
+  steps: number;
+  /** Called with the new step index whenever the user changes the slider. */
+  onChange: (index: number) => void;
+}
+
+/**
+ * Stateless controlled slider for selecting a thumbnail size step.
+ *
+ * Renders a discrete range input with step=1, min=0, max=steps-1, plus a
+ * compact "THUMBNAIL SIZE" label above the track. The input carries
+ * ARIA attributes so assistive technology announces the current step.
+ *
+ * When the document root has the `reduce-motion` class, CSS transitions on
+ * the slider thumb are suppressed (see styles.css for the scoped rules).
+ *
+ * Note: the consumer owns clamping/bounds via the controlled `value` prop.
+ * The native range input already constrains its emitted value to [min, max],
+ * so no extra clamping happens here.
+ */
+export default function ThumbnailSizeSlider({
+  value,
+  steps,
+  onChange,
+}: ThumbnailSizeSliderProps) {
+  const max = Math.max(0, steps - 1);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <div className="thumbnail-size-slider">
+      <div className="thumbnail-size-slider-label">THUMBNAIL SIZE</div>
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={1}
+        value={value}
+        onChange={handleChange}
+        aria-label="Thumbnail size"
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+      />
+    </div>
+  );
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1837,3 +1837,30 @@ html.reduce-effects .lightbox-image-wrap > * {
   }
 }
 
+/* =============================================================================
+   ThumbnailSizeSlider (structural-only; aesthetic styling lives in bead 2dn)
+   ============================================================================= */
+.thumbnail-size-slider {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+}
+.thumbnail-size-slider-label {
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.8;
+}
+.thumbnail-size-slider input[type='range'] {
+  width: 100%;
+}
+
+/* Reduce Motion: suppress thumb transitions per bead 6yt spec. */
+html.reduce-motion .thumbnail-size-slider input[type='range']::-webkit-slider-thumb {
+  transition: none !important;
+}
+html.reduce-motion .thumbnail-size-slider input[type='range']::-moz-range-thumb {
+  transition: none !important;
+}
+


### PR DESCRIPTION
## Bead

[fringematrix5-6yt](../) — Create ThumbnailSizeSlider React component

## Summary

- Adds `client/src/components/ThumbnailSizeSlider.tsx`: a stateless, controlled `input[type=range]` slider with `step=1`, `min=0`, `max=steps-1`, ARIA attributes (`aria-label='Thumbnail size'`, `aria-valuenow/min/max`), and a compact `THUMBNAIL SIZE` label above the track.
- Calls `onChange(parseInt(e.target.value, 10))` directly — the native range input clamps to `[min, max]` and the consumer owns any further bounds via the controlled `value` prop (no helper extraction; bead `fringematrix5-mm3` owns that).
- Adds minimal structural CSS in `client/src/styles.css` plus a `html.reduce-motion` override that suppresses transitions on the `::-webkit-slider-thumb` and `::-moz-range-thumb` pseudo-elements, matching the existing reduce-motion conventions in the file.

## Out of scope (per bead description)

- Aesthetic styling to match the app — bead `fringematrix5-2dn`.
- Placement in the lightbox / main toolbar and wiring into App.tsx — bead `fringematrix5-8gl`.
- Unit tests for the component — bead `fringematrix5-enp`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:scripts` — 83 tests pass
- [x] `npm run test:server` — 66 tests pass
- [x] `npm run test:client` — 525 tests pass (no regressions)
- [x] `npm run build` — production client bundle builds cleanly
- [ ] Manual visual check deferred to bead 8gl (placement) and 2dn (styling)

## Follow-ups

None filed from this bead — all downstream work is already tracked by the blockers `fringematrix5-2dn`, `fringematrix5-8gl`, and `fringematrix5-enp`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

[Generated with Claude Code]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adjustable thumbnail size slider with discrete steps for precise control of thumbnail dimensions.
  * Slider is accessible with clear labels and works with assistive technologies.
  * Honors user motion preferences to reduce slider animations and provide a calmer experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->