### PR TITLE
fringematrix5-mm3: Extract clampThumbnailSizeIndex helper

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,11 @@ import { closeSubwindowsState } from './utils/closeSubwindowsState';
 import { isSafeUrl } from './utils/isSafeUrl';
 import { applyTheme } from './config/theme';
 import { SITE_URL, SITE_SHARE_TEXT } from './config/site';
-import { GALLERY_DEFAULT_SIZE_INDEX, GALLERY_THUMBNAIL_SIZES } from './config/gallery';
+import {
+  clampThumbnailSizeIndex,
+  GALLERY_DEFAULT_SIZE_INDEX,
+  GALLERY_THUMBNAIL_SIZES,
+} from './config/gallery';
 import LoadingManager from './components/LoadingManager';
 import CampaignNavigation from './components/CampaignNavigation';
 import BuildInfoPopover from './components/BuildInfoPopover';
@@ -94,9 +98,7 @@ export default function App() {
           && Number.isFinite(parsed.thumbnailSizeIndex)
           && Number.isInteger(parsed.thumbnailSizeIndex)
         ) {
-          const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
-          const clamped = Math.max(0, Math.min(maxIndex, parsed.thumbnailSizeIndex));
-          setThumbnailSizeIndex(clamped);
+          setThumbnailSizeIndex(clampThumbnailSizeIndex(parsed.thumbnailSizeIndex));
         }
       }
     } catch { /* ignore corrupt localStorage */ }

--- a/client/src/config/gallery.ts
+++ b/client/src/config/gallery.ts
@@ -98,3 +98,13 @@ export const GALLERY_THUMBNAIL_SIZES: readonly number[] = resolved.thumbnailSize
  * in range [0, GALLERY_THUMBNAIL_SIZES.length - 1].
  */
 export const GALLERY_DEFAULT_SIZE_INDEX: number = resolved.defaultThumbnailSizeIndex;
+
+/**
+ * Clamps a thumbnail-size index into the valid range
+ * `[0, GALLERY_THUMBNAIL_SIZES.length - 1]`. Pure; non-finite or non-integer
+ * inputs are not validated here — callers should pre-validate the type if
+ * needed.
+ */
+export function clampThumbnailSizeIndex(n: number): number {
+  return Math.max(0, Math.min(GALLERY_THUMBNAIL_SIZES.length - 1, n));
+}

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -319,10 +319,11 @@ describe('Accessibility Settings Logic', () => {
     expect(parsed.reduceEffects).toBe(true);
   });
 
