### PR TITLE
fringematrix5-ufx: e2e test for lightbox AUTHOR row

### DIFF
--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -28,31 +28,63 @@ async function gotoCampaign(page: Page, campaignId: string) {
 }
 
 /**
- * Click the gallery card whose `alt` exactly matches `fileName` (the client
- * sets `alt={image.fileName}` in ImageCard). Returns false when no such card
- * is visible — typically because the live backend returned an empty image
- * list, in which case the caller should skip.
+ * Result of an attempted lightbox open:
+ *   - 'opened'      : the requested fileName was found and clicked.
+ *   - 'empty'       : the gallery returned no images at all (caller should
+ *                     skip — typically a no-token test environment).
+ *   - 'missing'     : the gallery had images but none matched fileName
+ *                     (caller should fail loudly — a real regression or
+ *                     fixture drift, not an environment issue).
  */
-async function openLightboxForFile(page: Page, fileName: string): Promise<boolean> {
+type OpenResult =
+  | { status: 'opened' }
+  | { status: 'empty' }
+  | { status: 'missing'; available: string[] };
+
+/**
+ * Click the gallery card whose `alt` exactly matches `fileName` (the client
+ * sets `alt={image.fileName}` in ImageCard).
+ *
+ * We deliberately distinguish "no images at all" (skip) from "the specific
+ * fixture file is gone" (hard fail) so that fixture drift on the live blob
+ * store can never silently turn this spec into a no-op.
+ */
+async function openLightboxForFile(page: Page, fileName: string): Promise<OpenResult> {
   const cards = page.locator('.gallery-grid .card img');
-  if ((await cards.count()) === 0) return false;
+  if ((await cards.count()) === 0) return { status: 'empty' };
+
   const target = page.locator(`.gallery-grid .card img[alt="${fileName}"]`);
-  if ((await target.count()) === 0) return false;
+  if ((await target.count()) === 0) {
+    // Capture a sample of available alt values so the failure message points
+    // straight at the likely culprit (file renamed, moved, removed).
+    const available = await cards.evaluateAll((els: Element[]) =>
+      els.slice(0, 10).map((el) => (el as HTMLImageElement).alt)
+    );
+    return { status: 'missing', available };
+  }
+
   await target.first().click();
   await expect(page.locator('#lightbox')).toBeVisible();
   // Make sure the lightbox is showing the intended image — fileName appears
   // in the HUD line ("FILE: <name> // <i> OF <n>").
   await expect(page.locator('.lightbox-hud')).toContainText(fileName);
-  return true;
+  return { status: 'opened' };
 }
 
 test.describe('Lightbox AUTHOR row — resolved (high confidence)', () => {
   test('renders avatar initials and a Twitter link for a known @Zort70 image', async ({ page }) => {
     await gotoCampaign(page, 'beabetterman');
 
-    const opened = await openLightboxForFile(page, 'beabettermanBrown.jpg');
-    if (!opened) {
+    const result = await openLightboxForFile(page, 'beabettermanBrown.jpg');
+    if (result.status === 'empty') {
       test.skip(true, 'No images available in this environment (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+    if (result.status === 'missing') {
+      throw new Error(
+        `Fixture 'beabettermanBrown.jpg' not found in BeABetterMan campaign. ` +
+        `Available alts (up to 10): ${JSON.stringify(result.available)}. ` +
+        `If the blob storage layout changed, pick another @Zort70 image and update this spec.`
+      );
     }
 
     // Scope assertions to the inline sidebar so we hit a single instance even
@@ -91,9 +123,16 @@ test.describe('Lightbox AUTHOR row — unresolved with candidates', () => {
 
     // Any image inside the fully-unresolved `oil/` folder works; pick the
     // first one alphabetically that we know lives there.
-    const opened = await openLightboxForFile(page, 'OIL_blue.jpg');
-    if (!opened) {
+    const result = await openLightboxForFile(page, 'OIL_blue.jpg');
+    if (result.status === 'empty') {
       test.skip(true, 'No images available in this environment (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+    if (result.status === 'missing') {
+      throw new Error(
+        `Fixture 'OIL_blue.jpg' not found in ObserveItLive campaign. ` +
+        `Available alts (up to 10): ${JSON.stringify(result.available)}. ` +
+        `If the blob storage layout changed, pick another image from the unresolved oil/ folder and update this spec.`
+      );
     }
 
     const sidebar = page.locator('.lightbox-details').first();

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * E2E coverage for the lightbox AUTHOR row introduced in fringematrix5-5s8.
+ *
+ * Two real-data flows are exercised against the live backend:
+ *   1. A high-confidence resolved attribution (BeABetterMan → @Zort70 via the
+ *      `BABM-zort70/` named-artist folder).
+ *   2. An unresolved attribution with multiple candidates (ObserveItLive →
+ *      `oil/` folder, three campaign candidates).
+ *
+ * Both flows depend on the Vercel Blob store being reachable. When the test
+ * environment has no `BLOB_READ_WRITE_TOKEN` the gallery comes back empty;
+ * we follow the existing spec convention and `test.skip` with a reason
+ * rather than failing.
+ */
+
+async function waitForLoaderToFinish(page: Page) {
+  const loader = page.getByRole('dialog', { name: 'Loading' });
+  if (await loader.isVisible().catch(() => false)) {
+    await loader.waitFor({ state: 'detached' });
+  }
+}
+
+async function gotoCampaign(page: Page, campaignId: string) {
+  await page.goto(`/#${campaignId}`);
+  await waitForLoaderToFinish(page);
+}
+
+/**
+ * Click the gallery card whose `alt` exactly matches `fileName` (the client
+ * sets `alt={image.fileName}` in ImageCard). Returns false when no such card
+ * is visible — typically because the live backend returned an empty image
+ * list, in which case the caller should skip.
+ */
+async function openLightboxForFile(page: Page, fileName: string): Promise<boolean> {
+  const cards = page.locator('.gallery-grid .card img');
+  if ((await cards.count()) === 0) return false;
+  const target = page.locator(`.gallery-grid .card img[alt="${fileName}"]`);
+  if ((await target.count()) === 0) return false;
+  await target.first().click();
+  await expect(page.locator('#lightbox')).toBeVisible();
+  // Make sure the lightbox is showing the intended image — fileName appears
+  // in the HUD line ("FILE: <name> // <i> OF <n>").
+  await expect(page.locator('.lightbox-hud')).toContainText(fileName);
+  return true;
+}
+
+test.describe('Lightbox AUTHOR row — resolved (high confidence)', () => {
+  test('renders avatar initials and a Twitter link for a known @Zort70 image', async ({ page }) => {
+    await gotoCampaign(page, 'beabetterman');
+
+    const opened = await openLightboxForFile(page, 'beabettermanBrown.jpg');
+    if (!opened) {
+      test.skip(true, 'No images available in this environment (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+
+    // Scope assertions to the inline sidebar so we hit a single instance even
+    // when the mobile drawer's hidden copy is also in the DOM.
+    const sidebar = page.locator('.lightbox-details').first();
+    await expect(sidebar).toBeVisible();
+
+    // AUTHOR row should be present.
+    const authorRow = sidebar.locator('.lightbox-details-author');
+    await expect(authorRow).toBeVisible();
+    await expect(authorRow.getByText('AUTHOR', { exact: true })).toBeVisible();
+
+    // Avatar element with initials derived from '@Zort70' → 'ZO' (one
+    // uppercase letter in the handle, so getInitials() falls through to the
+    // first-two-chars rule, yielding 'ZO').
+    const avatar = authorRow.locator('.lightbox-author-avatar');
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toHaveText('ZO');
+
+    // Handle rendered as a link pointing at the canonical Twitter URL.
+    const handleLink = authorRow.getByRole('link', { name: /Zort70/ });
+    await expect(handleLink).toBeVisible();
+    await expect(handleLink).toContainText('@Zort70');
+    await expect(handleLink).toHaveAttribute('href', 'https://twitter.com/Zort70');
+    await expect(handleLink).toHaveAttribute('target', '_blank');
+    await expect(handleLink).toHaveAttribute('rel', /noopener/);
+
+    // High-confidence images do NOT get the 'uncertain' badge.
+    await expect(authorRow.locator('.lightbox-author-badge')).toHaveCount(0);
+  });
+});
+
+test.describe('Lightbox AUTHOR row — unresolved with candidates', () => {
+  test('shows "Possibly: …" candidate list for an unresolved ObserveItLive image', async ({ page }) => {
+    await gotoCampaign(page, 'observeitlive');
+
+    // Any image inside the fully-unresolved `oil/` folder works; pick the
+    // first one alphabetically that we know lives there.
+    const opened = await openLightboxForFile(page, 'OIL_blue.jpg');
+    if (!opened) {
+      test.skip(true, 'No images available in this environment (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+
+    const sidebar = page.locator('.lightbox-details').first();
+    const authorRow = sidebar.locator('.lightbox-details-author');
+    await expect(authorRow).toBeVisible();
+    await expect(authorRow.getByText('AUTHOR', { exact: true })).toBeVisible();
+
+    // Unresolved avatar shows a literal '?'.
+    const avatar = authorRow.locator('.lightbox-author-avatar--unresolved');
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toHaveText('?');
+
+    // "Possibly:" label + each expected candidate handle.
+    const candidates = authorRow.locator('.lightbox-author-candidates');
+    await expect(candidates).toBeVisible();
+    await expect(candidates).toContainText('Possibly:');
+    await expect(candidates).toContainText('@Cheribot');
+    await expect(candidates).toContainText('@SarahProost');
+    await expect(candidates).toContainText('@Zort70');
+
+    // Unresolved state must NOT render an attribution link.
+    await expect(authorRow.locator('a')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `e2e/lightbox-author-row.spec.ts` with Playwright coverage for the lightbox AUTHOR row (fringematrix5-5s8).
- **Resolved flow**: opens `beabettermanBrown.jpg` in BeABetterMan and asserts the AUTHOR row renders `ZO` initials and a `@Zort70` link pointing at `https://twitter.com/Zort70`, with `target=_blank` / `rel=noopener` and no `uncertain` badge (high confidence).
- **Unresolved flow**: opens `OIL_blue.jpg` in ObserveItLive (the fully-unresolved `oil/` folder) and asserts the `?` avatar, the `Possibly:` label, and the three campaign candidates (`@Cheribot`, `@SarahProost`, `@Zort70`).
- Skips gracefully when the live backend returns no images (env without `BLOB_READ_WRITE_TOKEN`), matching the convention in `lightbox-redesign.spec.ts` and `app.spec.ts`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (scripts + server + client suites)
- [x] `npx playwright test --config e2e/playwright.config.ts e2e/lightbox-author-row.spec.ts` (with `BLOB_READ_WRITE_TOKEN` present) — both tests pass against live blob data
- [ ] CI runs the new spec via the existing `test:e2e` job with the repo secret token

## Follow-ups

None; further AUTHOR row hardening (e.g. asserting the `uncertain` badge against a known medium-confidence image) can be added if/when a stable medium-confidence fixture lands in `data/attribution.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)