### PR TITLE
fringematrix5-066: add server attribution module with author + path lookups

### DIFF
--- a/server/attribution.ts
+++ b/server/attribution.ts
@@ -72,14 +72,16 @@ function loadAuthors(): { authors: AuthorRecord[]; index: Map<string, AuthorReco
 
   // Build a lowercase-keyed index covering both the primary handle and every
   // alternate_handles entry, so getAuthorByHandle() is O(1) per lookup.
+  // Whitespace-only strings are skipped so accidental empty/whitespace YAML
+  // entries cannot pollute the index with a bare '@' key.
   const index = new Map<string, AuthorRecord>();
   for (const author of authors) {
-    if (typeof author.handle === 'string' && author.handle.length > 0) {
+    if (typeof author.handle === 'string' && author.handle.trim().length > 0) {
       index.set(normalizeHandle(author.handle), author);
     }
     const alts = Array.isArray(author.alternate_handles) ? author.alternate_handles : [];
     for (const alt of alts) {
-      if (typeof alt === 'string' && alt.length > 0) {
+      if (typeof alt === 'string' && alt.trim().length > 0) {
         index.set(normalizeHandle(alt), author);
       }
     }
@@ -144,7 +146,7 @@ export function getAuthorByHandle(handle: string): AuthorRecord | null {
  * callers must pass the full blob key, not just a filename.
  */
 export function getAttributionForPath(blobPath: string): AttributionRecord | null {
-  if (typeof blobPath !== 'string' || blobPath.length === 0) {
+  if (typeof blobPath !== 'string' || blobPath.trim().length === 0) {
     return null;
   }
   const table = ensureAttributionLoaded();

--- a/server/attribution.ts
+++ b/server/attribution.ts
@@ -1,0 +1,165 @@
+import path from 'path';
+import fs from 'fs';
+import yaml from 'js-yaml';
+import { fileURLToPath } from 'url';
+
+// ---------------------------------------------------------------------------
+// Attribution data-access module
+//
+// Loads two on-disk data sources once at first use and caches them at module
+// level for the rest of the process lifetime. Mirrors the same lazy-cache
+// pattern used by campaignsCache / buildInfoCache in server.ts.
+//
+//   data/authors.yaml      — list of AuthorRecord (one per known artist)
+//   data/attribution.json  — map of blob-path → AttributionRecord
+//
+// No HTTP routes are wired here; this module is consumed by future endpoints
+// (see beads fringematrix5-7hh and fringematrix5-hzm). Local types are defined
+// inline to keep this module decoupled from shared/types.ts during the
+// parallel rollout of the attribution epic.
+// ---------------------------------------------------------------------------
+
+export type AttributionConfidence = 'high' | 'medium' | 'unresolved';
+
+export interface AuthorRecord {
+  handle: string;            // primary, including the @ prefix
+  name: string;
+  twitter_url: string | null;
+  alternate_handles: string[];
+  roles: string[];
+  notes: string;
+}
+
+export interface AttributionRecord {
+  handle: string | null;
+  confidence: AttributionConfidence;
+  candidates: string[];
+  method: string;
+  evidence: string;
+}
+
+// Resolve PROJECT_ROOT the same way server.ts does: one level up from the
+// directory containing this file. Using fileURLToPath keeps the calculation
+// correct under Node's native ESM loader (where __dirname is not defined).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.join(__dirname, '..');
+const DATA_DIR = path.join(PROJECT_ROOT, 'data');
+const AUTHORS_YAML_PATH = path.join(DATA_DIR, 'authors.yaml');
+const ATTRIBUTION_JSON_PATH = path.join(DATA_DIR, 'attribution.json');
+
+// Module-level caches — populated once on first call and reused for the
+// lifetime of the process. The underlying data files never change at runtime.
+let authorsCache: AuthorRecord[] | null = null;
+let authorIndexCache: Map<string, AuthorRecord> | null = null;
+let attributionCache: Record<string, AttributionRecord> | null = null;
+
+/**
+ * Normalize a handle for case-insensitive lookup. Callers are expected to
+ * pass handles with the leading '@' (as stored in authors.yaml), but the
+ * function is tolerant: if '@' is missing it is prepended before comparison.
+ */
+function normalizeHandle(handle: string): string {
+  const trimmed = handle.trim();
+  const withAt = trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+  return withAt.toLowerCase();
+}
+
+function loadAuthors(): { authors: AuthorRecord[]; index: Map<string, AuthorRecord> } {
+  const file = fs.readFileSync(AUTHORS_YAML_PATH, 'utf8');
+  const data = yaml.load(file) as { authors?: AuthorRecord[] } | null;
+  const authors: AuthorRecord[] = Array.isArray(data?.authors) ? data.authors : [];
+
+  // Build a lowercase-keyed index covering both the primary handle and every
+  // alternate_handles entry, so getAuthorByHandle() is O(1) per lookup.
+  const index = new Map<string, AuthorRecord>();
+  for (const author of authors) {
+    if (typeof author.handle === 'string' && author.handle.length > 0) {
+      index.set(normalizeHandle(author.handle), author);
+    }
+    const alts = Array.isArray(author.alternate_handles) ? author.alternate_handles : [];
+    for (const alt of alts) {
+      if (typeof alt === 'string' && alt.length > 0) {
+        index.set(normalizeHandle(alt), author);
+      }
+    }
+  }
+
+  return { authors, index };
+}
+
+function ensureAuthorsLoaded(): { authors: AuthorRecord[]; index: Map<string, AuthorRecord> } {
+  if (authorsCache === null || authorIndexCache === null) {
+    const { authors, index } = loadAuthors();
+    authorsCache = authors;
+    authorIndexCache = index;
+  }
+  return { authors: authorsCache, index: authorIndexCache };
+}
+
+function loadAttribution(): Record<string, AttributionRecord> {
+  const raw = fs.readFileSync(ATTRIBUTION_JSON_PATH, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Record<string, AttributionRecord>;
+}
+
+function ensureAttributionLoaded(): Record<string, AttributionRecord> {
+  if (attributionCache === null) {
+    attributionCache = loadAttribution();
+  }
+  return attributionCache;
+}
+
+/**
+ * Returns all known author records, loading from data/authors.yaml on first
+ * call and serving from the module-level cache thereafter.
+ */
+export function getAuthors(): AuthorRecord[] {
+  return ensureAuthorsLoaded().authors;
+}
+
+/**
+ * Returns the author record matching the given handle, or null if not found.
+ *
+ * Matching is case-insensitive and considers both the primary `handle` and
+ * each entry in `alternate_handles`. Callers should pass handles prefixed
+ * with '@' (matching the on-disk format); inputs missing the '@' are
+ * tolerated and treated as if it were present.
+ */
+export function getAuthorByHandle(handle: string): AuthorRecord | null {
+  if (typeof handle !== 'string' || handle.trim().length === 0) {
+    return null;
+  }
+  const { index } = ensureAuthorsLoaded();
+  return index.get(normalizeHandle(handle)) ?? null;
+}
+
+/**
+ * Returns the attribution record for an exact blob path (e.g.
+ * "avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg"), or null
+ * if the path is not present in data/attribution.json. Lookup is exact —
+ * callers must pass the full blob key, not just a filename.
+ */
+export function getAttributionForPath(blobPath: string): AttributionRecord | null {
+  if (typeof blobPath !== 'string' || blobPath.length === 0) {
+    return null;
+  }
+  const table = ensureAttributionLoaded();
+  return Object.prototype.hasOwnProperty.call(table, blobPath)
+    ? (table[blobPath] ?? null)
+    : null;
+}
+
+/**
+ * Resets the module-level attribution caches.
+ * Exported for test isolation only — call before each test that mocks
+ * fs.readFileSync to ensure the next call re-reads from the mock.
+ */
+export function resetAttributionCache(): void {
+  authorsCache = null;
+  authorIndexCache = null;
+  attributionCache = null;
+}

--- a/server/test/attribution.test.ts
+++ b/server/test/attribution.test.ts
@@ -18,13 +18,15 @@ import {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  jest.spyOn(console, 'error').mockImplementation(() => {});
-  jest.spyOn(console, 'log').mockImplementation(() => {});
   // Reset the module-level caches so each test starts from a clean slate.
+  // (No console spies here — attribution.ts does not log, so suppressing
+  // console output would only hide unexpected logs from other code.)
   resetAttributionCache();
 });
 
 afterEach(() => {
+  // Restore any fs.readFileSync / other spies installed inside individual
+  // tests, preventing a mid-test failure from leaking state into the next.
   jest.restoreAllMocks();
 });
 
@@ -115,7 +117,7 @@ describe('getAuthorByHandle()', () => {
     expect(getAuthorByHandle('@definitely-not-a-real-handle-zzz')).toBeNull();
   });
 
-  it('returns null for empty or non-string inputs', () => {
+  it('returns null for empty or whitespace-only inputs', () => {
     expect(getAuthorByHandle('')).toBeNull();
     expect(getAuthorByHandle('   ')).toBeNull();
   });
@@ -156,8 +158,9 @@ describe('getAttributionForPath()', () => {
     ).toBeNull();
   });
 
-  it('returns null for empty or non-string inputs', () => {
+  it('returns null for empty or whitespace-only inputs', () => {
     expect(getAttributionForPath('')).toBeNull();
+    expect(getAttributionForPath('   ')).toBeNull();
   });
 
   it('does NOT match by filename alone — full blob path is required', () => {

--- a/server/test/attribution.test.ts
+++ b/server/test/attribution.test.ts
@@ -1,0 +1,208 @@
+import fs from 'fs';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import {
+  getAuthors,
+  getAuthorByHandle,
+  getAttributionForPath,
+  resetAttributionCache,
+} from '../attribution.ts';
+
+// ---------------------------------------------------------------------------
+// Tests for server/attribution.ts — the data-access module for authors.yaml
+// and attribution.json.
+//
+// These tests run against the real on-disk data files (not mocks), so they
+// double as a smoke test that data/authors.yaml and data/attribution.json
+// are well-formed and reachable from the server module's PROJECT_ROOT.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  // Reset the module-level caches so each test starts from a clean slate.
+  resetAttributionCache();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('getAuthors()', () => {
+  it('returns a non-empty array of author records loaded from authors.yaml', () => {
+    const authors = getAuthors();
+    expect(Array.isArray(authors)).toBe(true);
+    expect(authors.length).toBeGreaterThan(0);
+
+    const first = authors[0];
+    expect(first).toBeDefined();
+    expect(typeof first!.handle).toBe('string');
+    expect(first!.handle.startsWith('@')).toBe(true);
+    expect(typeof first!.name).toBe('string');
+    expect(Array.isArray(first!.alternate_handles)).toBe(true);
+    expect(Array.isArray(first!.roles)).toBe(true);
+  });
+
+  it('caches the result so authors.yaml is read only once across multiple calls', () => {
+    resetAttributionCache();
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+
+    const a = getAuthors();
+    const b = getAuthors();
+    const c = getAuthors();
+
+    expect(b).toBe(a); // same reference — served from cache
+    expect(c).toBe(a);
+
+    const callsForYaml = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('authors.yaml')
+    ).length;
+    expect(callsForYaml).toBe(1);
+  });
+
+  it('re-reads authors.yaml after resetAttributionCache() is called', () => {
+    resetAttributionCache();
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+
+    getAuthors();
+    const callsAfterFirst = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('authors.yaml')
+    ).length;
+    expect(callsAfterFirst).toBe(1);
+
+    resetAttributionCache();
+    getAuthors();
+
+    const callsAfterReset = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('authors.yaml')
+    ).length;
+    expect(callsAfterReset).toBe(2);
+  });
+});
+
+describe('getAuthorByHandle()', () => {
+  it('returns the author for an exact primary-handle match', () => {
+    const author = getAuthorByHandle('@Cheribot');
+    expect(author).not.toBeNull();
+    expect(author!.handle).toBe('@Cheribot');
+    expect(author!.name).toBe('Cheribot');
+  });
+
+  it('matches handles case-insensitively', () => {
+    const lower = getAuthorByHandle('@cheribot');
+    const mixed = getAuthorByHandle('@CHERIBOT');
+    expect(lower).not.toBeNull();
+    expect(mixed).not.toBeNull();
+    expect(lower!.handle).toBe('@Cheribot');
+    expect(mixed!.handle).toBe('@Cheribot');
+  });
+
+  it('matches via alternate_handles entries', () => {
+    // From authors.yaml: @Cheribot has alternate_handles: ["@cheribot"].
+    // The match is case-insensitive so a differently-cased alt still resolves.
+    const byAlt = getAuthorByHandle('@cheribot');
+    expect(byAlt).not.toBeNull();
+    expect(byAlt!.handle).toBe('@Cheribot');
+  });
+
+  it('tolerates a missing leading @ on the input', () => {
+    const author = getAuthorByHandle('Cheribot');
+    expect(author).not.toBeNull();
+    expect(author!.handle).toBe('@Cheribot');
+  });
+
+  it('returns null for unknown handles', () => {
+    expect(getAuthorByHandle('@definitely-not-a-real-handle-zzz')).toBeNull();
+  });
+
+  it('returns null for empty or non-string inputs', () => {
+    expect(getAuthorByHandle('')).toBeNull();
+    expect(getAuthorByHandle('   ')).toBeNull();
+  });
+
+  it('caches the author index so authors.yaml is read only once across mixed calls', () => {
+    resetAttributionCache();
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+
+    getAuthors();
+    getAuthorByHandle('@Cheribot');
+    getAuthorByHandle('@nikolai3d');
+    getAuthorByHandle('not-a-real-handle');
+
+    const callsForYaml = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('authors.yaml')
+    ).length;
+    expect(callsForYaml).toBe(1);
+  });
+});
+
+describe('getAttributionForPath()', () => {
+  it('returns an attribution record for a known blob path', () => {
+    const record = getAttributionForPath(
+      'avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg'
+    );
+    expect(record).not.toBeNull();
+    expect(record!.handle).toBe('@Cheribot');
+    expect(record!.confidence).toBe('high');
+    expect(Array.isArray(record!.candidates)).toBe(true);
+    expect(record!.candidates).toContain('@Cheribot');
+    expect(typeof record!.method).toBe('string');
+    expect(typeof record!.evidence).toBe('string');
+  });
+
+  it('returns null for unknown blob paths', () => {
+    expect(
+      getAttributionForPath('avatars/Season99/NotARealFolder/not-a-real-file.jpg')
+    ).toBeNull();
+  });
+
+  it('returns null for empty or non-string inputs', () => {
+    expect(getAttributionForPath('')).toBeNull();
+  });
+
+  it('does NOT match by filename alone — full blob path is required', () => {
+    // Exact-key lookup: just the filename should never resolve to a record.
+    expect(getAttributionForPath('AtU_amber.jpg')).toBeNull();
+  });
+
+  it('caches the attribution map so attribution.json is read only once across calls', () => {
+    resetAttributionCache();
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+
+    getAttributionForPath(
+      'avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg'
+    );
+    getAttributionForPath('avatars/missing/path.jpg');
+    getAttributionForPath(
+      'avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_birdie_amber.jpg'
+    );
+
+    const callsForJson = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('attribution.json')
+    ).length;
+    expect(callsForJson).toBe(1);
+  });
+
+  it('re-reads attribution.json after resetAttributionCache() is called', () => {
+    resetAttributionCache();
+    const fsSpy = jest.spyOn(fs, 'readFileSync');
+
+    getAttributionForPath(
+      'avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg'
+    );
+    const callsAfterFirst = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('attribution.json')
+    ).length;
+    expect(callsAfterFirst).toBe(1);
+
+    resetAttributionCache();
+    getAttributionForPath(
+      'avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg'
+    );
+
+    const callsAfterReset = fsSpy.mock.calls.filter(
+      ([p]) => typeof p === 'string' && p.toString().endsWith('attribution.json')
+    ).length;
+    expect(callsAfterReset).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `server/attribution.ts`, the data-access module for the attribution epic (parent: `fringematrix5-k3g`).
- Loads `data/authors.yaml` and `data/attribution.json` once on first use and caches them at module level, mirroring the `campaignsCache` / `buildInfoCache` pattern in `server.ts`.
- Exposes `getAuthors()`, `getAuthorByHandle()` (case-insensitive, matches `alternate_handles`, tolerant of missing `@`), `getAttributionForPath()` (exact key lookup), and `resetAttributionCache()` for test isolation.
- Local types (`AuthorRecord`, `AttributionRecord`, `AttributionConfidence`) are declared inline to avoid coupling with the in-flight shared-types bead `fringematrix5-8ol`; a follow-up bead will bridge these to wire types.
- No HTTP routes are added here — endpoint wiring is intentionally deferred to follow-up beads `fringematrix5-7hh` (new `/api/authors`) and `fringematrix5-hzm` (enrich `/api/campaigns/:id/images`).

## Test plan

- [x] `npm run typecheck` (client) — passes
- [x] `npm test` — 94 server tests + 571 client tests pass
- [x] New `server/test/attribution.test.ts` covers: authors load + cache + reset; case-insensitive handle lookup; `alternate_handles` resolution; missing-`@` tolerance; unknown handle / empty input → `null`; exact-key path lookup; unknown path / filename-only / empty input → `null`; attribution.json cache + reset.
- [x] `server/attribution.ts` coverage: 97.95% statements / 87.5% branches / 100% functions.

## Follow-ups

- `fringematrix5-7hh` — add `GET /api/authors` and `GET /api/authors/:handle` endpoints backed by this module.
- `fringematrix5-hzm` — enrich `GET /api/campaigns/:id/images` with per-image author blocks using `getAttributionForPath()` + `getAuthorByHandle()`.
- When `fringematrix5-8ol` (shared types) lands, replace the local types here with imports from `shared/types.ts` if duplicated.