### PR TITLE
fringematrix5-7hh: add /api/authors and /api/authors/:handle endpoints

### DIFF
--- a/server/attribution.ts
+++ b/server/attribution.ts
@@ -140,6 +140,36 @@ export function getAuthorByHandle(handle: string): AuthorRecord | null {
 }
 
 /**
+ * Returns the full attribution table (blob-path → AttributionRecord), loading
+ * from data/attribution.json on first call and serving from the module-level
+ * cache thereafter. Used by aggregation endpoints (e.g. /api/authors) that
+ * need to scan all entries; single-path callers should prefer
+ * getAttributionForPath() which avoids exposing the full map.
+ *
+ * The returned object is the cached instance and MUST NOT be mutated by
+ * callers — doing so would corrupt subsequent reads for the process lifetime.
+ */
+export function getAllAttributions(): Record<string, AttributionRecord> {
+  return ensureAttributionLoaded();
+}
+
+/**
+ * Returns the full attribution table (blob-path → AttributionRecord), loading
+ * from data/attribution.json on first call and serving from the module-level
+ * cache thereafter. Used by aggregation endpoints (e.g. /api/authors) that
+ * need to scan all entries; single-path callers should prefer
+ * getAttributionForPath() which avoids exposing the full map.
+ *
+ * The returned object is the cached instance; the Readonly<> return type
+ * blocks accidental writes at compile time. Callers must not bypass it via
+ * casts — mutating the underlying map would corrupt subsequent reads for
+ * the process lifetime.
+ */
+export function getAllAttributions(): Readonly<Record<string, AttributionRecord>> {
+  return ensureAttributionLoaded();
+}
+
+/**
  * Returns the attribution record for an exact blob path (e.g.
  * "avatars/Season4/AcrossTheUniverse/ATU-Cheribot/AtU_amber.jpg"), or null
  * if the path is not present in data/attribution.json. Lookup is exact —

--- a/server/attribution.ts
+++ b/server/attribution.ts
@@ -146,20 +146,6 @@ export function getAuthorByHandle(handle: string): AuthorRecord | null {
  * need to scan all entries; single-path callers should prefer
  * getAttributionForPath() which avoids exposing the full map.
  *
- * The returned object is the cached instance and MUST NOT be mutated by
- * callers — doing so would corrupt subsequent reads for the process lifetime.
- */
-export function getAllAttributions(): Record<string, AttributionRecord> {
-  return ensureAttributionLoaded();
-}
-
-/**
- * Returns the full attribution table (blob-path → AttributionRecord), loading
- * from data/attribution.json on first call and serving from the module-level
- * cache thereafter. Used by aggregation endpoints (e.g. /api/authors) that
- * need to scan all entries; single-path callers should prefer
- * getAttributionForPath() which avoids exposing the full map.
- *
  * The returned object is the cached instance; the Readonly<> return type
  * blocks accidental writes at compile time. Callers must not bypass it via
  * casts — mutating the underlying map would corrupt subsequent reads for

--- a/server/server.ts
+++ b/server/server.ts
@@ -658,8 +658,11 @@ app.get('/api/glyphs', async (_req: Request, res: Response): Promise<void> => {
   }
 });
 
-// Cache-Control header value shared by /api/campaigns, /api/build-info,
-// and the /api/authors endpoints below.
+// Cache-Control header value used by the /api/authors endpoints below.
+// This is the same string the /api/campaigns and /api/build-info handlers
+// hard-code inline; hoisting a single shared constant across all three
+// endpoints is a tidy follow-up but is left out of this PR to keep it
+// strictly scoped to the new attribution routes.
 const AUTHORS_CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
 
 /**
@@ -770,8 +773,10 @@ app.get('/api/authors/:handle', (req: Request, res: Response): void => {
       if (!campaignId) continue;
 
       const fileName = blobPath.split('/').pop() || '';
-      // Strip the leading "avatars/" so the public path matches the
-      // /avatars/* redirect route which already handles CDN resolution.
+      // blobPath already starts with "avatars/" (it's the on-disk key), so
+      // prefixing a leading "/" yields "/avatars/<rest>", which the existing
+      // /avatars/* redirect route resolves to the Vercel Blob CDN URL on
+      // request. No need to hit the blob API from this handler.
       const src = `/${blobPath}`;
       images.push({
         src,

--- a/server/server.ts
+++ b/server/server.ts
@@ -6,9 +6,16 @@ import dotenv from 'dotenv';
 import { list, ListBlobResultBlob } from '@vercel/blob';
 import { fileURLToPath } from 'url';
 import { VALID_CONTENT_PAGES } from '../shared/types.js';
-import type { ContentPage, ImageAuthor } from '../shared/types.js';
+import type { ContentPage, ImageAuthor, Author, AuthorWithCount } from '../shared/types.js';
 import { timeoutMiddleware } from './middleware/timeout.js';
-import { getAttributionForPath, getAuthorByHandle } from './attribution.js';
+import {
+  getAuthors as getAttributionAuthors,
+  getAuthorByHandle,
+  getAttributionForPath,
+  getAllAttributions,
+  type AuthorRecord,
+  type AttributionRecord,
+} from './attribution.js';
 
 interface Campaign {
   id: string;
@@ -648,6 +655,139 @@ app.get('/api/glyphs', async (_req: Request, res: Response): Promise<void> => {
     }
     console.error('Glyphs listing error:', err);
     res.status(500).json({ error: 'Failed to list glyphs' });
+  }
+});
+
+// Cache-Control header value shared by /api/campaigns, /api/build-info,
+// and the /api/authors endpoints below.
+const AUTHORS_CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
+
+/**
+ * Maps an internal AuthorRecord (snake_case, on-disk shape) to the wire-format
+ * Author (camelCase) consumed by the client.
+ */
+function toWireAuthor(record: AuthorRecord): Author {
+  return {
+    handle: record.handle,
+    name: record.name,
+    twitterUrl: record.twitter_url,
+    alternateHandles: Array.isArray(record.alternate_handles) ? record.alternate_handles : [],
+    roles: Array.isArray(record.roles) ? record.roles : [],
+  };
+}
+
+/**
+ * Derives the campaign id (matching getCampaigns()[].id) from a full
+ * attribution blob path. Paths follow the shape
+ *   avatars/<season>/<campaignFolder>/<...>/<file>
+ * where <campaignFolder> is the slugify() input the campaigns.yaml hashtag
+ * field also produces. Returns null when the path doesn't match the expected
+ * shape (defensive — shouldn't happen for valid attribution entries).
+ */
+function deriveCampaignIdFromBlobPath(blobPath: string): string | null {
+  const parts = blobPath.split('/');
+  // Expect: ['avatars', '<season>', '<campaignFolder>', ...]
+  if (parts.length < 3 || parts[0] !== 'avatars') return null;
+  const campaignFolder = parts[2];
+  if (!campaignFolder) return null;
+  const slug = slugify(campaignFolder);
+  return slug || null;
+}
+
+// API endpoint: list of authors with image counts.
+// Counts are computed by a single O(N) pass over attribution.json on each
+// request. At ~1741 entries this is negligible; if it grows materially we
+// can memoize a handle→count map inside attribution.ts.
+app.get('/api/authors', (_req: Request, res: Response): void => {
+  try {
+    const authorRecords = getAttributionAuthors();
+    const attribution = getAllAttributions();
+
+    // Build a canonical-handle → count map. We canonicalize via
+    // getAuthorByHandle() so alternate-handle attribution entries are
+    // attributed to the primary handle (matching the per-author detail
+    // endpoint below). Entries with unresolved/null handles are skipped.
+    const counts = new Map<string, number>();
+    for (const record of Object.values(attribution)) {
+      if (typeof record.handle !== 'string' || record.handle.length === 0) continue;
+      const author = getAuthorByHandle(record.handle);
+      if (!author) continue;
+      counts.set(author.handle, (counts.get(author.handle) ?? 0) + 1);
+    }
+
+    const authors: AuthorWithCount[] = authorRecords
+      .map((record) => ({
+        ...toWireAuthor(record),
+        imageCount: counts.get(record.handle) ?? 0,
+      }))
+      .sort((a, b) => {
+        if (b.imageCount !== a.imageCount) return b.imageCount - a.imageCount;
+        return a.handle.localeCompare(b.handle);
+      });
+
+    res.set('Cache-Control', AUTHORS_CACHE_CONTROL);
+    res.set('Vary', 'Accept-Encoding');
+    res.json({ authors });
+  } catch (err: unknown) {
+    console.error('Authors listing error:', err);
+    res.status(500).json({ error: 'Failed to load authors' });
+  }
+});
+
+// API endpoint: single-author detail with the list of images attributed to them.
+app.get('/api/authors/:handle', (req: Request, res: Response): void => {
+  try {
+    const handleParam = req.params['handle'];
+    if (typeof handleParam !== 'string' || handleParam.length === 0) {
+      res.status(404).json({ error: 'Author not found' });
+      return;
+    }
+
+    const author = getAuthorByHandle(handleParam);
+    if (!author) {
+      res.status(404).json({ error: 'Author not found' });
+      return;
+    }
+
+    const attribution = getAllAttributions();
+    const canonicalHandleLower = author.handle.toLowerCase();
+    const images: Array<{
+      src: string;
+      fileName: string;
+      blobPath: string;
+      campaignId: string;
+      confidence: AttributionRecord['confidence'];
+    }> = [];
+
+    for (const [blobPath, record] of Object.entries(attribution)) {
+      if (typeof record.handle !== 'string' || record.handle.length === 0) continue;
+      // Resolve attribution.handle to its canonical handle before comparing,
+      // so alternate-handle entries unify under the primary handle.
+      const recordAuthor = getAuthorByHandle(record.handle);
+      if (!recordAuthor || recordAuthor.handle.toLowerCase() !== canonicalHandleLower) continue;
+
+      const campaignId = deriveCampaignIdFromBlobPath(blobPath);
+      if (!campaignId) continue;
+
+      const fileName = blobPath.split('/').pop() || '';
+      // Strip the leading "avatars/" so the public path matches the
+      // /avatars/* redirect route which already handles CDN resolution.
+      const src = `/${blobPath}`;
+      images.push({
+        src,
+        fileName,
+        blobPath,
+        campaignId,
+        confidence: record.confidence,
+      });
+    }
+
+    res.set('Cache-Control', AUTHORS_CACHE_CONTROL);
+    res.set('Vary', 'Accept-Encoding');
+    res.json({ author: toWireAuthor(author), images });
+  } catch (err: unknown) {
+    console.error('Author detail error:', err);
+    res.status(500).json({ error: 'Failed to load author' });
   }
 });
 

