### PR TITLE
fringematrix5-7us: Add magnifier-minus / magnifier-plus icon buttons to scale widget

### DIFF
--- a/client/src/components/ThumbnailSizeSlider.tsx
+++ b/client/src/components/ThumbnailSizeSlider.tsx
@@ -16,12 +16,67 @@ interface ThumbnailSizeSliderProps {
 }
 
 /**
+ * Inline SVG for a magnifying glass with a minus sign (zoom out).
+ * Drawn at 16x16 viewBox to match the icon size used by the buttons.
+ */
+function ZoomOutIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      <line x1="8" y1="11" x2="14" y2="11" />
+    </svg>
+  );
+}
+
+/**
+ * Inline SVG for a magnifying glass with a plus sign (zoom in).
+ * Drawn at 16x16 viewBox to match the icon size used by the buttons.
+ */
+function ZoomInIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      <line x1="11" y1="8" x2="11" y2="14" />
+      <line x1="8" y1="11" x2="14" y2="11" />
+    </svg>
+  );
+}
+
+/**
  * Stateless controlled slider for selecting a thumbnail size step.
  *
  * Renders a discrete range input with step=1, min=0, max=steps-1, plus a
  * compact "THUMBNAIL SIZE" label above the track. The label is
  * programmatically associated with the input via `htmlFor`/`id` so screen
  * readers announce the visible text and click-to-focus works.
+ *
+ * Magnifier buttons flank the slider: zoom-out (minus) on the left and
+ * zoom-in (plus) on the right. Each click steps the index by one and is
+ * disabled when already at the corresponding bound.
  *
  * Accessibility: this component relies on the native semantics of
  * `<input type="range">` for `aria-valuenow`/`aria-valuemin`/`aria-valuemax`;
@@ -48,6 +103,14 @@ export default function ThumbnailSizeSlider({
     onChange(parseInt(e.target.value, 10));
   };
 
+  const handleZoomOut = () => {
+    if (value > 0) onChange(value - 1);
+  };
+
+  const handleZoomIn = () => {
+    if (value < max) onChange(value + 1);
+  };
+
   // Percentage of the track that the accent fill covers (0..100). When
   // `max === 0` the slider is disabled, so the fill is meaningless — we
   // still emit 0 so the CSS variable is always defined.
@@ -65,23 +128,43 @@ export default function ThumbnailSizeSlider({
       <label htmlFor={inputId} className="thumbnail-size-slider-label">
         THUMBNAIL SIZE
       </label>
-      <div className="thumbnail-size-slider-track-wrap">
-        <input
-          id={inputId}
-          type="range"
-          min={0}
-          max={max}
-          step={1}
-          value={value}
-          onChange={handleChange}
-          disabled={disabled}
-          style={trackStyle}
-        />
-        <div className="thumbnail-size-slider-ticks" aria-hidden="true">
-          {Array.from({ length: tickCount }, (_, i) => (
-            <span className="thumbnail-size-slider-tick" key={i} />
-          ))}
+      <div className="thumbnail-size-slider-controls">
+        <button
+          type="button"
+          className="thumbnail-size-slider-zoom-btn"
+          aria-label="Zoom out"
+          onClick={handleZoomOut}
+          disabled={disabled || value <= 0}
+        >
+          <ZoomOutIcon />
+        </button>
+        <div className="thumbnail-size-slider-track-wrap">
+          <input
+            id={inputId}
+            type="range"
+            min={0}
+            max={max}
+            step={1}
+            value={value}
+            onChange={handleChange}
+            disabled={disabled}
+            style={trackStyle}
+          />
+          <div className="thumbnail-size-slider-ticks" aria-hidden="true">
+            {Array.from({ length: tickCount }, (_, i) => (
+              <span className="thumbnail-size-slider-tick" key={i} />
+            ))}
+          </div>
         </div>
+        <button
+          type="button"
+          className="thumbnail-size-slider-zoom-btn"
+          aria-label="Zoom in"
+          onClick={handleZoomIn}
+          disabled={disabled || value >= max}
+        >
+          <ZoomInIcon />
+        </button>
       </div>
     </div>
   );

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1858,6 +1858,55 @@ html.reduce-effects .lightbox-image-wrap > * {
   min-width: 160px;
 }
 
+/* Row that holds zoom-out button, slider track, and zoom-in button. */
+.thumbnail-size-slider-controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Magnifier zoom buttons flanking the slider track. */
+.thumbnail-size-slider-zoom-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: rgba(var(--theme-accent-rgb), 0.12);
+  color: var(--theme-accent);
+  border: 1px solid rgba(var(--theme-accent-rgb), 0.35);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.thumbnail-size-slider-zoom-btn:hover:not(:disabled) {
+  background: rgba(var(--theme-accent-rgb), 0.25);
+  border-color: var(--theme-accent);
+  box-shadow: 0 0 8px rgba(var(--theme-accent-rgb), 0.4);
+}
+
+.thumbnail-size-slider-zoom-btn:focus-visible {
+  outline: 2px solid var(--theme-accent);
+  outline-offset: 2px;
+}
+
+.thumbnail-size-slider-zoom-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+html.reduce-effects .thumbnail-size-slider-zoom-btn {
+  transition: none;
+}
+
+html.reduce-effects .thumbnail-size-slider-zoom-btn:hover:not(:disabled) {
+  box-shadow: none;
+}
+
 .thumbnail-size-slider-label {
   font-family: 'Courier New', Courier, monospace;
   font-size: 10px;
@@ -1874,6 +1923,8 @@ html.reduce-effects .lightbox-image-wrap > * {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 /* Range input — reset native chrome so we can paint a custom track with the
@@ -2014,15 +2065,17 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
   box-shadow: none;
 }
 
-/* Toolbar-context overrides: keep the slider compact (~160px wide) and
-   prevent it from shrinking inside the horizontally-scrolling toolbar.
+/* Toolbar-context overrides: keep the slider widget compact and prevent it
+   from shrinking inside the horizontally-scrolling toolbar.  The extra width
+   (vs the original 160 px) accounts for the two 24 px zoom buttons plus their
+   6 px gaps on each side.
    Reduces vertical padding so the slider fits within the 52px toolbar
    height without clipping the label or track. */
 .toolbar .thumbnail-size-slider {
   flex-shrink: 0;
-  width: 160px;
-  min-width: 160px;
-  max-width: 160px;
+  width: 220px;
+  min-width: 220px;
+  max-width: 220px;
   padding: 4px 10px 6px;
   gap: 2px;
 }

--- a/client/test/components/ThumbnailSizeSlider.test.tsx
+++ b/client/test/components/ThumbnailSizeSlider.test.tsx
@@ -162,4 +162,74 @@ describe('ThumbnailSizeSlider', () => {
       ).toBe(0);
     });
   });
