### PR TITLE
fringematrix5-qbp: Remove file name labels from thumbnails

### DIFF
--- a/client/src/components/ImageCard.tsx
+++ b/client/src/components/ImageCard.tsx
@@ -35,7 +35,6 @@ const ImageCard = React.memo(function ImageCard({ image, onClick, imgRef }: Imag
           onClick={onClick}
         />
       )}
-      <div className="filename">{image.fileName}</div>
     </div>
   );
 });

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -392,7 +392,6 @@ footer.navbar {
 
 .card img { width: 100%; height: 100%; display: block; object-fit: cover; aspect-ratio: 1 / 1; }
 .card img.lightbox-active-thumb { opacity: 0; }
-.card .filename { position: absolute; left: 8px; bottom: 8px; right: 8px; font-size: 12px; color: #cfe3ff; text-shadow: 0 2px 6px rgba(0,0,0,0.9); overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
 .lightbox {
   position: fixed;
@@ -1287,18 +1286,6 @@ body::before {
   opacity: 1;
   transform: translateY(100%);
   transition: transform 0.8s ease-in-out;
-}
-
-/* Card filename "data tag" style */
-.card .filename {
-  background: linear-gradient(90deg, rgba(0,0,0,0.85), rgba(0,0,0,0.5));
-  border-left: 2px solid var(--theme-accent);
-  padding: 4px 8px;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 11px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  z-index: 3;
 }
 
 /* Staggered card entrance animation */

--- a/client/test/GalleryGrid.test.tsx
+++ b/client/test/GalleryGrid.test.tsx
@@ -308,11 +308,12 @@ describe('GalleryGrid — image card rendering', () => {
     expect(screen.getAllByRole('img')).toHaveLength(3);
   });
 
-  it('renders the filename for each image card', () => {
+  it('does not render a visible filename label for each image card', () => {
     const images = [makeImage('fringe-avatar.png'), makeImage('walter-bishop.jpg')];
     render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
-    expect(screen.getByText('fringe-avatar.png')).toBeTruthy();
-    expect(screen.getByText('walter-bishop.jpg')).toBeTruthy();
+    // Filename text must not appear as visible text — only used for img alt.
+    expect(screen.queryByText('fringe-avatar.png')).toBeNull();
+    expect(screen.queryByText('walter-bishop.jpg')).toBeNull();
   });
 
   it('renders the image src as the img element src', () => {
@@ -408,10 +409,11 @@ describe('GalleryGrid — loading placeholder', () => {
     expect(screen.getByText('Loading...')).toBeTruthy();
   });
 
-  it('renders the filename alongside the loading placeholder', () => {
+  it('does not render a visible filename alongside the loading placeholder', () => {
     const images = [makeLoading('pending.png')];
     render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
-    expect(screen.getByText('pending.png')).toBeTruthy();
+    // Filename text must not appear as visible text in loading state either.
+    expect(screen.queryByText('pending.png')).toBeNull();
   });
 
   it('renders an img (not a placeholder) when isLoading=false', () => {

--- a/client/test/ImageCard.test.tsx
+++ b/client/test/ImageCard.test.tsx
@@ -38,10 +38,11 @@ describe('ImageCard — rendering', () => {
     expect(screen.getByAltText('my-avatar.png')).toBeTruthy();
   });
 
-  it('renders the filename label below the image', () => {
+  it('does not render a visible filename label', () => {
     const image = makeImage('fringe-banner.jpg');
     render(<ImageCard image={image} onClick={vi.fn()} />);
-    expect(screen.getByText('fringe-banner.jpg')).toBeTruthy();
+    // The filename must NOT appear as visible text; it is only used for alt.
+    expect(screen.queryByText('fringe-banner.jpg')).toBeNull();
   });
 
   it('falls back to src when loadedSrc is not set', () => {
@@ -95,10 +96,11 @@ describe('ImageCard — loading placeholder', () => {
     expect(screen.getByText('Loading...')).toBeTruthy();
   });
 
-  it('still renders the filename when isLoading is true', () => {
+  it('does not render a visible filename when isLoading is true', () => {
     const image = makeLoading('pending.png');
     render(<ImageCard image={image} onClick={vi.fn()} />);
-    expect(screen.getByText('pending.png')).toBeTruthy();
+    // Filename must not appear as visible text in loading state either.
+    expect(screen.queryByText('pending.png')).toBeNull();
   });
 
   it('renders an img (not a placeholder) when isLoading is false', () => {

--- a/client/test/cyberpunk-styles.test.js
+++ b/client/test/cyberpunk-styles.test.js
@@ -84,9 +84,10 @@ describe('Card Cyberpunk Effects', () => {
     expect(cssContent).toMatch(/\.card:hover\s*\{[^}]*border-color:\s*var\(--theme-accent\)/s);
   });
 
-  it('card filename should have z-index above pseudo-elements', () => {
-    // Filename should be above scanlines (z:1) and scan beam (z:2)
-    expect(cssContent).toMatch(/\.card\s+\.filename\s*\{[^}]*z-index:\s*3/s);
+  it('card should not have a filename overlay rule (filename labels removed)', () => {
+    // Filename text overlays have been removed from thumbnails; no CSS rule
+    // should style a .card .filename element.
+    expect(cssContent).not.toMatch(/\.card\s+\.filename\s*\{/);
   });
 
   it('should have card entrance animation', () => {


### PR DESCRIPTION
## Summary
- Removes the `<div className="filename">` overlay from `ImageCard` so thumbnails show only the image
- Removes both CSS rules for `.card .filename` (base and cyberpunk-style blocks) in `styles.css`
- Preserves `fileName` as the `img` `alt` attribute for screen reader accessibility
- Lightbox filename display is unchanged

## Tests
- Updated `ImageCard.test.tsx`: replaced "renders filename label" tests with "does not render visible filename" assertions
- Updated `GalleryGrid.test.tsx`: same pattern for grid-level tests
- Updated `cyberpunk-styles.test.js`: asserts the `.card .filename` CSS rule no longer exists

## Test plan
- [ ] All 546 unit tests pass (`npm test`)
- [ ] TypeScript check passes (`npm run typecheck`)
- [ ] Thumbnails show only the image (no text overlay)
- [ ] `img` alt text still carries the filename for accessibility
- [ ] Lightbox sidebar still shows the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image cards no longer display filename labels in the gallery view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->