--- a/server/test/api.test.ts
+++ b/server/test/api.test.ts
@@ -298,6 +298,106 @@ describe('API contract', () => {
     });
   });
 
+  describe('GET /api/authors', () => {
+    it('returns authors sorted by imageCount desc with non-snake-case shape', async () => {
+      const res = await request(app).get('/api/authors');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('authors');
+      expect(Array.isArray(res.body.authors)).toBe(true);
+      expect(res.body.authors.length).toBeGreaterThan(0);
+
+      // Wire shape is camelCase — no snake_case fields should leak through.
+      const first = res.body.authors[0];
+      expect(first).toHaveProperty('handle');
+      expect(first).toHaveProperty('name');
+      expect(first).toHaveProperty('twitterUrl');
+      expect(first).toHaveProperty('alternateHandles');
+      expect(first).toHaveProperty('roles');
+      expect(first).toHaveProperty('imageCount');
+      expect(first).not.toHaveProperty('twitter_url');
+      expect(first).not.toHaveProperty('alternate_handles');
+
+      // Sorted by imageCount desc.
+      const counts: number[] = res.body.authors.map((a: { imageCount: number }) => a.imageCount);
+      for (let i = 1; i < counts.length; i++) {
+        expect(counts[i]).toBeLessThanOrEqual(counts[i - 1]!);
+      }
+
+      // @Zort70 should be present with the expected count from data/attribution.json.
+      const zort = res.body.authors.find((a: { handle: string }) => a.handle === '@Zort70');
+      expect(zort).toBeDefined();
+      expect(zort.imageCount).toBe(98);
+    });
+
+    it('includes Cache-Control header for CDN/browser caching', async () => {
+      const res = await request(app).get('/api/authors');
+      expect(res.status).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600, stale-while-revalidate=86400');
+      expect(res.headers['vary']).toContain('Accept-Encoding');
+    });
+  });
+
+  describe('GET /api/authors/:handle', () => {
+    it('returns author detail with non-empty images list', async () => {
+      const res = await request(app).get('/api/authors/@Zort70');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('author');
+      expect(res.body.author.handle).toBe('@Zort70');
+      expect(res.body.author).toHaveProperty('twitterUrl');
+      expect(Array.isArray(res.body.images)).toBe(true);
+      expect(res.body.images.length).toBeGreaterThan(0);
+
+      const img = res.body.images[0];
+      expect(typeof img.src).toBe('string');
+      expect(img.src.startsWith('/avatars/')).toBe(true);
+      expect(typeof img.fileName).toBe('string');
+      expect(img.fileName.length).toBeGreaterThan(0);
+      expect(typeof img.blobPath).toBe('string');
+      expect(img.blobPath.startsWith('avatars/')).toBe(true);
+      expect(typeof img.campaignId).toBe('string');
+      expect(img.campaignId.length).toBeGreaterThan(0);
+      expect(['high', 'medium', 'unresolved']).toContain(img.confidence);
+    });
+
+    it('matches handles case-insensitively (with @ prefix)', async () => {
+      const res = await request(app).get('/api/authors/@zort70');
+      expect(res.status).toBe(200);
+      expect(res.body.author.handle).toBe('@Zort70');
+      expect(res.body.images.length).toBeGreaterThan(0);
+    });
+
+    it('matches handles without an @ prefix', async () => {
+      const res = await request(app).get('/api/authors/zort70');
+      expect(res.status).toBe(200);
+      expect(res.body.author.handle).toBe('@Zort70');
+    });
+
+    it('campaignId for each image matches an existing campaign', async () => {
+      const campaignsRes = await request(app).get('/api/campaigns');
+      expect(campaignsRes.status).toBe(200);
+      const ids = new Set<string>((campaignsRes.body.campaigns as Array<{ id: string }>).map((c) => c.id));
+
+      const res = await request(app).get('/api/authors/@Zort70');
+      expect(res.status).toBe(200);
+      for (const img of res.body.images as Array<{ campaignId: string }>) {
+        expect(ids.has(img.campaignId)).toBe(true);
+      }
+    });
+
+    it('404s for an unknown handle', async () => {
+      const res = await request(app).get('/api/authors/@Doesnotexist');
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual(expect.objectContaining({ error: 'Author not found' }));
+    });
+
+    it('includes Cache-Control header for CDN/browser caching', async () => {
+      const res = await request(app).get('/api/authors/@Zort70');
+      expect(res.status).toBe(200);
+      expect(res.headers['cache-control']).toBe('public, max-age=3600, stale-while-revalidate=86400');
+      expect(res.headers['vary']).toContain('Accept-Encoding');
+    });
+  });
+
   describe('Security headers', () => {
     it('does not emit X-Powered-By header', async () => {
       const res = await request(app).get('/api/campaigns');


### PR DESCRIPTION
## Summary

Adds two new read-only endpoints surfacing the attribution dataset shipped in `fringematrix5-kj7`:

- `GET /api/authors` → `{ authors: AuthorWithCount[] }`, sorted by `imageCount` desc then `handle` asc. Counts canonicalize attribution entries via `getAuthorByHandle` so alternate-handle attributions roll up to the primary handle.
- `GET /api/authors/:handle` → `{ author, images }`. Lookup is case-insensitive and tolerates URLs with or without the leading `@`. Each image carries `src` (using the existing `/avatars/*` redirect), `fileName`, `blobPath`, `campaignId` (derived via `slugify` of the segment-after-Season folder, matching `getCampaigns()[].id`), and `confidence`. Returns 404 with `{ error: 'Author not found' }` for unknown handles.

Cache-Control headers mirror `/api/campaigns` (`public, max-age=3600, stale-while-revalidate=86400`).

Adds one small accessor (`getAllAttributions()`) to `server/attribution.ts` so the listing endpoint can scan all entries without re-parsing JSON per request.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (102 server tests, 571 client tests)
- [x] New server tests cover:
  - `/api/authors` shape + sort + camelCase wire fields + `@Zort70` count = 98
  - `/api/authors/@Zort70` returns author + non-empty images, each `campaignId` resolves to a known campaign
  - case-insensitive lookup with and without `@` prefix
  - 404 for unknown handle with expected error message
  - Cache-Control / Vary headers on both endpoints

## Follow-ups

- The bead epic (`fringematrix5-k3g`) tracks the eventual authors index UI (`fringematrix5-lfn`) and dedicated server-test bead (`fringematrix5-sg6`).