### PR TITLE
fringematrix5-rq6: wire author-detail thumbnails into the lightbox

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,6 +49,14 @@ export default function App() {
   } = useCampaignLoader();
   const [lightboxIndex, setLightboxIndex] = useState<number>(0);
   const [isLightboxOpen, setIsLightboxOpen] = useState<boolean>(false);
+  // When the user clicks a thumbnail on the author-detail page we navigate to
+  // the containing campaign and remember which image to open in the lightbox.
+  // An effect below watches `currentImages` and opens the lightbox once the
+  // campaign has finished loading and the matching image is present. Stored
+  // as state (not a ref) so React re-renders trigger the effect.
+  const [pendingLightboxImage, setPendingLightboxImage] = useState<
+    { blobPath: string; campaignId: string } | null
+  >(null);
   const [hideLightboxImage, setHideLightboxImage] = useState<boolean>(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
   const [isBuildInfoOpen, setIsBuildInfoOpen] = useState<boolean>(false);
@@ -117,11 +125,23 @@ export default function App() {
   const navigateToAuthorDetail = useCallback((handle: string) => {
     window.location.hash = `authors/${encodeURIComponent(handle)}`;
   }, []);
-  const navigateToCampaign = useCallback((campaignId: string) => {
-    // Setting the hash triggers hashchange → setRoute({ type: 'gallery', ... }),
-    // and the gallery view's effect (further below) syncs activeCampaignId.
-    window.location.hash = campaignId;
-  }, []);
+  // Click handler for author-detail thumbnails. Navigates to the source
+  // campaign and stashes the target image so the effect below can open the
+  // lightbox once `currentImages` arrives.
+  //
+  // Defensive: if matching ever fails (e.g. blobPath mismatch from an older
+  // server build), the effect simply clears `pendingLightboxImage` and the
+  // user lands on the campaign gallery rather than getting stuck.
+  const openImageFromAuthorPage = useCallback(
+    ({ blobPath, campaignId }: { blobPath: string; campaignId: string }) => {
+      setPendingLightboxImage({ blobPath, campaignId });
+      // Setting the hash drives the same route-sync effect that
+      // navigateToCampaign uses; the campaign loader will fire and
+      // `currentImages` updates downstream.
+      window.location.hash = campaignId;
+    },
+    [],
+  );
   const navigateToGalleryHome = useCallback(() => {
     // Drop the hash entirely so the gallery view falls back to its default
     // campaign on next mount; for the current session we just clear route.
@@ -467,6 +487,40 @@ export default function App() {
     getThumbElement,
   });
 
+  // Open the lightbox at the image flagged by `pendingLightboxImage` once the
+  // matching campaign has finished loading. We wait for `isCampaignLoading`
+  // to flip false so the lightbox renders against the fully-loaded image
+  // array (placeholder rows have `src: null` and would briefly flash blank).
+  //
+  // Defensive: if `currentImages` contains no entry whose blobPath matches we
+  // still clear `pendingLightboxImage` so a transient mismatch does not trap
+  // the user in a half-open state — they land on the campaign gallery and
+  // can find the image manually.
+  //
+  // The `activeCampaignId === pendingLightboxImage.campaignId` guard prevents
+  // us from opening the lightbox on the wrong campaign mid-switch (e.g. if
+  // the user clicks one author thumbnail and then another while the first
+  // campaign is still loading).
+  useEffect(() => {
+    if (!pendingLightboxImage) return;
+    if (activeCampaignId !== pendingLightboxImage.campaignId) return;
+    if (isCampaignLoading) return;
+    if (currentImages.length === 0) return;
+    const idx = currentImages.findIndex(
+      (img) => img.blobPath === pendingLightboxImage.blobPath,
+    );
+    if (idx >= 0) {
+      openLightbox(idx);
+    }
+    setPendingLightboxImage(null);
+  }, [
+    pendingLightboxImage,
+    currentImages,
+    activeCampaignId,
+    isCampaignLoading,
+    openLightbox,
+  ]);
+
   // Centralized function to close all subwindows - add new subwindows here
   const closeAllSubwindows = useCallback(() => {
     if (isLightboxOpen) closeLightbox();
@@ -648,7 +702,7 @@ export default function App() {
         <AuthorDetail
           handle={route.handle}
           onBack={navigateToAuthorsIndex}
-          onSelectCampaign={navigateToCampaign}
+          onOpenImage={openImageFromAuthorPage}
         />
       )}
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -503,6 +503,13 @@ export default function App() {
   // campaign is still loading).
   useEffect(() => {
     if (!pendingLightboxImage) return;
+    // If the user navigated away from the gallery before the campaign
+    // finished loading (e.g. back to the authors index), drop the pending
+    // request so we don't pop a lightbox over a non-gallery view.
+    if (route.type !== 'gallery') {
+      setPendingLightboxImage(null);
+      return;
+    }
     if (activeCampaignId !== pendingLightboxImage.campaignId) return;
     if (isCampaignLoading) return;
     if (currentImages.length === 0) return;
@@ -518,6 +525,7 @@ export default function App() {
     currentImages,
     activeCampaignId,
     isCampaignLoading,
+    route,
     openLightbox,
   ]);
 

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -10,24 +10,23 @@ interface Props {
   /** Navigate back to the authors index page. */
   onBack: () => void;
   /**
-   * Navigate to a specific campaign in the main gallery. Used by image
-   * thumbnails on the detail page to jump back to the campaign view.
-   *
-   * Lightbox integration with the source-of-truth state is intentionally
-   * out of scope here — tracked as a follow-up bead.
+   * Open the lightbox at a specific image. The App-level handler selects the
+   * containing campaign and, once its images finish preloading, opens the
+   * lightbox at the matching index. If the lookup fails for any reason the
+   * handler still navigates to the campaign view so the user is not stranded.
    */
-  onSelectCampaign: (campaignId: string) => void;
+  onOpenImage: (params: { blobPath: string; campaignId: string }) => void;
 }
 
 /**
  * Author detail page. Shows the author's avatar, name, handle, image count,
- * and a mini grid of all their attributed images. Clicking a thumbnail
- * navigates to that image's campaign view (no lightbox integration yet).
+ * and a mini grid of all their attributed images. Clicking a thumbnail opens
+ * the lightbox at that image (in its source campaign).
  *
  * Errors render an inline message rather than crashing the app — 404s from a
  * missing handle surface as "Failed to load author".
  */
-export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props) {
+export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
   const [data, setData] = useState<AuthorDetailResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -131,8 +130,8 @@ export default function AuthorDetail({ handle, onBack, onSelectCampaign }: Props
                   <button
                     type="button"
                     className="author-image-button"
-                    onClick={() => onSelectCampaign(image.campaignId)}
-                    aria-label={`Open campaign ${image.campaignId}`}
+                    onClick={() => onOpenImage({ blobPath: image.blobPath, campaignId: image.campaignId })}
+                    aria-label={`Open image ${image.fileName}`}
                   >
                     <img
                       src={image.src}

--- a/client/src/hooks/useCampaignLoader.ts
+++ b/client/src/hooks/useCampaignLoader.ts
@@ -100,12 +100,18 @@ export function useCampaignLoader(): CampaignLoaderState {
       }
 
       // loadedSrc stays null until preload completes; gallery renders loadedSrc||src so placeholders show nothing while the browser fetches each image.
+      // blobPath is carried even on placeholders so the App-level effect that
+      // opens the lightbox at a specific image (after navigating from the
+      // authors page) can match while images are still preloading and avoid a
+      // race where it sees the placeholder array first and clears the pending
+      // request prematurely.
       const placeholderImages = campaignImages.map((img: ApiImageData) => ({
         fileName: img.fileName,
         originalSrc: img.src,
         src: null,
         isLoading: true,
-        loadedSrc: null
+        loadedSrc: null,
+        blobPath: img.blobPath,
       }));
       setCurrentImages(placeholderImages);
 

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -16,6 +16,10 @@ export interface Campaign {
 export interface ApiImageData {
   fileName: string;
   src: string;
+  // Stable on-disk identifier (e.g. "avatars/Season4/CrossTheLine/abc.jpg").
+  // Optional for defensive compatibility with older responses; the campaign
+  // images endpoint always populates it.
+  blobPath?: string;
   // Populated by the server's attribution enrichment. Optional + nullable so
   // the client stays defensive against older responses or unresolved authors.
   author?: ImageAuthor | null;
@@ -28,6 +32,10 @@ export interface ImageData {
   originalSrc?: string;
   isLoading?: boolean;
   loadedSrc?: string | null;
+  // Stable on-disk identifier carried from the server response so we can match
+  // a specific image across views (e.g. opening the lightbox at the right
+  // image after navigating from the authors page).
+  blobPath?: string;
   // Carried through from the server's attribution enrichment so the lightbox
   // AUTHOR row can render without an extra lookup.
   author?: ImageAuthor | null;

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -53,7 +53,7 @@ describe('AuthorDetail', () => {
       <AuthorDetail
         handle="@Zort70"
         onBack={() => {}}
-        onSelectCampaign={() => {}}
+        onOpenImage={() => {}}
       />,
     );
 
@@ -75,23 +75,35 @@ describe('AuthorDetail', () => {
     expect(grid.querySelectorAll('img').length).toBe(2);
   });
 
-  it('navigates to the campaign when a thumbnail is clicked', async () => {
+  it('opens the lightbox for the clicked image (blobPath + campaignId)', async () => {
     globalThis.fetch = mockFetch(SAMPLE_DETAIL) as unknown as typeof fetch;
-    const onSelectCampaign = vi.fn();
+    const onOpenImage = vi.fn();
 
     render(
       <AuthorDetail
         handle="@Zort70"
         onBack={() => {}}
-        onSelectCampaign={onSelectCampaign}
+        onOpenImage={onOpenImage}
       />,
     );
 
     const grid = await screen.findByTestId('author-images-grid');
-    const firstButton = grid.querySelector('button')!;
-    fireEvent.click(firstButton);
+    const buttons = grid.querySelectorAll('button');
+    fireEvent.click(buttons[0]!);
 
-    expect(onSelectCampaign).toHaveBeenCalledWith('crosstheline');
+    expect(onOpenImage).toHaveBeenCalledWith({
+      blobPath: 'avatars/Season4/CrossTheLine/abc.jpg',
+      campaignId: 'crosstheline',
+    });
+
+    // Clicking a different thumbnail dispatches the matching blobPath, not the
+    // first image's. Guards against a regression where the click handler
+    // captures the wrong row from the map.
+    fireEvent.click(buttons[1]!);
+    expect(onOpenImage).toHaveBeenLastCalledWith({
+      blobPath: 'avatars/Season4/CrossTheLine/def.jpg',
+      campaignId: 'crosstheline',
+    });
   });
 
   it('clears stale data and error when the handle prop changes', async () => {
@@ -115,14 +127,14 @@ describe('AuthorDetail', () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { rerender } = render(
-      <AuthorDetail handle="@first" onBack={() => {}} onSelectCampaign={() => {}} />,
+      <AuthorDetail handle="@first" onBack={() => {}} onOpenImage={() => {}} />,
     );
     await screen.findByText('First Person');
 
     // Re-render with a different handle — the previous "First Person" header
     // and image grid should disappear immediately while the new fetch runs.
     rerender(
-      <AuthorDetail handle="@second" onBack={() => {}} onSelectCampaign={() => {}} />,
+      <AuthorDetail handle="@second" onBack={() => {}} onOpenImage={() => {}} />,
     );
     expect(screen.queryByText('First Person')).toBeNull();
     expect(screen.queryByTestId('author-images-grid')).toBeNull();
@@ -142,7 +154,7 @@ describe('AuthorDetail', () => {
       <AuthorDetail
         handle="@nope"
         onBack={() => {}}
-        onSelectCampaign={() => {}}
+        onOpenImage={() => {}}
       />,
     );
 


### PR DESCRIPTION
## Summary
- Clicking a thumbnail on `#authors/:handle` now opens the existing lightbox at that exact image instead of just navigating to the source campaign.
- `AuthorDetail` exposes `onOpenImage({ blobPath, campaignId })`; `App.tsx` stashes that as `pendingLightboxImage`, navigates to the campaign hash, and an effect matches `blobPath` against `currentImages` once the campaign finishes loading and calls `openLightbox(idx)`.
- If matching ever fails the pending state is cleared so the user lands on the campaign gallery rather than getting stuck (defensive fallback).
- `blobPath` is propagated through `ApiImageData` / `ImageData` and `useCampaignLoader` so the App-level matcher has a stable identifier.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 107 server + 604 client tests pass
- [x] `AuthorDetail.test.tsx` updated to assert the new `onOpenImage` contract for both the first and second thumbnails (guards against a stale-closure regression)
- [ ] Manual smoke: click an author handle → click a thumbnail → lightbox opens at the right image; cached-campaign and cold-load paths both work

Closes fringematrix5-rq6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)