### PR TITLE
fringematrix5-25r: Unit tests for server blob routes in empty-mode and full-mode

### DIFF
--- a/server/test/api.blob-full-mode.test.ts
+++ b/server/test/api.blob-full-mode.test.ts
@@ -1,0 +1,192 @@
+import request from 'supertest';
+import { jest, describe, it, expect, beforeAll, beforeEach } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Blob full-mode tests: BLOB_READ_WRITE_TOKEN present, list() mocked.
+//
+// Verifies that GET /api/campaigns/:id/images calls the Vercel Blob list()
+// function and returns correctly-shaped results (fileName, src) when a token
+// is configured. Also verifies that non-image files are filtered out.
+// ---------------------------------------------------------------------------
+
+const listMock = jest.fn<() => Promise<unknown>>();
+
+// Mock must be installed before the server module is imported.
+jest.unstable_mockModule('@vercel/blob', () => ({
+  list: listMock,
+  put: jest.fn(),
+  del: jest.fn(),
+  head: jest.fn(),
+}));
+
+let app: any;
+let blobCache: Map<string, unknown>;
+let firstCampaignId: string;
+
+// Fixture blobs: two valid images + one non-image to exercise the filter.
+const FIXTURE_BLOBS = [
+  {
+    pathname: 'avatars/Season4/CrossTheLine/avatar1.png',
+    url: 'https://cdn.example.com/avatars/Season4/CrossTheLine/avatar1.png',
+    size: 1024,
+  },
+  {
+    pathname: 'avatars/Season4/CrossTheLine/avatar2.jpg',
+    url: 'https://cdn.example.com/avatars/Season4/CrossTheLine/avatar2.jpg',
+    size: 2048,
+  },
+  {
+    pathname: 'avatars/Season4/CrossTheLine/readme.txt',
+    url: 'https://cdn.example.com/avatars/Season4/CrossTheLine/readme.txt',
+    size: 128,
+  },
+];
+
+beforeAll(async () => {
+  // Set token before module loads so HAS_BLOB_TOKEN resolves to true.
+  process.env['BLOB_READ_WRITE_TOKEN'] = 'test-token-full-mode';
+
+  const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const serverModule = await import('../server.ts');
+  app = serverModule.default;
+  blobCache = (serverModule as any).blobCache;
+  consoleSpy.mockRestore();
+
+  // Resolve the first campaign id from the real campaigns.yaml.
+  const campaignsRes = await request(app).get('/api/campaigns');
+  firstCampaignId = campaignsRes.body.campaigns[0].id;
+});
+
+beforeEach(() => {
+  // Start each test with a clean cache and a fresh mock state so tests are
+  // independent of ordering and don't bleed into each other via the TTL cache.
+  blobCache.clear();
+  listMock.mockReset();
+  listMock.mockResolvedValue({ blobs: FIXTURE_BLOBS, hasMore: false, cursor: undefined });
+});
+
+describe('GET /api/campaigns/:id/images — full mode (mocked blob)', () => {
+  it('returns 200 with an images array', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('images');
+    expect(Array.isArray(res.body.images)).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('calls the Vercel Blob list() function exactly once per cache miss', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(listMock).toHaveBeenCalledTimes(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('shapes each image entry with non-empty src and fileName fields', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+
+    const images: Array<{ src: string; fileName: string }> = res.body.images;
+    expect(images.length).toBeGreaterThan(0);
+
+    for (const img of images) {
+      expect(typeof img.src).toBe('string');
+      expect(img.src.length).toBeGreaterThan(0);
+      expect(typeof img.fileName).toBe('string');
+      expect(img.fileName.length).toBeGreaterThan(0);
+    }
+
+    consoleSpy.mockRestore();
+  });
+
+  it('filters out non-image files from blob results', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+
+    const images: Array<{ src: string; fileName: string }> = res.body.images;
+    // readme.txt must be filtered out; only .png and .jpg survive.
+    const fileNames = images.map(img => img.fileName);
+    expect(fileNames).not.toContain('readme.txt');
+    expect(fileNames).toContain('avatar1.png');
+    expect(fileNames).toContain('avatar2.jpg');
+    expect(images).toHaveLength(2);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('sets fileName to the last path segment of the blob pathname', async () => {
+    const singleBlob = [
+      {
+        pathname: 'avatars/Season4/CrossTheLine/my-avatar.png',
+        url: 'https://cdn.example.com/avatars/Season4/CrossTheLine/my-avatar.png',
+        size: 500,
+      },
+    ];
+    listMock.mockReset();
+    listMock.mockResolvedValue({ blobs: singleBlob, hasMore: false, cursor: undefined });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+
+    const images: Array<{ src: string; fileName: string }> = res.body.images;
+    expect(images).toHaveLength(1);
+    expect(images[0]!.fileName).toBe('my-avatar.png');
+    expect(images[0]!.src).toBe('https://cdn.example.com/avatars/Season4/CrossTheLine/my-avatar.png');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('sets src to the direct CDN URL from the blob', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+
+    const images: Array<{ src: string; fileName: string }> = res.body.images;
+    const pngImage = images.find(img => img.fileName === 'avatar1.png');
+    expect(pngImage).toBeDefined();
+    expect(pngImage!.src).toBe('https://cdn.example.com/avatars/Season4/CrossTheLine/avatar1.png');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns an empty images array when blob list returns no image files', async () => {
+    // Override the default mock to return only non-image blobs.
+    listMock.mockReset();
+    listMock.mockResolvedValue({
+      blobs: [
+        { pathname: 'avatars/Season4/CrossTheLine/doc.pdf', url: 'https://cdn.example.com/doc.pdf', size: 100 },
+      ],
+      hasMore: false,
+      cursor: undefined,
+    });
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get(`/api/campaigns/${firstCampaignId}/images`);
+    expect(res.status).toBe(200);
+    expect(res.body.images).toHaveLength(0);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns 404 for a campaign id that does not exist', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get('/api/campaigns/__no_such_campaign__/images');
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/server/test/api.blob-modes.test.ts
+++ b/server/test/api.blob-modes.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import { jest, describe, it, expect, beforeAll } from '@jest/globals';
+
+// ---------------------------------------------------------------------------
+// Blob empty-mode tests: BLOB_READ_WRITE_TOKEN absent.
+//
+// Verifies that GET /api/campaigns/:id/images returns 200 with an empty
+// images array (not a 500) when no token is configured, and that the
+// @vercel/blob list() function is never called in this code path.
+// ---------------------------------------------------------------------------
+
+const listMock = jest.fn<() => Promise<unknown>>();
+
+jest.unstable_mockModule('@vercel/blob', () => ({
+  list: listMock,
+  put: jest.fn(),
+  del: jest.fn(),
+  head: jest.fn(),
+}));
+
+let app: any;
+
+beforeAll(async () => {
+  // Ensure token is absent so HAS_BLOB_TOKEN resolves to false at module-load time.
+  delete process.env['BLOB_READ_WRITE_TOKEN'];
+  listMock.mockReset();
+
+  const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const serverModule = await import('../server.ts');
+  app = serverModule.default;
+  consoleSpy.mockRestore();
+});
+
+describe('GET /api/campaigns/:id/images — empty mode (no token)', () => {
+  it('returns 200 for a known campaign', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    expect(campaignsRes.status).toBe(200);
+    const campaigns: Array<{ id: string }> = campaignsRes.body.campaigns;
+    expect(campaigns.length).toBeGreaterThan(0);
+
+    const firstId = campaigns[0]!.id;
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(200);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns an empty images array (not a 500)', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId: string = campaignsRes.body.campaigns[0].id;
+
+    const res = await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('images');
+    expect(Array.isArray(res.body.images)).toBe(true);
+    expect(res.body.images).toHaveLength(0);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not call the Vercel Blob list() function', async () => {
+    listMock.mockReset();
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const campaignsRes = await request(app).get('/api/campaigns');
+    const firstId: string = campaignsRes.body.campaigns[0].id;
+
+    await request(app).get(`/api/campaigns/${firstId}/images`);
+    expect(listMock).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('returns 404 for an unknown campaign even in empty mode', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const res = await request(app).get('/api/campaigns/__no_such_campaign__/images');
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `server/test/api.blob-modes.test.ts`: covers the no-token code path — asserts `GET /api/campaigns/:id/images` returns 200 with an empty images array and never calls `@vercel/blob`'s `list()` function
- Adds `server/test/api.blob-full-mode.test.ts`: covers the token-present code path with a mocked blob — asserts correctly-shaped response (`src`, `fileName` fields), non-image file filtering, and 404 for unknown campaigns
- Both test files run independently in the same `npm test` invocation via Jest's per-file module isolation, which lets each file load `server.ts` with the correct `HAS_BLOB_TOKEN` state (false / true respectively)
- All 78 server tests pass; full `npm test` green (83 script + 78 server + 571 client)

## Test plan

- [x] `npm run test:server -- --testPathPattern="api.blob-modes|api.blob-full"` — both new suites pass (12 tests)
- [x] `npm test` — full suite green (83 + 78 + 571 tests)
- [x] `npm run typecheck` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)