+
+  describe('zoom buttons', () => {
+    it('renders a "Zoom in" button and a "Zoom out" button', () => {
+      renderSlider({ value: 2, steps: 5 });
+      expect(screen.getByRole('button', { name: 'Zoom out' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument();
+    });
+
+    it('clicking "Zoom in" calls onChange with value + 1', () => {
+      const onChange = vi.fn();
+      renderSlider({ value: 2, steps: 5, onChange });
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(3);
+    });
+
+    it('clicking "Zoom out" calls onChange with value - 1', () => {
+      const onChange = vi.fn();
+      renderSlider({ value: 2, steps: 5, onChange });
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }));
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it('"Zoom out" is disabled at the minimum (value === 0)', () => {
+      renderSlider({ value: 0, steps: 5 });
+      const zoomOut = screen.getByRole('button', { name: 'Zoom out' }) as HTMLButtonElement;
+      expect(zoomOut.disabled).toBe(true);
+    });
+
+    it('"Zoom in" is disabled at the maximum (value === steps - 1)', () => {
+      renderSlider({ value: 4, steps: 5 });
+      const zoomIn = screen.getByRole('button', { name: 'Zoom in' }) as HTMLButtonElement;
+      expect(zoomIn.disabled).toBe(true);
+    });
+
+    it('"Zoom out" is enabled when value > 0', () => {
+      renderSlider({ value: 1, steps: 5 });
+      const zoomOut = screen.getByRole('button', { name: 'Zoom out' }) as HTMLButtonElement;
+      expect(zoomOut.disabled).toBe(false);
+    });
+
+    it('"Zoom in" is enabled when value < max', () => {
+      renderSlider({ value: 3, steps: 5 });
+      const zoomIn = screen.getByRole('button', { name: 'Zoom in' }) as HTMLButtonElement;
+      expect(zoomIn.disabled).toBe(false);
+    });
+
+    it('clicking "Zoom in" does not call onChange when already at max', () => {
+      const onChange = vi.fn();
+      renderSlider({ value: 4, steps: 5, onChange });
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('clicking "Zoom out" does not call onChange when already at min', () => {
+      const onChange = vi.fn();
+      renderSlider({ value: 0, steps: 5, onChange });
+      fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('both buttons are disabled when steps <= 1', () => {
+      renderSlider({ value: 0, steps: 1 });
+      const zoomOut = screen.getByRole('button', { name: 'Zoom out' }) as HTMLButtonElement;
+      const zoomIn = screen.getByRole('button', { name: 'Zoom in' }) as HTMLButtonElement;
+      expect(zoomOut.disabled).toBe(true);
+      expect(zoomIn.disabled).toBe(true);
+    });
+  });
 });

--- a/e2e/thumbnail-size.spec.ts
+++ b/e2e/thumbnail-size.spec.ts
@@ -192,4 +192,89 @@ test.describe('Thumbnail size slider (toolbar)', () => {
     expect(tickCount).toBeGreaterThan(1);
     expect(max + 1).toBe(tickCount);
   });
+
+  test('zoom-in button is visible and clicking it increases slider value', async ({ page }) => {
+    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
+    await expect(toolbar).toBeVisible();
+
+    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+    await expect(slider).toBeVisible();
+
+    // Move to the minimum step so there is room to zoom in.
+    await setSliderValue(slider, '0');
+    await expect(slider).toHaveValue('0');
+
+    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    await expect(zoomIn).toBeVisible();
+    await expect(zoomIn).toBeEnabled();
+
+    await zoomIn.click();
+
+    // After one click the slider value should have advanced by 1.
+    await expect(slider).toHaveValue('1');
+  });
+
+  test('zoom-out button is visible and clicking it decreases slider value', async ({ page }) => {
+    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
+    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+
+    // Move to a non-zero step so there is room to zoom out.
+    const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
+    await setSliderValue(slider, max);
+    await expect(slider).toHaveValue(max);
+
+    const zoomOut = toolbar.getByRole('button', { name: 'Zoom out' });
+    await expect(zoomOut).toBeVisible();
+    await expect(zoomOut).toBeEnabled();
+
+    await zoomOut.click();
+
+    await expect(slider).toHaveValue(String(Number(max) - 1));
+  });
+
+  test('zoom-in button is disabled at max and zoom-out is disabled at min', async ({ page }) => {
+    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
+    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+
+    // At minimum: zoom-out should be disabled.
+    await setSliderValue(slider, '0');
+    await expect(slider).toHaveValue('0');
+    await expect(toolbar.getByRole('button', { name: 'Zoom out' })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: 'Zoom in' })).toBeEnabled();
+
+    // At maximum: zoom-in should be disabled.
+    const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
+    await setSliderValue(slider, max);
+    await expect(slider).toHaveValue(max);
+    await expect(toolbar.getByRole('button', { name: 'Zoom in' })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: 'Zoom out' })).toBeEnabled();
+  });
+
+  test('clicking zoom-in button measurably increases card width', async ({ page }) => {
+    const hasCards = await findCampaignWithCards(page);
+    if (!hasCards) {
+      test.skip(true, 'No gallery cards available to measure');
+    }
+
+    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
+    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+
+    // Start at minimum step for a clear baseline.
+    await setSliderValue(slider, '0');
+    await expect(slider).toHaveValue('0');
+
+    const firstCard = page.locator('.gallery-grid .card').first();
+    const baseBox = await firstCard.boundingBox();
+    expect(baseBox).not.toBeNull();
+    const baseW = baseBox!.width;
+
+    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    await zoomIn.click();
+
+    // Card width should increase after zooming in.
+    await expect.poll(async () => {
+      const b = await firstCard.boundingBox();
+      return b ? b.width : 0;
+    }, { timeout: 5000 }).toBeGreaterThan(baseW);
+  });
 });


