### PR TITLE
fringematrix5-lfn: add Authors index + detail pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,9 @@ import SettingsModal from './components/SettingsModal';
 import ThumbnailSizeSlider from './components/ThumbnailSizeSlider';
 import LightboxContainer from './components/LightboxContainer';
 import GalleryGrid, { type GalleryGridHandle } from './components/GalleryGrid';
+import AuthorsIndex from './components/AuthorsIndex';
+import AuthorDetail from './components/AuthorDetail';
+import { parseHashRoute, type HashRoute } from './utils/parseHashRoute';
 import type {
   Campaign,
   BuildInfo,
@@ -79,10 +82,52 @@ export default function App() {
   const modalLoadAbortRef = useRef<AbortController | null>(null);
   const modalTriggerRef = useRef<HTMLElement | null>(null);
 
+  // Route state: which top-level view to render. Driven by the URL hash so it
+  // survives reloads and is bookmarkable. The hash also drives campaign
+  // selection (see the mount effect below); on first render we seed `route`
+  // synchronously from window.location.hash so the correct view paints on
+  // initial render and SSR-friendly fallback ('gallery') for the no-window case.
+  const [route, setRoute] = useState<HashRoute>(() => {
+    if (typeof window === 'undefined') return { type: 'gallery', campaignId: null };
+    return parseHashRoute(window.location.hash);
+  });
+
   // Apply theme CSS variables on mount
   useEffect(() => {
     applyTheme();
   }, []);
+
+  // Keep `route` in sync with the URL hash. This handles direct navigation
+  // (#authors / #authors/:handle) via browser back/forward as well as our
+  // own programmatic navigation that calls window.location.hash = '...'.
+  useEffect(() => {
+    function handleHashChange() {
+      setRoute(parseHashRoute(window.location.hash));
+    }
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  // Programmatic navigation helpers for the Authors pages. Setting the hash
+  // triggers the listener above, which updates `route`. We don't push
+  // intermediate state — the URL is the source of truth.
+  const navigateToAuthorsIndex = useCallback(() => {
+    window.location.hash = 'authors';
+  }, []);
+  const navigateToAuthorDetail = useCallback((handle: string) => {
+    window.location.hash = `authors/${encodeURIComponent(handle)}`;
+  }, []);
+  const navigateToCampaign = useCallback((campaignId: string) => {
+    // Setting the hash triggers hashchange → setRoute({ type: 'gallery', ... }),
+    // and the gallery view's effect (further below) syncs activeCampaignId.
+    window.location.hash = campaignId;
+  }, []);
+  const navigateToGalleryHome = useCallback(() => {
+    // Drop the hash entirely so the gallery view falls back to its default
+    // campaign on next mount; for the current session we just clear route.
+    window.history.replaceState({}, '', window.location.pathname);
+    setRoute({ type: 'gallery', campaignId: activeCampaignId });
+  }, [activeCampaignId]);
 
   // Load accessibility settings from localStorage on mount
   useEffect(() => {
@@ -149,6 +194,26 @@ export default function App() {
       window.history.replaceState({}, '', `#${campaignId}`);
     });
   }, [selectCampaignFromHook]);
+
+  // Stable ref to `selectCampaign` so the route-sync effect below doesn't
+  // need to re-subscribe every time selectCampaign's identity changes.
+  const selectCampaignRef = useRef(selectCampaign);
+  useEffect(() => {
+    selectCampaignRef.current = selectCampaign;
+  }, [selectCampaign]);
+
+  // When the route flips to gallery with a different campaignId (e.g. an
+  // author-detail thumbnail click sets the hash to a campaign id), select
+  // that campaign so the gallery view shows the right images.
+  useEffect(() => {
+    if (route.type !== 'gallery') return;
+    if (!route.campaignId) return;
+    if (route.campaignId === activeCampaignId) return;
+    if (campaigns.length === 0) return;
+    const exists = campaigns.some((c) => c.id === route.campaignId);
+    if (!exists) return;
+    selectCampaignRef.current?.(route.campaignId);
+  }, [route, campaigns, activeCampaignId]);
 
   const activeIndex = useMemo(() => {
     if (!activeCampaignId) return -1;
@@ -325,9 +390,16 @@ export default function App() {
         // Update loading screen with campaign count
         setLoadingCampaignCount(campaignList.length);
 
-        // Choose initial campaign and load its images
-        const hash = window.location.hash.replace('#', '');
-        const initial = campaignList.find((c: Campaign) => c.id === hash) || campaignList[0];
+        // Choose initial campaign and load its images.
+        // Note: when the URL hash points to a non-gallery route (e.g. #authors
+        // or #authors/:handle) the campaign id lookup will miss and we fall
+        // back to the first campaign for preload. The hash is NOT rewritten in
+        // that case — otherwise we'd clobber the user's authors route on load.
+        const parsedHash = parseHashRoute(window.location.hash);
+        const hashCampaignId = parsedHash.type === 'gallery' ? parsedHash.campaignId : null;
+        const initial = (hashCampaignId
+          ? campaignList.find((c: Campaign) => c.id === hashCampaignId)
+          : null) || campaignList[0];
 
         if (initial) {
           // Mount-time initial campaign load. Shares campaignLoadAbortRef so a
@@ -336,7 +408,11 @@ export default function App() {
           campaignLoadAbortRef.current = controller;
 
           setActiveCampaignId(initial.id);
-          window.history.replaceState({}, '', `#${initial.id}`);
+          // Only sync the hash when we're on a gallery route — never overwrite
+          // an explicit non-gallery hash (#authors, #authors/:handle).
+          if (parsedHash.type === 'gallery') {
+            window.history.replaceState({}, '', `#${initial.id}`);
+          }
 
           await loadCampaignImages(initial.id, controller.signal, setLoadingImageCount);
           if (isMounted && !controller.signal.aborted) setIsDataReady(true);
@@ -407,8 +483,10 @@ export default function App() {
     closeAllSubwindows();
     // Clear the hash from the URL
     window.history.replaceState({}, '', window.location.pathname);
+    // Ensure we're on the gallery view (in case user was on an Authors page)
+    setRoute({ type: 'gallery', campaignId: firstCampaign?.id ?? null });
     // Select the first campaign
-    selectCampaign(firstCampaign.id);
+    if (firstCampaign) selectCampaign(firstCampaign.id);
   }, [campaigns, selectCampaign, closeAllSubwindows]);
 
   // Settings modal: close callback with focus restoration
@@ -482,6 +560,13 @@ export default function App() {
           </button>
           <button
             className="toolbar-button"
+            onClick={navigateToAuthorsIndex}
+            disabled={isCampaignLoading}
+          >
+            Authors
+          </button>
+          <button
+            className="toolbar-button"
             onClick={() => openModal('legal')}
             disabled={isCampaignLoading}
           >
@@ -547,38 +632,55 @@ export default function App() {
         onClose={closeSidebar}
       />
 
-      <main className="content">
-        <section id="campaign-info" className="campaign-info">
-          {activeCampaign && (
-            <>
-              <h1>{activeCampaign.episode} ({activeCampaign.episode_id})</h1>
-              <div className="campaign-meta">
-                <span>Hashtag: #{activeCampaign.hashtag}</span>
-                <span>Air date: {activeCampaign.date}</span>
-                <span>Path: {activeCampaign.icon_path}</span>
-              </div>
-              <div className="campaign-links">
-                {isSafeUrl(activeCampaign.fringenuity_link) && (
-                  <a href={activeCampaign.fringenuity_link} target="_blank" rel="noreferrer noopener">Fringenuity</a>
-                )}
-                {isSafeUrl(activeCampaign.imdb_link) && (
-                  <a href={activeCampaign.imdb_link} target="_blank" rel="noreferrer noopener">IMDB</a>
-                )}
-                {isSafeUrl(activeCampaign.wiki_link) && (
-                  <a href={activeCampaign.wiki_link} target="_blank" rel="noreferrer noopener">Wiki</a>
-                )}
-              </div>
-            </>
-          )}
-        </section>
-
-        <GalleryGrid
-          ref={galleryGridRef}
-          images={currentImages}
-          hasCampaign={!!activeCampaign}
-          onImageClick={openLightbox}
+      {route.type === 'authors-index' && (
+        <AuthorsIndex
+          onSelectAuthor={navigateToAuthorDetail}
+          onBack={navigateToGalleryHome}
         />
-      </main>
+      )}
+
+      {route.type === 'author-detail' && (
+        <AuthorDetail
+          handle={route.handle}
+          onBack={navigateToAuthorsIndex}
+          onSelectCampaign={navigateToCampaign}
+        />
+      )}
+
+      {route.type === 'gallery' && (
+        <main className="content">
+          <section id="campaign-info" className="campaign-info">
+            {activeCampaign && (
+              <>
+                <h1>{activeCampaign.episode} ({activeCampaign.episode_id})</h1>
+                <div className="campaign-meta">
+                  <span>Hashtag: #{activeCampaign.hashtag}</span>
+                  <span>Air date: {activeCampaign.date}</span>
+                  <span>Path: {activeCampaign.icon_path}</span>
+                </div>
+                <div className="campaign-links">
+                  {isSafeUrl(activeCampaign.fringenuity_link) && (
+                    <a href={activeCampaign.fringenuity_link} target="_blank" rel="noreferrer noopener">Fringenuity</a>
+                  )}
+                  {isSafeUrl(activeCampaign.imdb_link) && (
+                    <a href={activeCampaign.imdb_link} target="_blank" rel="noreferrer noopener">IMDB</a>
+                  )}
+                  {isSafeUrl(activeCampaign.wiki_link) && (
+                    <a href={activeCampaign.wiki_link} target="_blank" rel="noreferrer noopener">Wiki</a>
+                  )}
+                </div>
+              </>
+            )}
+          </section>
+
+          <GalleryGrid
+            ref={galleryGridRef}
+            images={currentImages}
+            hasCampaign={!!activeCampaign}
+            onImageClick={openLightbox}
+          />
+        </main>
+      )}
 
       {/* Build info popover */}
       {isBuildInfoOpen && (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -191,7 +191,12 @@ export default function App() {
   const selectCampaign = useCallback(async (id: string) => {
     await selectCampaignFromHook(id, (campaignId) => {
       setActiveCampaignId(campaignId);
+      // `replaceState` does NOT fire a hashchange event, so we have to manually
+      // sync `route` here — otherwise the route-sync effect below would see a
+      // mismatch between route.campaignId and activeCampaignId and snap us
+      // back to the previous campaign. (Spotted in code review of bead lfn.)
       window.history.replaceState({}, '', `#${campaignId}`);
+      setRoute({ type: 'gallery', campaignId });
     });
   }, [selectCampaignFromHook]);
 

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { fetchJSON } from '../utils/fetchJSON';
+import { getInitials } from '../utils/author';
+import { isSafeUrl } from '../utils/isSafeUrl';
+import type { AuthorDetailResponse } from '../types/api';
+
+interface Props {
+  /** Handle of the author whose detail page we're rendering (includes leading "@"). */
+  handle: string;
+  /** Navigate back to the authors index page. */
+  onBack: () => void;
+  /**
+   * Navigate to a specific campaign in the main gallery. Used by image
+   * thumbnails on the detail page to jump back to the campaign view.
+   *
+   * Lightbox integration with the source-of-truth state is intentionally
+   * out of scope here — tracked as a follow-up bead.
+   */
+  onSelectCampaign: (campaignId: string) => void;
+}
+
+/**
+ * Author detail page. Shows the author's avatar, name, handle, image count,
+ * and a mini grid of all their attributed images. Clicking a thumbnail
+ * navigates to that image's campaign view (no lightbox integration yet).
+ *
+ * Errors render an inline message rather than crashing the app — 404s from a
+ * missing handle surface as "Failed to load author".
+ */
+export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props) {
+  const [data, setData] = useState<AuthorDetailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    (async () => {
+      try {
+        // Server :handle param accepts the raw "@..." string; we URL-encode so
+        // the leading "@" is transmitted safely as %40.
+        const encoded = encodeURIComponent(handle);
+        const res = await fetchJSON<AuthorDetailResponse>(`/api/authors/${encoded}`, {
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+        setData(res);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load author detail:', e);
+        setError('Failed to load author');
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [handle]);
+
+  const isLoading = data === null && error === null;
+
+  return (
+    <main className="content authors-page author-detail">
+      <div className="authors-header">
+        <button
+          className="toolbar-button authors-back"
+          onClick={onBack}
+          aria-label="Back to authors"
+        >
+          ← All authors
+        </button>
+      </div>
+
+      {isLoading && (
+        <div className="authors-status" role="status" aria-live="polite">
+          Loading author…
+        </div>
+      )}
+
+      {error && (
+        <div className="authors-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {data && (
+        <>
+          <header className="author-detail-header">
+            <div className="author-avatar author-avatar-large" aria-hidden={true}>
+              {getInitials(data.author.name) || getInitials(data.author.handle) || '?'}
+            </div>
+            <div className="author-detail-info">
+              <h1>{data.author.name}</h1>
+              {isSafeUrl(data.author.twitterUrl) && data.author.twitterUrl ? (
+                <a
+                  className="author-handle"
+                  href={data.author.twitterUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {data.author.handle}
+                </a>
+              ) : (
+                <span className="author-handle">{data.author.handle}</span>
+              )}
+              <div className="author-count">
+                {data.images.length} {data.images.length === 1 ? 'image' : 'images'}
+              </div>
+            </div>
+          </header>
+
+          {data.images.length === 0 ? (
+            <div className="authors-status" role="status" aria-live="polite">
+              No images attributed to this author yet.
+            </div>
+          ) : (
+            <section
+              className="gallery-grid"
+              aria-label={`Images by ${data.author.name}`}
+              data-testid="author-images-grid"
+            >
+              {data.images.map((image) => (
+                <div className="card" key={image.blobPath}>
+                  <img
+                    src={image.src}
+                    alt={image.fileName}
+                    loading="lazy"
+                    onClick={() => onSelectCampaign(image.campaignId)}
+                  />
+                </div>
+              ))}
+            </section>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -34,6 +34,11 @@ export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props
   useEffect(() => {
     const controller = new AbortController();
     let cancelled = false;
+    // Reset state when the handle changes so we don't briefly show stale
+    // data (or a stale error alert) from the previous request before the
+    // new one resolves.
+    setData(null);
+    setError(null);
     (async () => {
       try {
         // Server :handle param accepts the raw "@..." string; we URL-encode so
@@ -44,10 +49,12 @@ export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props
         });
         if (cancelled) return;
         setData(res);
+        setError(null);
       } catch (e) {
         if (cancelled) return;
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Failed to load author detail:', e);
+        setData(null);
         setError('Failed to load author');
       }
     })();
@@ -121,12 +128,18 @@ export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props
             >
               {data.images.map((image) => (
                 <div className="card" key={image.blobPath}>
-                  <img
-                    src={image.src}
-                    alt={image.fileName}
-                    loading="lazy"
+                  <button
+                    type="button"
+                    className="author-image-button"
                     onClick={() => onSelectCampaign(image.campaignId)}
-                  />
+                    aria-label={`Open campaign ${image.campaignId}`}
+                  >
+                    <img
+                      src={image.src}
+                      alt={image.fileName}
+                      loading="lazy"
+                    />
+                  </button>
                 </div>
               ))}
             </section>

--- a/client/src/components/AuthorsIndex.tsx
+++ b/client/src/components/AuthorsIndex.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { fetchJSON } from '../utils/fetchJSON';
+import { getInitials } from '../utils/author';
+import { isSafeUrl } from '../utils/isSafeUrl';
+import type { AuthorsResponse, AuthorWithCount } from '../types/api';
+
+interface Props {
+  /** Navigate to a single-author detail page. */
+  onSelectAuthor: (handle: string) => void;
+  /** Navigate back to the main gallery. */
+  onBack: () => void;
+}
+
+/**
+ * Authors index page. Lists all known artists as cards (avatar + name + handle
+ * + image count). Sorted by imageCount desc — the order is preserved from the
+ * /api/authors response.
+ */
+export default function AuthorsIndex({ onSelectAuthor, onBack }: Props) {
+  const [authors, setAuthors] = useState<AuthorWithCount[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchJSON<AuthorsResponse>('/api/authors', { signal: controller.signal });
+        if (cancelled) return;
+        setAuthors(data.authors ?? []);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load authors:', e);
+        setError('Failed to load authors');
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
+  const isLoading = authors === null && error === null;
+  const isEmpty = authors !== null && authors.length === 0;
+
+  return (
+    <main className="content authors-page">
+      <div className="authors-header">
+        <button className="toolbar-button authors-back" onClick={onBack} aria-label="Back to gallery">
+          ← Back
+        </button>
+        <h1>Artists</h1>
+      </div>
+
+      {isLoading && (
+        <div className="authors-status" role="status" aria-live="polite">
+          Loading authors…
+        </div>
+      )}
+
+      {error && (
+        <div className="authors-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="authors-status" role="status" aria-live="polite">
+          No authors found.
+        </div>
+      )}
+
+      {authors && authors.length > 0 && (
+        <section
+          className="authors-grid"
+          aria-label="Authors"
+          data-testid="authors-grid"
+        >
+          {authors.map((author) => (
+            <AuthorCard
+              key={author.handle}
+              author={author}
+              onClick={() => onSelectAuthor(author.handle)}
+            />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+interface AuthorCardProps {
+  author: AuthorWithCount;
+  onClick: () => void;
+}
+
+function AuthorCard({ author, onClick }: AuthorCardProps) {
+  // The 5s8 helper expects a handle, but its rules (extract uppercase letters,
+  // else first-2-chars) also produce reasonable initials for display names
+  // like "Sarah Proost" → "SP". Falls back to "?" for empty strings.
+  const initials = getInitials(author.name) || getInitials(author.handle) || '?';
+  const twitterSafe = isSafeUrl(author.twitterUrl);
+
+  return (
+    <article className="author-card" data-testid="author-card">
+      <button
+        type="button"
+        className="author-card-button"
+        onClick={onClick}
+        aria-label={`Open ${author.name} (${author.imageCount} images)`}
+      >
+        <div className="author-avatar" aria-hidden={true}>{initials}</div>
+        <div className="author-name">{author.name}</div>
+      </button>
+      <div className="author-meta">
+        {twitterSafe && author.twitterUrl ? (
+          <a
+            className="author-handle"
+            href={author.twitterUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {author.handle}
+          </a>
+        ) : (
+          <span className="author-handle">{author.handle}</span>
+        )}
+        <span className="author-count" aria-label={`${author.imageCount} images`}>
+          {author.imageCount} {author.imageCount === 1 ? 'image' : 'images'}
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2261,4 +2261,22 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
   margin-top: 6px;
   font-size: 14px;
 }
+/* Author-detail thumbnail wrapper: a button for keyboard/screen-reader access
+   that visually behaves like the bare <img> in the campaign GalleryGrid. */
+.author-image-button {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  cursor: zoom-in;
+  color: inherit;
+  font: inherit;
+}
+.author-image-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2119,3 +2119,146 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
   gap: 2px;
 }
 
+/* =============================================================================
+   Authors index + detail pages (bead fringematrix5-lfn)
+   ========================================================================== */
+.authors-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+.authors-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.authors-header h1 {
+  margin: 0;
+  font-family: Orbitron, Inter, sans-serif;
+  font-size: 28px;
+  letter-spacing: 0.04em;
+}
+.authors-back {
+  flex-shrink: 0;
+}
+.authors-status,
+.authors-error {
+  padding: 20px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+.authors-error {
+  color: #ff8b8b;
+}
+.authors-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+  margin: 18px 0 80px;
+}
+.author-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  background: var(--bg-elev);
+  border: 1px solid rgba(124,77,255,0.2);
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.author-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  box-shadow: 0 6px 16px rgba(var(--theme-accent-rgb), 0.2);
+}
+.author-card-button {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+}
+.author-card .author-avatar {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(var(--theme-accent-rgb), 0.6), rgba(124,77,255,0.6));
+  display: grid;
+  place-items: center;
+  font-family: Orbitron, Inter, sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+.author-detail .author-avatar-large {
+  width: 96px;
+  height: 96px;
+  font-size: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(var(--theme-accent-rgb), 0.6), rgba(124,77,255,0.6));
+  display: grid;
+  place-items: center;
+  font-family: Orbitron, Inter, sans-serif;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.04em;
+}
+.author-card .author-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.author-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.authors-page .author-handle {
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px dashed rgba(var(--theme-accent-rgb), 0.5);
+}
+.authors-page .author-handle:hover {
+  border-bottom-style: solid;
+}
+.authors-page .author-count {
+  white-space: nowrap;
+  color: var(--muted);
+}
+.author-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 0;
+  margin-bottom: 16px;
+  border-bottom: 1px solid rgba(124,77,255,0.2);
+}
+.author-detail-header h1 {
+  margin: 0 0 6px;
+  font-family: Orbitron, Inter, sans-serif;
+  font-size: 26px;
+  letter-spacing: 0.04em;
+}
+.author-detail-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.author-detail-info .author-count {
+  margin-top: 6px;
+  font-size: 14px;
+}
+

--- a/client/src/utils/parseHashRoute.ts
+++ b/client/src/utils/parseHashRoute.ts
@@ -1,0 +1,41 @@
+/**
+ * Parses `window.location.hash` into one of three app routes:
+ *   #authors           → authors index
+ *   #authors/:handle   → single-author detail page
+ *   #<anything-else>   → gallery view (the value is treated as a campaign id)
+ *
+ * The handle segment is URL-decoded so the leading "@" round-trips through
+ * encodeURIComponent (which the AuthorDetail page uses when fetching).
+ *
+ * Empty hashes also fall through as gallery routes with a null campaignId, so
+ * App.tsx can apply its existing "first campaign" default.
+ */
+export type HashRoute =
+  | { type: 'gallery'; campaignId: string | null }
+  | { type: 'authors-index' }
+  | { type: 'author-detail'; handle: string };
+
+export function parseHashRoute(rawHash: string): HashRoute {
+  const hash = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
+  if (!hash) {
+    return { type: 'gallery', campaignId: null };
+  }
+  if (hash === 'authors') {
+    return { type: 'authors-index' };
+  }
+  if (hash.startsWith('authors/')) {
+    const rest = hash.slice('authors/'.length);
+    if (rest.length === 0) {
+      return { type: 'authors-index' };
+    }
+    let handle: string;
+    try {
+      handle = decodeURIComponent(rest);
+    } catch {
+      // malformed escape — treat as raw text rather than crashing
+      handle = rest;
+    }
+    return { type: 'author-detail', handle };
+  }
+  return { type: 'gallery', campaignId: hash };
+}

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -88,10 +88,50 @@ describe('AuthorDetail', () => {
     );
 
     const grid = await screen.findByTestId('author-images-grid');
-    const firstImg = grid.querySelectorAll('img')[0]!;
-    fireEvent.click(firstImg);
+    const firstButton = grid.querySelector('button')!;
+    fireEvent.click(firstButton);
 
     expect(onSelectCampaign).toHaveBeenCalledWith('crosstheline');
+  });
+
+  it('clears stale data and error when the handle prop changes', async () => {
+    // First render: successful response for @first.
+    const FIRST = {
+      ...SAMPLE_DETAIL,
+      author: { ...SAMPLE_DETAIL.author, handle: '@first', name: 'First Person' },
+    };
+    let callIdx = 0;
+    const fetchSpy = vi.fn(async () => {
+      const body = callIdx++ === 0
+        ? FIRST
+        : { error: 'not found' };
+      const status = callIdx === 1 ? 200 : 404;
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rerender } = render(
+      <AuthorDetail handle="@first" onBack={() => {}} onSelectCampaign={() => {}} />,
+    );
+    await screen.findByText('First Person');
+
+    // Re-render with a different handle — the previous "First Person" header
+    // and image grid should disappear immediately while the new fetch runs.
+    rerender(
+      <AuthorDetail handle="@second" onBack={() => {}} onSelectCampaign={() => {}} />,
+    );
+    expect(screen.queryByText('First Person')).toBeNull();
+    expect(screen.queryByTestId('author-images-grid')).toBeNull();
+
+    // Second fetch resolves to 404 — error alert appears.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load author/i);
+    });
+    errSpy.mockRestore();
   });
 
   it('shows an inline error message when the request fails (e.g. 404)', async () => {

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import AuthorDetail from '../src/components/AuthorDetail';
+
+const SAMPLE_DETAIL = {
+  author: {
+    handle: '@Zort70',
+    name: 'Sarah Proost',
+    twitterUrl: 'https://twitter.com/Zort70',
+    alternateHandles: [],
+    roles: ['artist'],
+  },
+  images: [
+    {
+      src: '/avatars/Season4/CrossTheLine/abc.jpg',
+      fileName: 'abc.jpg',
+      blobPath: 'avatars/Season4/CrossTheLine/abc.jpg',
+      campaignId: 'crosstheline',
+      confidence: 'high' as const,
+    },
+    {
+      src: '/avatars/Season4/CrossTheLine/def.jpg',
+      fileName: 'def.jpg',
+      blobPath: 'avatars/Season4/CrossTheLine/def.jpg',
+      campaignId: 'crosstheline',
+      confidence: 'high' as const,
+    },
+  ],
+};
+
+function mockFetch(response: unknown, status = 200) {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(response), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('AuthorDetail', () => {
+  it('fetches /api/authors/:handle with the handle URL-encoded and renders header + images', async () => {
+    const fetchSpy = mockFetch(SAMPLE_DETAIL);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    render(
+      <AuthorDetail
+        handle="@Zort70"
+        onBack={() => {}}
+        onSelectCampaign={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Sarah Proost')).toBeTruthy();
+    });
+
+    // URL-encoded handle in the request
+    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(calledUrl).toContain('/api/authors/%40Zort70');
+
+    // Header bits
+    expect(screen.getByRole('link', { name: '@Zort70' }).getAttribute('href'))
+      .toBe('https://twitter.com/Zort70');
+    expect(screen.getByText('2 images')).toBeTruthy();
+
+    // Two thumbnails rendered
+    const grid = screen.getByTestId('author-images-grid');
+    expect(grid.querySelectorAll('img').length).toBe(2);
+  });
+
+  it('navigates to the campaign when a thumbnail is clicked', async () => {
+    globalThis.fetch = mockFetch(SAMPLE_DETAIL) as unknown as typeof fetch;
+    const onSelectCampaign = vi.fn();
+
+    render(
+      <AuthorDetail
+        handle="@Zort70"
+        onBack={() => {}}
+        onSelectCampaign={onSelectCampaign}
+      />,
+    );
+
+    const grid = await screen.findByTestId('author-images-grid');
+    const firstImg = grid.querySelectorAll('img')[0]!;
+    fireEvent.click(firstImg);
+
+    expect(onSelectCampaign).toHaveBeenCalledWith('crosstheline');
+  });
+
+  it('shows an inline error message when the request fails (e.g. 404)', async () => {
+    globalThis.fetch = mockFetch({ error: 'not found' }, 404) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <AuthorDetail
+        handle="@nope"
+        onBack={() => {}}
+        onSelectCampaign={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load author/i);
+    });
+    errSpy.mockRestore();
+  });
+});

--- a/client/test/AuthorsIndex.test.tsx
+++ b/client/test/AuthorsIndex.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import AuthorsIndex from '../src/components/AuthorsIndex';
+import type { AuthorWithCount } from '../src/types/api';
+
+const SAMPLE_AUTHORS: AuthorWithCount[] = [
+  {
+    handle: '@Zort70',
+    name: 'Sarah Proost',
+    twitterUrl: 'https://twitter.com/Zort70',
+    alternateHandles: [],
+    roles: ['artist'],
+    imageCount: 244,
+  },
+  {
+    handle: '@someone',
+    name: 'Someone Else',
+    twitterUrl: null,
+    alternateHandles: [],
+    roles: [],
+    imageCount: 1,
+  },
+];
+
+function mockFetch(response: unknown, status = 200) {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(response), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('AuthorsIndex', () => {
+  it('renders a card for each author returned by /api/authors', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('author-card')).toHaveLength(2);
+    });
+
+    expect(screen.getByText('Sarah Proost')).toBeTruthy();
+    expect(screen.getByText('Someone Else')).toBeTruthy();
+    expect(screen.getByText('244 images')).toBeTruthy();
+    expect(screen.getByText('1 image')).toBeTruthy();
+  });
+
+  it('linkifies the @handle to the twitterUrl when present', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    const link = await screen.findByRole('link', { name: '@Zort70' });
+    expect(link.getAttribute('href')).toBe('https://twitter.com/Zort70');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('renders @handle as plain text when twitterUrl is null', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await screen.findByText('Someone Else');
+    expect(screen.queryByRole('link', { name: '@someone' })).toBeNull();
+    expect(screen.getByText('@someone')).toBeTruthy();
+  });
+
+  it('calls onSelectAuthor with the handle when a card is clicked', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    const onSelectAuthor = vi.fn();
+    render(<AuthorsIndex onSelectAuthor={onSelectAuthor} onBack={() => {}} />);
+
+    const sarahBtn = await screen.findByRole('button', { name: /Open Sarah Proost/ });
+    fireEvent.click(sarahBtn);
+
+    expect(onSelectAuthor).toHaveBeenCalledWith('@Zort70');
+  });
+
+  it('shows an inline error when the request fails', async () => {
+    globalThis.fetch = mockFetch({ error: 'boom' }, 500) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load authors/i);
+    });
+    errSpy.mockRestore();
+  });
+
+  it('shows a friendly empty state when the API returns no authors', async () => {
+    globalThis.fetch = mockFetch({ authors: [] }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no authors found/i)).toBeTruthy();
+    });
+    expect(screen.queryByTestId('authors-grid')).toBeNull();
+  });
+});

--- a/client/test/parseHashRoute.test.ts
+++ b/client/test/parseHashRoute.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseHashRoute } from '../src/utils/parseHashRoute';
+
+describe('parseHashRoute', () => {
+  it('returns gallery with null campaignId for an empty hash', () => {
+    expect(parseHashRoute('')).toEqual({ type: 'gallery', campaignId: null });
+    expect(parseHashRoute('#')).toEqual({ type: 'gallery', campaignId: null });
+  });
+
+  it('returns authors-index for "#authors"', () => {
+    expect(parseHashRoute('#authors')).toEqual({ type: 'authors-index' });
+    expect(parseHashRoute('authors')).toEqual({ type: 'authors-index' });
+  });
+
+  it('returns authors-index when the handle segment is empty (trailing slash)', () => {
+    expect(parseHashRoute('#authors/')).toEqual({ type: 'authors-index' });
+  });
+
+  it('returns author-detail with a URL-decoded handle', () => {
+    expect(parseHashRoute('#authors/%40Zort70')).toEqual({
+      type: 'author-detail',
+      handle: '@Zort70',
+    });
+  });
+
+  it('treats any other hash value as a campaign id', () => {
+    expect(parseHashRoute('#crosstheline')).toEqual({
+      type: 'gallery',
+      campaignId: 'crosstheline',
+    });
+  });
+
+  it('gracefully handles malformed URI escape sequences', () => {
+    // '%E0%A4' is incomplete and would throw in decodeURIComponent
+    expect(parseHashRoute('#authors/%E0%A4')).toEqual({
+      type: 'author-detail',
+      handle: '%E0%A4',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an Artists / Authors browsing experience consuming the new `/api/authors` + `/api/authors/:handle` endpoints (bead 7hh).

- **Index page** (`#authors`): responsive grid of cards (avatar + name + linkified @handle + image count), sorted server-side by image count desc. Loading, error, and empty states all handled inline.
- **Detail page** (`#authors/:handle`): large avatar + name + handle + count, then a thumbnail grid of every image attributed to that author. Clicking a thumbnail navigates to the corresponding campaign view.
- **Toolbar entry point**: new "Authors" button added between Credits and Legal.
- **Routing**: hash-based (`#authors`, `#authors/:handle`) — matches the existing campaign-id hash convention. A small `parseHashRoute` utility handles parsing + URL-decoding the handle segment. The mount-time campaign loader is careful to NOT clobber a non-gallery hash.

### Reuse of bead 5s8

5s8 (lightbox AUTHOR row) merged before this — its `getInitials(handle)` helper in `client/src/utils/author.ts` is reused for avatar placeholders. It accepts handles but happens to produce sensible initials for display names too (`Sarah Proost` → `SP` via the uppercase-letters rule).

### Follow-ups (deferred from bead scope)

- Wire author-detail thumbnails into the existing lightbox (currently they navigate to the campaign view, not the lightbox state). Bead allowed punting this; will file as a follow-up.
- Optional alphabetical sort toggle on the index (bead lists this as optional).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 107 server + 603 client tests pass
- [x] `npm run build` clean
- [ ] Manual smoke: navigate `#authors`, click a card, follow a thumbnail back to a campaign, back-button navigation, malformed `#authors/...` handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Authors section with a browsable gallery displaying all authors
  * Author detail pages showcase individual author information and their attributed images
  * New "Authors" navigation button in the toolbar for quick access
  * Hash-based URL routing enables cleaner, bookmarkable links across gallery and author pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->