-  it('thumbnailSizeIndex clamping keeps in-range values unchanged', () => {
+  it('thumbnailSizeIndex clamping keeps in-range boundary values unchanged', () => {
+    // Only boundary indices 0 and maxIndex are guaranteed in-range regardless
+    // of the resolved sizes-array length.
     const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
     expect(clampThumbnailSizeIndex(0)).toBe(0);
-    expect(clampThumbnailSizeIndex(1)).toBe(1);
     expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
   });
 

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import {
+  clampThumbnailSizeIndex,
+  GALLERY_THUMBNAIL_SIZES,
+} from '../src/config/gallery';
 
 /**
  * Accessibility tests for the cyberpunk redesign.
@@ -316,22 +320,18 @@ describe('Accessibility Settings Logic', () => {
   });
 
   it('thumbnailSizeIndex clamping keeps in-range values unchanged', () => {
-    const sizesLength = 4; // matches GALLERY_THUMBNAIL_SIZES default
-    const maxIndex = sizesLength - 1;
-    const clamp = (n) => Math.max(0, Math.min(maxIndex, n));
-    expect(clamp(0)).toBe(0);
-    expect(clamp(1)).toBe(1);
-    expect(clamp(3)).toBe(3);
+    const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
+    expect(clampThumbnailSizeIndex(0)).toBe(0);
+    expect(clampThumbnailSizeIndex(1)).toBe(1);
+    expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
   });
 
   it('thumbnailSizeIndex clamping pulls out-of-range values into range', () => {
-    const sizesLength = 4;
-    const maxIndex = sizesLength - 1;
-    const clamp = (n) => Math.max(0, Math.min(maxIndex, n));
+    const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
     // Saved value larger than the current sizes array (e.g. config shrank)
-    expect(clamp(7)).toBe(3);
+    expect(clampThumbnailSizeIndex(maxIndex + 4)).toBe(maxIndex);
     // Negative saved value (corrupt or downgraded)
-    expect(clamp(-1)).toBe(0);
+    expect(clampThumbnailSizeIndex(-1)).toBe(0);
   });
 
   it('rejects non-integer thumbnailSizeIndex (App validates type before clamping)', () => {

--- a/client/test/galleryConfig.test.ts
+++ b/client/test/galleryConfig.test.ts
@@ -209,11 +209,12 @@ describe('resolveGallery — invalid defaultThumbnailSizeIndex', () => {
 });
 
 describe('clampThumbnailSizeIndex', () => {
+  // Only the non-empty invariant is guaranteed by resolveThumbnailSizes, so
+  // boundary indices 0 and maxIndex are the only universally in-range values.
   const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
 
-  it('returns in-range values unchanged', () => {
+  it('returns boundary values 0 and maxIndex unchanged', () => {
     expect(clampThumbnailSizeIndex(0)).toBe(0);
-    expect(clampThumbnailSizeIndex(1)).toBe(1);
     expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
   });
 
@@ -225,10 +226,5 @@ describe('clampThumbnailSizeIndex', () => {
   it('clamps negative values to 0', () => {
     expect(clampThumbnailSizeIndex(-1)).toBe(0);
     expect(clampThumbnailSizeIndex(-100)).toBe(0);
-  });
-
-  it('treats the boundary values 0 and maxIndex as fixed points', () => {
-    expect(clampThumbnailSizeIndex(0)).toBe(0);
-    expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
   });
 });

--- a/client/test/galleryConfig.test.ts
+++ b/client/test/galleryConfig.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   GALLERY_THUMBNAIL_SIZES,
   GALLERY_DEFAULT_SIZE_INDEX,
+  clampThumbnailSizeIndex,
   resolveGallery,
 } from '../src/config/gallery';
 
@@ -204,5 +205,30 @@ describe('resolveGallery — invalid defaultThumbnailSizeIndex', () => {
     });
     expect(result.thumbnailSizes).toEqual([200]);
     expect(result.defaultThumbnailSizeIndex).toBe(0);
+  });
+});
+
+describe('clampThumbnailSizeIndex', () => {
+  const maxIndex = GALLERY_THUMBNAIL_SIZES.length - 1;
+
+  it('returns in-range values unchanged', () => {
+    expect(clampThumbnailSizeIndex(0)).toBe(0);
+    expect(clampThumbnailSizeIndex(1)).toBe(1);
+    expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
+  });
+
+  it('clamps values above the upper bound to maxIndex', () => {
+    expect(clampThumbnailSizeIndex(maxIndex + 1)).toBe(maxIndex);
+    expect(clampThumbnailSizeIndex(999)).toBe(maxIndex);
+  });
+
+  it('clamps negative values to 0', () => {
+    expect(clampThumbnailSizeIndex(-1)).toBe(0);
+    expect(clampThumbnailSizeIndex(-100)).toBe(0);
+  });
+
+  it('treats the boundary values 0 and maxIndex as fixed points', () => {
+    expect(clampThumbnailSizeIndex(0)).toBe(0);
+    expect(clampThumbnailSizeIndex(maxIndex)).toBe(maxIndex);
   });
 });


### PR DESCRIPTION
## Summary

- Extracted the `Math.max(0, Math.min(maxIndex, n))` clamp formula into a reusable `clampThumbnailSizeIndex(n)` helper in `client/src/config/gallery.ts`.
- Replaced the inlined clamp in the `App.tsx` localStorage hydration effect with a call to the helper.
- Replaced the duplicated clamp logic in `client/test/accessibility.test.js` with the imported helper.
- Added focused unit tests for the helper in `client/test/galleryConfig.test.ts` (in-range, above bound, negative, boundary fixed points).

The helper is pure and uses `GALLERY_THUMBNAIL_SIZES.length - 1` as the upper bound. Type validation of the input remains the caller's responsibility (matching the prior App.tsx behaviour, which checks `Number.isInteger` before invoking the clamp). `ThumbnailSizeSlider.tsx` is untouched because it relies on native `<input type=\"range\">` clamping.

Closes fringematrix5-mm3.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test:server` (66 tests)
- [x] `npm run test:client` (530 tests, including new clampThumbnailSizeIndex coverage)