### PR DESCRIPTION
## Summary

- Added zoom-out (magnifier-minus) and zoom-in (magnifier-plus) buttons flanking the `ThumbnailSizeSlider` component
- Each button steps the scale index by ±1 and is disabled at the corresponding bound (zoom-out disabled at min=0, zoom-in disabled at max=steps-1)
- Used inline SVGs for icons (no new dependency) styled to match existing toolbar button aesthetic
- Updated CSS: new `.thumbnail-size-slider-controls` flex row, `.thumbnail-size-slider-zoom-btn` class with hover/focus/disabled states, and `.thumbnail-size-slider-track-wrap` now grows to fill available space
- Toolbar context override width updated from 160px to 220px to accommodate the two new 24px buttons plus gaps

## Test plan

- [ ] 10 new unit tests in `ThumbnailSizeSlider.test.tsx`: zoom-in/out buttons render, clicking zoom-in calls onChange with value+1, clicking zoom-out calls onChange with value-1, buttons disable at bounds, no-op click at bounds, both disabled when steps≤1
- [ ] 4 new e2e tests in `thumbnail-size.spec.ts`: zoom-in button visible and increases slider value, zoom-out button visible and decreases slider value, buttons disable at bounds, clicking zoom-in measurably increases card width
- [ ] All 556 client unit tests pass; all 66 server tests pass; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)