### PR TITLE
fringematrix5-8gl: Place ThumbnailSizeSlider in the main toolbar

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import BuildInfoPopover from './components/BuildInfoPopover';
 import SharePopover from './components/SharePopover';
 import ContentModal from './components/ContentModal';
 import SettingsModal from './components/SettingsModal';
+import ThumbnailSizeSlider from './components/ThumbnailSizeSlider';
 import LightboxContainer from './components/LightboxContainer';
 import GalleryGrid, { type GalleryGridHandle } from './components/GalleryGrid';
 import type {
@@ -480,6 +481,11 @@ export default function App() {
           >
             Legal
           </button>
+          <ThumbnailSizeSlider
+            value={thumbnailSizeIndex}
+            steps={GALLERY_THUMBNAIL_SIZES.length}
+            onChange={setThumbnailSizeIndex}
+          />
           <button
             className="toolbar-button"
             aria-pressed={isSettingsOpen}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2014,3 +2014,16 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
   box-shadow: none;
 }
 
+/* Toolbar-context overrides: keep the slider compact (~160px wide) and
+   prevent it from shrinking inside the horizontally-scrolling toolbar.
+   Reduces vertical padding so the slider fits within the 52px toolbar
+   height without clipping the label or track. */
+.toolbar .thumbnail-size-slider {
+  flex-shrink: 0;
+  width: 160px;
+  min-width: 160px;
+  max-width: 160px;
+  padding: 4px 10px 6px;
+  gap: 2px;
+}
+


### PR DESCRIPTION
## Summary

Closes bead `fringematrix5-8gl`.

- Import `ThumbnailSizeSlider` into `App.tsx` and place it in the primary `.toolbar` cluster, just before the Settings button.
- Wire it to the existing `thumbnailSizeIndex` state: `value={thumbnailSizeIndex}`, `steps={GALLERY_THUMBNAIL_SIZES.length}`, `onChange={setThumbnailSizeIndex}`. The native range input already clamps to `[0, steps-1]`, so no extra wrapper is needed.
- Add a toolbar-scoped CSS override (`.toolbar .thumbnail-size-slider`) that locks the slider to 160px wide, applies `flex-shrink: 0` so it does not compress inside the horizontally-scrolling `.toolbar-inner` flex row, and trims vertical padding so the slider fits within the 52px toolbar height without clipping the label or track.

The slider component itself was not modified. E2E coverage is intentionally out of scope (tracked by `fringematrix5-27t`).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` (build-info + vite build + config validate) succeeds
- [x] `npm run test:server` — 66/66 passing
- [x] `npm run test:client` — 529/529 passing
- [ ] Manual: verify slider renders in toolbar between Legal and Settings buttons, adjusts thumbnails, and does not break horizontal scroll on narrow viewports