### PR TITLE
fringematrix5-c320: link campaign rows to in-app campaign gallery

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -836,6 +836,17 @@ export default function App() {
         closeLightbox={closeLightbox}
         isAnimatingRef={isAnimatingRef}
         onOpenAuthorGallery={handleOpenAuthorGalleryFromLightbox}
+        onOpenCampaignGallery={(campaignId) => {
+          // Always close the lightbox; if the gallery is already showing this
+          // campaign the selectCampaign call is a no-op and we just return to
+          // the existing view. When author-browse mode (fringematrix5-ik5)
+          // lands and the lightbox can show images from a non-active
+          // campaign, this same branch will perform a real switch.
+          closeLightbox();
+          if (campaignId !== activeCampaignId) {
+            selectCampaign(campaignId);
+          }
+        }}
       />
 
       {/* Settings Modal */}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -578,6 +578,22 @@ export default function App() {
     openLightboxForCampaign,
   ]);
 
+  // Stable handler for the EPISODE NAME affordance in `LightboxDetails`.
+  // Hoisted into useCallback so `LightboxDetails` — which is React.memo'd —
+  // doesn't re-render on every App render just because a fresh inline arrow
+  // would change prop identity. (Spotted in Copilot review of fringematrix5-c320.)
+  const handleOpenCampaignGallery = useCallback((campaignId: string) => {
+    // Always close the lightbox; if the gallery is already showing this
+    // campaign the selectCampaign call is a no-op and we just return to
+    // the existing view. When author-browse mode (fringematrix5-ik5)
+    // lands and the lightbox can show images from a non-active
+    // campaign, this same branch will perform a real switch.
+    closeLightbox();
+    if (campaignId !== activeCampaignId) {
+      selectCampaign(campaignId);
+    }
+  }, [closeLightbox, activeCampaignId, selectCampaign]);
+
   // Centralized function to close all subwindows - add new subwindows here
   const closeAllSubwindows = useCallback(() => {
     if (isLightboxOpen) closeLightbox();
@@ -836,17 +852,7 @@ export default function App() {
         closeLightbox={closeLightbox}
         isAnimatingRef={isAnimatingRef}
         onOpenAuthorGallery={handleOpenAuthorGalleryFromLightbox}
-        onOpenCampaignGallery={(campaignId) => {
-          // Always close the lightbox; if the gallery is already showing this
-          // campaign the selectCampaign call is a no-op and we just return to
-          // the existing view. When author-browse mode (fringematrix5-ik5)
-          // lands and the lightbox can show images from a non-active
-          // campaign, this same branch will perform a real switch.
-          closeLightbox();
-          if (campaignId !== activeCampaignId) {
-            selectCampaign(campaignId);
-          }
-        }}
+        onOpenCampaignGallery={handleOpenCampaignGallery}
       />
 
       {/* Settings Modal */}

--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -29,6 +29,12 @@ interface Props {
    * LightboxDetails. See fringematrix5-4a6o.
    */
   onOpenAuthorGallery?: (handle: string) => void;
+  /**
+   * Forwarded to `LightboxDetails` so the EPISODE NAME affordance can close
+   * the lightbox and select the source campaign. See LightboxDetails for the
+   * full contract.
+   */
+  onOpenCampaignGallery?: (campaignId: string) => void;
 }
 
 export default function LightboxContainer({
@@ -41,6 +47,7 @@ export default function LightboxContainer({
   closeLightbox,
   isAnimatingRef,
   onOpenAuthorGallery,
+  onOpenCampaignGallery,
 }: Props) {
   const swipeRef = useRef<{ startX: number; startY: number; startTime: number } | null>(null);
   const infoBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -265,6 +272,7 @@ export default function LightboxContainer({
               campaign={activeCampaign}
               author={images[lightboxIndex]?.author ?? null}
               onOpenAuthorGallery={onOpenAuthorGallery}
+              onOpenCampaignGallery={onOpenCampaignGallery}
             />
           </aside>
         </div>
@@ -345,6 +353,7 @@ export default function LightboxContainer({
             campaign={activeCampaign}
             author={images[lightboxIndex]?.author ?? null}
             onOpenAuthorGallery={onOpenAuthorGallery}
+            onOpenCampaignGallery={onOpenCampaignGallery}
           />
         </div>
       )}

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -17,6 +17,18 @@ interface Props {
    * tests and any context where in-app author navigation isn't applicable.
    */
   onOpenAuthorGallery?: (handle: string) => void;
+  /**
+   * Called when the user activates the EPISODE NAME affordance. Receives the
+   * id of the image's source campaign. The handler is expected to close the
+   * lightbox and, if the gallery isn't already showing that campaign, switch
+   * to it. When omitted, the EPISODE NAME value renders as plain text.
+   *
+   * The callback signature takes a campaignId (rather than capturing the
+   * current `campaign.id` internally) so it stays correct once the lightbox
+   * begins displaying images from different campaigns — i.e. author-browse
+   * mode in fringematrix5-ik5.
+   */
+  onOpenCampaignGallery?: (campaignId: string) => void;
 }
 
 interface RowProps {
@@ -163,7 +175,7 @@ function AuthorRow({
  * author props haven't changed — e.g. during prev/next image navigation
  * within the same campaign.
  */
-function LightboxDetails({ campaign, author, onOpenAuthorGallery }: Props) {
+function LightboxDetails({ campaign, author, onOpenAuthorGallery, onOpenCampaignGallery }: Props) {
   if (!campaign) {
     return (
       <>
@@ -178,10 +190,28 @@ function LightboxDetails({ campaign, author, onOpenAuthorGallery }: Props) {
   const imdbId = extractImdbId(campaign.imdb_link);
   const imdbLinkText = imdbId ?? campaign.imdb_link ?? null;
 
+  const campaignId = campaign.id;
+  const handleOpenCampaign = onOpenCampaignGallery
+    ? () => onOpenCampaignGallery(campaignId)
+    : null;
+
   return (
     <>
       <div className="lightbox-details-heading">IMAGE DETAILS</div>
-      <Row label="EPISODE NAME">{campaign.episode}</Row>
+      <Row label="EPISODE NAME">
+        {handleOpenCampaign ? (
+          <button
+            type="button"
+            className="lightbox-details-link lightbox-details-campaign-link"
+            onClick={handleOpenCampaign}
+            aria-label={`View campaign gallery for ${campaign.episode}`}
+          >
+            {campaign.episode}
+          </button>
+        ) : (
+          campaign.episode
+        )}
+      </Row>
       <Row label="SEASON / NUMBER">{seasonNumberLabel}</Row>
       <Row label="AIR DATE">{campaign.date}</Row>
       <Row label="HASHTAG">{`#${campaign.hashtag}`}</Row>

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -200,9 +200,14 @@ function LightboxDetails({ campaign, author, onOpenAuthorGallery, onOpenCampaign
       <div className="lightbox-details-heading">IMAGE DETAILS</div>
       <Row label="EPISODE NAME">
         {handleOpenCampaign ? (
+          // Intentionally NOT given the `lightbox-details-link` class — that
+          // class is shared with external <a> anchors (e.g. IMDB) and an
+          // e2e test (lightbox-redesign.spec.ts) relies on it identifying
+          // the external link via `.first()`. We use a dedicated class
+          // here and inline the link-like styling in styles.css.
           <button
             type="button"
-            className="lightbox-details-link lightbox-details-campaign-link"
+            className="lightbox-details-campaign-link"
             onClick={handleOpenCampaign}
             aria-label={`View campaign gallery for ${campaign.episode}`}
           >

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -482,7 +482,10 @@ footer.navbar {
 .lightbox-details-external { font-size: 0.85em; }
 /* EPISODE NAME affordance — fringematrix5-c320. Resets default <button>
    chrome so the inline campaign-gallery link is visually consistent with
-   the IMDB anchor while remaining keyboard- and screen-reader-friendly. */
+   the IMDB anchor while remaining keyboard- and screen-reader-friendly.
+   Note: deliberately does NOT reuse the .lightbox-details-link class
+   because an e2e selector relies on that class identifying external <a>
+   anchors only. The visual rules are duplicated here on purpose. */
 .lightbox-details-campaign-link {
   background: transparent;
   border: 0;
@@ -491,7 +494,13 @@ footer.navbar {
   font: inherit;
   cursor: pointer;
   text-align: left;
+  color: var(--theme-accent);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
+.lightbox-details-campaign-link:hover { text-decoration: underline; }
 .lightbox-details-campaign-link:focus-visible {
   outline: 2px solid var(--theme-accent);
   outline-offset: 2px;

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -480,6 +480,22 @@ footer.navbar {
 }
 .lightbox-details-link:hover { text-decoration: underline; }
 .lightbox-details-external { font-size: 0.85em; }
+/* EPISODE NAME affordance — fringematrix5-c320. Resets default <button>
+   chrome so the inline campaign-gallery link is visually consistent with
+   the IMDB anchor while remaining keyboard- and screen-reader-friendly. */
+.lightbox-details-campaign-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+.lightbox-details-campaign-link:focus-visible {
+  outline: 2px solid var(--theme-accent);
+  outline-offset: 2px;
+}
 .lightbox-details-empty {
   color: rgba(255, 255, 255, 0.55);
   font-style: italic;

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -121,7 +121,14 @@ describe('LightboxDetails', () => {
       expect(onOpen).toHaveBeenCalledWith('crosstheline');
     });
 
-    it('is keyboard-activatable (Enter triggers click)', () => {
+    it('is focusable and uses a native <button> so the browser handles Enter/Space activation', () => {
+      // We intentionally do NOT dispatch a synthetic keydown here: jsdom
+      // does not translate Enter on a <button> into a click event, so a
+      // fake keypress would only test our scaffolding rather than the
+      // contract. The acceptance criterion ("Enter activates") is met by
+      // being a real <button> with type="button" and an onClick handler —
+      // real browsers perform the Enter/Space → click translation natively.
+      // (Copilot reviewer flagged the previous test's misleading name.)
       const onOpen = vi.fn();
       render(
         <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
@@ -129,14 +136,13 @@ describe('LightboxDetails', () => {
       const btn = screen.getByRole('button', {
         name: /view campaign gallery/i,
       }) as HTMLButtonElement;
+      // Focusable via .focus().
       btn.focus();
       expect(document.activeElement).toBe(btn);
-      // <button> elements natively activate onClick when Enter is pressed
-      // and the click is dispatched by the browser. In jsdom we simulate
-      // that by firing a click event directly — the production behaviour
-      // is covered by browser semantics for <button type="button">.
-      fireEvent.click(btn);
-      expect(onOpen).toHaveBeenCalledWith('crosstheline');
+      // Native <button>, not a div+role.
+      expect(btn.tagName).toBe('BUTTON');
+      // Not disabled.
+      expect(btn.hasAttribute('disabled')).toBe(false);
     });
 
     it('keeps the IMDB row as a real external anchor (not affected by the new affordance)', () => {

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -83,6 +83,74 @@ describe('LightboxDetails', () => {
     expect(screen.getByText(/no campaign selected/i)).toBeTruthy();
   });
 
+  describe('EPISODE NAME → campaign gallery link (fringematrix5-c320)', () => {
+    it('renders the episode name as plain text when no onOpenCampaignGallery handler is provided', () => {
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} />);
+      // No button-role element with the episode name.
+      expect(
+        screen.queryByRole('button', { name: /Back To Where You've Never Been/ })
+      ).toBeNull();
+      // The episode name is still rendered (as plain text).
+      expect(screen.getByText("Back To Where You've Never Been")).toBeTruthy();
+    });
+
+    it('renders the episode name as a button when onOpenCampaignGallery is provided', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery for back to where you've never been/i,
+      });
+      expect(btn).toBeTruthy();
+      expect(btn.tagName).toBe('BUTTON');
+      // Must be of type="button" so it never accidentally submits a form.
+      expect(btn.getAttribute('type')).toBe('button');
+    });
+
+    it('invokes onOpenCampaignGallery with the campaign id on click', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery/i,
+      });
+      fireEvent.click(btn);
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onOpen).toHaveBeenCalledWith('crosstheline');
+    });
+
+    it('is keyboard-activatable (Enter triggers click)', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery/i,
+      }) as HTMLButtonElement;
+      btn.focus();
+      expect(document.activeElement).toBe(btn);
+      // <button> elements natively activate onClick when Enter is pressed
+      // and the click is dispatched by the browser. In jsdom we simulate
+      // that by firing a click event directly — the production behaviour
+      // is covered by browser semantics for <button type="button">.
+      fireEvent.click(btn);
+      expect(onOpen).toHaveBeenCalledWith('crosstheline');
+    });
+
+    it('keeps the IMDB row as a real external anchor (not affected by the new affordance)', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const link = screen.getByRole('link', { name: /tt2125636/ });
+      expect(link.tagName).toBe('A');
+      expect(link.getAttribute('href')).toBe('http://www.imdb.com/title/tt2125636/');
+      expect(link.getAttribute('target')).toBe('_blank');
+    });
+  });
+
   describe('AUTHOR row', () => {
     const resolvedHigh: ImageAuthor = {
       handle: '@SarahProost',


### PR DESCRIPTION
## Bead

fringematrix5-c320: Info box: link campaign rows to in-app campaign gallery

## Summary

- Make the EPISODE NAME value in `LightboxDetails` a real `<button type="button">` that, when activated, closes the lightbox and selects the source campaign in the gallery.
- New optional `onOpenCampaignGallery: (campaignId: string) => void` prop threaded `App.tsx` → `LightboxContainer` → both `LightboxDetails` instances (inline sidebar + mobile drawer).
- App-level handler closes the lightbox and only calls `selectCampaign` when the requested id differs from the active one (no-op fast path for today's campaign-browse-only world, real switch once author-browse from fringematrix5-ik5 lands).
- Falls back to plain text when no handler is provided, so the component stays usable in isolation (existing tests still cover the no-handler path).
- IMDB row continues to render as an external `<a target="_blank">` — unchanged.
- Minimal CSS to reset default `<button>` chrome and add a `:focus-visible` outline, so the affordance reads as a link but keeps `<button>` keyboard semantics (Enter activates, focus trap picks it up automatically).
- 5 new tests cover: no-handler renders plain text, handler renders a `<button>`, click invokes with the campaign id, keyboard focus lands on the button, IMDB anchor is unaffected.

## Test plan

- [x] Local CI passes (`npm run typecheck && npm run test`: 107 server + 619 client, all green)
- [ ] Manual: open lightbox, click campaign affordance, lightbox closes and lands on that campaign's gallery; IMDB ↗ still opens externally

## Follow-ups

- The bead description mentions a possible "HASHTAG row affordance" alternative — not pursued; EPISODE NAME reads more naturally and one affordance per campaign avoids visual noise. Easy to revisit if UX prefers the hashtag.
- Author-browse mode (the actual cross-campaign switch path) is fringematrix5-ik5 — once it lands the same callback will perform the real navigation; no further plumbing should be needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Episode names displayed in lightbox image details are now interactive elements. Click on any episode name to instantly navigate to and view the associated campaign's complete gallery.

* **Improvements**
  * Enhanced keyboard navigation and screen reader accessibility support for improved usability of the new interactive episode name feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->