### PR TITLE
fringematrix5-5s8: render AUTHOR row in lightbox image details sidebar

### DIFF
--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -253,7 +253,7 @@ export default function LightboxContainer({
             ref={sidebarRef}
             aria-label="Image details"
           >
-            <LightboxDetails campaign={activeCampaign} />
+            <LightboxDetails campaign={activeCampaign} author={images[lightboxIndex]?.author ?? null} />
           </aside>
         </div>
 
@@ -329,7 +329,7 @@ export default function LightboxContainer({
           >
             ✕
           </button>
-          <LightboxDetails campaign={activeCampaign} />
+          <LightboxDetails campaign={activeCampaign} author={images[lightboxIndex]?.author ?? null} />
         </div>
       )}
     </div>

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -102,9 +102,9 @@ function AuthorRow({ author }: { author: ImageAuthor }) {
 }
 
 /**
- * Renders the IMAGE DETAILS sidebar content (episode name, season/number,
+ * Renders the IMAGE DETAILS sidebar content: episode name, season/number,
  * air date, hashtag, IMDB link, and the AUTHOR row when attribution data is
- * available — see fringematrix5-5s8).
+ * available (see fringematrix5-5s8).
  *
  * The AUTHOR row is conditionally rendered based on the `author` prop:
  *   - high/medium confidence → handle as link (with avatar + optional badge)

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import type { Campaign } from '../types/api';
+import type { Campaign, ImageAuthor } from '../types/api';
 import { parseEpisodeId } from '../utils/parseEpisodeId';
 import { extractImdbId } from '../utils/extractImdbId';
 import { isSafeUrl } from '../utils/isSafeUrl';
+import { getInitials } from '../utils/author';
 
 interface Props {
   campaign: Campaign | null;
+  author?: ImageAuthor | null;
 }
 
 interface RowProps {
@@ -23,18 +25,101 @@ function Row({ label, children }: RowProps) {
 }
 
 /**
+ * Renders the AUTHOR row content based on the three states defined in
+ * fringematrix5-5s8:
+ *   1. Resolved (handle present, confidence 'high' | 'medium')
+ *   2. Unresolved (handle null, candidates.length > 0)
+ *   3. No data (author null OR handle null AND no candidates) → return null
+ *      so the caller can omit the row entirely.
+ */
+function AuthorRow({ author }: { author: ImageAuthor }) {
+  // Case 1: resolved (we have a handle).
+  if (author.handle) {
+    const initials = getInitials(author.handle) || '?';
+    const isMedium = author.confidence === 'medium';
+    const hasSafeUrl = isSafeUrl(author.twitterUrl);
+    return (
+      <div className="lightbox-details-row lightbox-details-author">
+        <div className="lightbox-details-label">AUTHOR</div>
+        <div className="lightbox-details-value lightbox-details-author-value">
+          <span
+            className="lightbox-author-avatar"
+            aria-hidden={true}
+            title={author.displayName ?? undefined}
+          >
+            {initials}
+          </span>
+          {hasSafeUrl && author.twitterUrl ? (
+            <a
+              className="lightbox-details-link lightbox-author-handle"
+              href={author.twitterUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {author.handle}
+              <span className="lightbox-details-external" aria-hidden={true}>↗</span>
+              <span className="visually-hidden"> (opens in new tab)</span>
+            </a>
+          ) : (
+            <span className="lightbox-author-handle">{author.handle}</span>
+          )}
+          {isMedium ? (
+            <span
+              className="lightbox-author-badge"
+              title="Attribution uncertain"
+              aria-label="Attribution uncertain"
+            >
+              uncertain
+            </span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  // Case 2: unresolved with candidates.
+  if (author.candidates && author.candidates.length > 0) {
+    return (
+      <div className="lightbox-details-row lightbox-details-author">
+        <div className="lightbox-details-label">AUTHOR</div>
+        <div className="lightbox-details-value lightbox-details-author-value">
+          <span
+            className="lightbox-author-avatar lightbox-author-avatar--unresolved"
+            aria-hidden={true}
+          >
+            ?
+          </span>
+          <span className="lightbox-author-candidates">
+            Possibly: {author.candidates.join(', ')}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Case 3: no data → omit (handled by the caller).
+  return null;
+}
+
+/**
  * Renders the IMAGE DETAILS sidebar content (episode name, season/number,
- * air date, hashtag, IMDB link). AUTHOR row is intentionally omitted —
- * tracked in fringematrix5-qyr until an author data source is decided.
+ * air date, hashtag, IMDB link, and the AUTHOR row when attribution data is
+ * available — see fringematrix5-5s8).
+ *
+ * The AUTHOR row is conditionally rendered based on the `author` prop:
+ *   - high/medium confidence → handle as link (with avatar + optional badge)
+ *   - unresolved with candidates → "Possibly: @A, @B" with a '?' avatar
+ *   - null / no candidates → row is omitted entirely
  *
  * If no active campaign is available the component renders a single
  * empty-state line so the sidebar is not a confusing blank panel.
  *
  * Wrapped in React.memo so that both instances rendered by LightboxContainer
- * (inline sidebar + mobile drawer) skip re-computation when the campaign prop
- * hasn't changed — e.g. during prev/next image navigation.
+ * (inline sidebar + mobile drawer) skip re-computation when the campaign and
+ * author props haven't changed — e.g. during prev/next image navigation
+ * within the same campaign.
  */
-function LightboxDetails({ campaign }: Props) {
+function LightboxDetails({ campaign, author }: Props) {
   if (!campaign) {
     return (
       <>
@@ -70,6 +155,7 @@ function LightboxDetails({ campaign }: Props) {
           </a>
         </Row>
       ) : null}
+      {author ? <AuthorRow author={author} /> : null}
     </>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -485,6 +485,58 @@ footer.navbar {
   font-style: italic;
   font-size: 14px;
 }
+/* AUTHOR row — fringematrix5-5s8. Avatar circle + handle (link if resolved)
+   + optional "uncertain" badge for medium-confidence attributions. */
+.lightbox-details-author-value {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lightbox-author-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(var(--theme-accent-rgb), 0.55);
+  background: rgba(var(--theme-accent-rgb), 0.10);
+  color: var(--theme-accent);
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.lightbox-author-avatar--unresolved {
+  color: rgba(255, 255, 255, 0.55);
+  border-color: rgba(255, 255, 255, 0.30);
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 400;
+  font-size: 16px;
+}
+.lightbox-author-handle {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.lightbox-author-candidates {
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.lightbox-author-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.65);
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .visually-hidden {
   position: absolute;
   width: 1px;

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -28,6 +28,9 @@ export interface ImageData {
   originalSrc?: string;
   isLoading?: boolean;
   loadedSrc?: string | null;
+  // Carried through from the server's attribution enrichment so the lightbox
+  // AUTHOR row can render without an extra lookup.
+  author?: ImageAuthor | null;
 }
 
 export interface BuildInfo {

--- a/client/src/utils/author.ts
+++ b/client/src/utils/author.ts
@@ -1,0 +1,32 @@
+/**
+ * Author-row helpers for the lightbox IMAGE DETAILS sidebar.
+ */
+
+/**
+ * Derive a short (2-character) initials string from a Twitter-style handle for
+ * use as the avatar label in the AUTHOR row.
+ *
+ * Rules (per fringematrix5-5s8):
+ *   1. Strip a leading '@'.
+ *   2. If the handle contains 2+ uppercase letters, use the first two
+ *      (handy for camelCase handles like '@SarahProost' → 'SP').
+ *   3. Otherwise fall back to the first two characters of the handle,
+ *      upper-cased.
+ *
+ * Edge cases:
+ *   - Empty input (or just '@') returns '' so the caller can choose a
+ *     placeholder.
+ *   - Single-character handles return that single character upper-cased.
+ *   - Handles starting with a digit (e.g. '@7th') still work — they just
+ *     don't match rule 2 and fall through to rule 3.
+ */
+export function getInitials(handle: string): string {
+  const stripped = handle.replace(/^@/, '');
+  if (stripped.length === 0) return '';
+
+  const upperLetters = stripped.match(/[A-Z]/g) ?? [];
+  if (upperLetters.length >= 2) {
+    return (upperLetters[0] + upperLetters[1]).toUpperCase();
+  }
+  return stripped.slice(0, 2).toUpperCase();
+}

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import LightboxDetails from '../src/components/LightboxDetails';
-import type { Campaign } from '../src/types/api';
+import type { Campaign, ImageAuthor } from '../src/types/api';
 
 const SAMPLE_CAMPAIGN: Campaign = {
   id: 'crosstheline',
@@ -61,10 +61,19 @@ describe('LightboxDetails', () => {
     expect(screen.queryByText('IMDB')).toBeNull();
   });
 
-  it('does NOT render Download, Share, or Author rows (scope decisions)', () => {
+  it('does NOT render Download or Share rows (still out of scope)', () => {
     render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} />);
     expect(screen.queryByText(/^download$/i)).toBeNull();
     expect(screen.queryByText(/^share$/i)).toBeNull();
+  });
+
+  it('omits the AUTHOR row when no author prop is provided', () => {
+    render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} />);
+    expect(screen.queryByText(/^author$/i)).toBeNull();
+  });
+
+  it('omits the AUTHOR row when author is null', () => {
+    render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={null} />);
     expect(screen.queryByText(/^author$/i)).toBeNull();
   });
 
@@ -72,5 +81,100 @@ describe('LightboxDetails', () => {
     render(<LightboxDetails campaign={null} />);
     expect(screen.getByText('IMAGE DETAILS')).toBeTruthy();
     expect(screen.getByText(/no campaign selected/i)).toBeTruthy();
+  });
+
+  describe('AUTHOR row', () => {
+    const resolvedHigh: ImageAuthor = {
+      handle: '@SarahProost',
+      displayName: 'Sarah Proost',
+      twitterUrl: 'https://twitter.com/SarahProost',
+      confidence: 'high',
+      candidates: [],
+    };
+    const resolvedMedium: ImageAuthor = {
+      handle: '@Zort70',
+      displayName: 'Zort',
+      twitterUrl: 'https://twitter.com/Zort70',
+      confidence: 'medium',
+      candidates: [],
+    };
+    const unresolved: ImageAuthor = {
+      handle: null,
+      displayName: null,
+      twitterUrl: null,
+      confidence: 'unresolved',
+      candidates: ['@AliceA', '@BobB', '@Carol_C'],
+    };
+
+    it('renders an AUTHOR row with avatar initials and a link for resolved high-confidence authors', () => {
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={resolvedHigh} />);
+      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      // Avatar initials derived from camelCase
+      expect(screen.getByText('SP')).toBeTruthy();
+      const link = screen.getByRole('link', { name: /SarahProost/ });
+      expect(link.getAttribute('href')).toBe('https://twitter.com/SarahProost');
+      expect(link.getAttribute('target')).toBe('_blank');
+      expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+      // No 'uncertain' badge for high confidence.
+      expect(screen.queryByText(/uncertain/i)).toBeNull();
+    });
+
+    it('renders an "uncertain" badge for medium-confidence authors', () => {
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={resolvedMedium} />);
+      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('ZO')).toBeTruthy();
+      expect(screen.getByText(/uncertain/i)).toBeTruthy();
+      expect(screen.getByRole('link', { name: /Zort70/ })).toBeTruthy();
+    });
+
+    it('renders "Possibly: @A, @B, @C" with a "?" avatar for unresolved authors with candidates', () => {
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={unresolved} />);
+      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('?')).toBeTruthy();
+      expect(screen.getByText(/Possibly:\s*@AliceA,\s*@BobB,\s*@Carol_C/)).toBeTruthy();
+      // No link in unresolved state.
+      expect(screen.queryByRole('link', { name: /AliceA/ })).toBeNull();
+    });
+
+    it('omits the AUTHOR row entirely when handle is null and there are no candidates', () => {
+      const empty: ImageAuthor = {
+        handle: null,
+        displayName: null,
+        twitterUrl: null,
+        confidence: 'unresolved',
+        candidates: [],
+      };
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={empty} />);
+      expect(screen.queryByText(/^author$/i)).toBeNull();
+    });
+
+    it('does not render a link when twitterUrl is missing for a resolved author', () => {
+      const noUrl: ImageAuthor = {
+        handle: '@cheribot',
+        displayName: null,
+        twitterUrl: null,
+        confidence: 'high',
+        candidates: [],
+      };
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={noUrl} />);
+      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('CH')).toBeTruthy();
+      expect(screen.getByText('@cheribot')).toBeTruthy();
+      expect(screen.queryByRole('link', { name: /cheribot/ })).toBeNull();
+    });
+
+    it('rejects unsafe twitterUrl values and renders the handle as plain text', () => {
+      const unsafe: ImageAuthor = {
+        handle: '@evil',
+        displayName: null,
+        // eslint-disable-next-line no-script-url
+        twitterUrl: 'javascript:alert(1)' as string,
+        confidence: 'high',
+        candidates: [],
+      };
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={unsafe} />);
+      expect(screen.getByText('@evil')).toBeTruthy();
+      expect(screen.queryByRole('link', { name: /evil/ })).toBeNull();
+    });
   });
 });

--- a/client/test/author.test.ts
+++ b/client/test/author.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getInitials } from '../src/utils/author';
+
+describe('getInitials', () => {
+  it('returns first two uppercase letters from a camelCase handle', () => {
+    expect(getInitials('@SarahProost')).toBe('SP');
+  });
+
+  it('handles handles without a leading @', () => {
+    expect(getInitials('SarahProost')).toBe('SP');
+  });
+
+  it('falls back to first two characters when only one uppercase letter present', () => {
+    // '@Zort70' has a single uppercase letter, so per the rule the first two
+    // characters of the stripped handle are used: 'Zo' → 'ZO'.
+    expect(getInitials('@Zort70')).toBe('ZO');
+  });
+
+  it('upper-cases the fallback two characters for all-lowercase handles', () => {
+    expect(getInitials('@cheribot')).toBe('CH');
+  });
+
+  it('handles single-character handles', () => {
+    expect(getInitials('@a')).toBe('A');
+  });
+
+  it('returns empty string for an empty handle', () => {
+    expect(getInitials('')).toBe('');
+  });
+
+  it('returns empty string for just a leading @', () => {
+    expect(getInitials('@')).toBe('');
+  });
+
+  it('treats handles starting with digits via the fallback rule', () => {
+    expect(getInitials('@7thStar')).toBe('7T');
+  });
+
+  it('uses the first two uppercase letters when there are more than two', () => {
+    expect(getInitials('@ABCdef')).toBe('AB');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the AUTHOR row to the lightbox IMAGE DETAILS sidebar, consuming the per-image `author` block from the server's attribution enrichment (landed in fringematrix5-hzm). Three render states:

- **Resolved (`confidence` = `high` | `medium`):** circular avatar with derived initials, `@handle` rendered as a link to `twitterUrl` (`target=_blank`, `rel="noopener noreferrer"`), small `uncertain` badge for medium confidence.
- **Unresolved (`handle === null` and `candidates.length > 0`):** `?` avatar with muted `Possibly: @A, @B, @C` text; no link.
- **No data (`author === null`, or `handle === null` with no candidates):** AUTHOR row is omitted entirely - no stub rendered.

New helper `getInitials()` in `client/src/utils/author.ts`: strips leading `@`, returns the first two uppercase letters for camelCase handles (`@SarahProost` -> `SP`), otherwise the first two characters upper-cased (`@cheribot` -> `CH`, `@Zort70` -> `ZO`). Edge cases (empty, single char, digit-leading) covered.

Twitter URLs are gated through the existing `isSafeUrl()` (http/https only) so hostile schemes fall back to plain-text rendering of the handle.

This resolves the long-pending **fringematrix5-qyr** bead, which was the original placeholder created when no author data source existed.

### Files touched

- `client/src/utils/author.ts` (new) - `getInitials` helper.
- `client/test/author.test.ts` (new) - 9 unit tests for the helper.
- `client/src/components/LightboxDetails.tsx` - accepts optional `author` prop, renders the AUTHOR row.
- `client/src/components/LightboxContainer.tsx` - passes the active image's `author` into both the inline sidebar and the mobile drawer instance.
- `client/src/types/api.ts` - `ImageData` gains optional `author?: ImageAuthor | null` so the spread in `useCampaignLoader` is type-safe.
- `client/src/styles.css` - new `.lightbox-author-*` styles matching the existing dark-theme aesthetic.
- `client/test/LightboxDetails.test.tsx` - 9 new test cases covering the three states + edge cases (no `twitterUrl`, unsafe URL scheme).

## Test plan

- [x] `npm run typecheck` (client)
- [x] `npm test` (server + client, 99 + 588 tests)
- [ ] Manual: open the lightbox on a real campaign and confirm:
  - [ ] Resolved authors render avatar + clickable handle.
  - [ ] Medium-confidence authors show the `uncertain` badge.
  - [ ] Unresolved images with candidates show `Possibly: ...` and a `?` avatar.
  - [ ] Images with no attribution data omit the row entirely.

## Follow-ups

- `fringematrix5-ufx` (already filed): e2e Playwright coverage of the AUTHOR row across the three states.
- After merge: close `fringematrix5-qyr` as superseded by this PR.

Refs: fringematrix5-5s8, fringematrix5-qyr, epic fringematrix5-k3g.