### PR TITLE
fringematrix5-s7i: split getInitials into handle- and name-flavored helpers

### DIFF
--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchJSON } from '../utils/fetchJSON';
-import { getInitials } from '../utils/author';
+import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
 import type { AuthorDetailResponse } from '../types/api';
 
@@ -94,7 +94,7 @@ export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props
         <>
           <header className="author-detail-header">
             <div className="author-avatar author-avatar-large" aria-hidden={true}>
-              {getInitials(data.author.name) || getInitials(data.author.handle) || '?'}
+              {getInitialsFromName(data.author.name) || '?'}
             </div>
             <div className="author-detail-info">
               <h1>{data.author.name}</h1>

--- a/client/src/components/AuthorsIndex.tsx
+++ b/client/src/components/AuthorsIndex.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchJSON } from '../utils/fetchJSON';
-import { getInitials } from '../utils/author';
+import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
 import type { AuthorsResponse, AuthorWithCount } from '../types/api';
 
@@ -96,10 +96,9 @@ interface AuthorCardProps {
 }
 
 function AuthorCard({ author, onClick }: AuthorCardProps) {
-  // The 5s8 helper expects a handle, but its rules (extract uppercase letters,
-  // else first-2-chars) also produce reasonable initials for display names
-  // like "Sarah Proost" → "SP". Falls back to "?" for empty strings.
-  const initials = getInitials(author.name) || getInitials(author.handle) || '?';
+  // Display-name flavored initials ("Sarah Proost" → "SP"). Falls back to
+  // "?" for empty names so the avatar circle never renders blank.
+  const initials = getInitialsFromName(author.name) || '?';
   const twitterSafe = isSafeUrl(author.twitterUrl);
 
   return (

--- a/client/src/utils/author.ts
+++ b/client/src/utils/author.ts
@@ -1,10 +1,16 @@
 /**
- * Author-row helpers for the lightbox IMAGE DETAILS sidebar.
+ * Author-row helpers for the lightbox IMAGE DETAILS sidebar and the
+ * /authors index + detail pages.
+ *
+ * Two distinct flavors of "initials" exist because the two call sites have
+ * different inputs:
+ *   - `getInitials(handle)` — Twitter-style handle, possibly camelCase.
+ *   - `getInitialsFromName(name)` — human-readable display name with spaces.
  */
 
 /**
  * Derive a short (2-character) initials string from a Twitter-style handle for
- * use as the avatar label in the AUTHOR row.
+ * use as the avatar label in the AUTHOR row of the lightbox sidebar.
  *
  * Rules (per fringematrix5-5s8):
  *   1. Strip a leading '@'.
@@ -19,6 +25,9 @@
  *   - Single-character handles return that single character upper-cased.
  *   - Handles starting with a digit (e.g. '@7th') still work — they just
  *     don't match rule 2 and fall through to rule 3.
+ *
+ * For display names with whitespace (e.g. "Sarah Proost"), prefer
+ * `getInitialsFromName` — this function does not split on whitespace.
  */
 export function getInitials(handle: string): string {
   const stripped = handle.replace(/^@/, '');
@@ -29,4 +38,34 @@ export function getInitials(handle: string): string {
     return (upperLetters[0] + upperLetters[1]).toUpperCase();
   }
   return stripped.slice(0, 2).toUpperCase();
+}
+
+/**
+ * Derive a short (2-character) initials string from a human-readable display
+ * name for use as the avatar label on the authors index + detail pages.
+ *
+ * Rules:
+ *   1. Trim leading/trailing whitespace.
+ *   2. Split on whitespace. If there are 2+ words, take the first letter of
+ *      the first two words (e.g. "Sarah Proost" → "SP").
+ *   3. Otherwise (single word like "Cheribot") fall back to the first two
+ *      characters of the name.
+ *   4. Result is upper-cased.
+ *
+ * Edge cases:
+ *   - Empty input (or whitespace-only) returns '' so the caller can choose a
+ *     placeholder.
+ *   - Single-character names return that single character upper-cased.
+ *   - Unlike `getInitials`, no leading '@' is stripped — display names are
+ *     not handles.
+ */
+export function getInitialsFromName(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return '';
+
+  const words = trimmed.split(/\s+/);
+  if (words.length >= 2) {
+    return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase();
+  }
+  return trimmed.slice(0, 2).toUpperCase();
 }

--- a/client/test/author.test.ts
+++ b/client/test/author.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getInitials } from '../src/utils/author';
+import { getInitials, getInitialsFromName } from '../src/utils/author';
 
 describe('getInitials', () => {
   it('returns first two uppercase letters from a camelCase handle', () => {
@@ -38,5 +38,49 @@ describe('getInitials', () => {
 
   it('uses the first two uppercase letters when there are more than two', () => {
     expect(getInitials('@ABCdef')).toBe('AB');
+  });
+});
+
+describe('getInitialsFromName', () => {
+  it('returns first letter of the first two words for a two-word name', () => {
+    expect(getInitialsFromName('Sarah Proost')).toBe('SP');
+  });
+
+  it('uses only the first two words when more than two are present', () => {
+    expect(getInitialsFromName('Mary Anne Smith')).toBe('MA');
+  });
+
+  it('falls back to first two characters for a single-word name', () => {
+    expect(getInitialsFromName('Cheribot')).toBe('CH');
+  });
+
+  it('upper-cases the result for lowercase input', () => {
+    expect(getInitialsFromName('sarah proost')).toBe('SP');
+  });
+
+  it('returns empty string for an empty name', () => {
+    expect(getInitialsFromName('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(getInitialsFromName('   ')).toBe('');
+  });
+
+  it('handles leading and trailing whitespace', () => {
+    expect(getInitialsFromName('  Sarah Proost  ')).toBe('SP');
+  });
+
+  it('handles a single character name', () => {
+    expect(getInitialsFromName('a')).toBe('A');
+  });
+
+  it('does not strip a leading @ (display names are not handles)', () => {
+    // Unlike `getInitials`, '@' is treated as a literal character of the
+    // first (and only) word, so the first two chars are '@F'.
+    expect(getInitialsFromName('@Foo')).toBe('@F');
+  });
+
+  it('collapses multiple whitespace characters between words', () => {
+    expect(getInitialsFromName('Sarah   Proost')).toBe('SP');
   });
 });


### PR DESCRIPTION
## Summary

- Adds `getInitialsFromName(name)` to `client/src/utils/author.ts` for display-name initials (splits on whitespace, e.g. "Sarah Proost" → "SP", falls back to first two chars for single-word names like "Cheribot")
- Keeps the existing `getInitials(handle)` unchanged — handle-flavored (strips leading `@`, scans for uppercase letters)
- Updates `AuthorsIndex.tsx` and `AuthorDetail.tsx` to call the name flavor directly instead of the unclear `getInitials(name) || getInitials(handle) || '?'` fall-through
- `LightboxDetails.tsx` is unchanged — it continues to use `getInitials` on a handle, which is the intent

Resolves bead `fringematrix5-s7i`. Pure refactor for clarity, no behavior change at the existing call sites (the two flavors happen to produce the same output for the inputs the app actually receives).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (614 client + 107 server tests; new `getInitialsFromName` test cases for two-word names, single-word fallback, lowercase input, empty/whitespace inputs, leading-`@`-not-stripped, multi-space collapse)
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)