### PR TITLE
fringematrix5-4a6o: link AUTHOR row to in-app author gallery

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -527,6 +527,15 @@ export default function App() {
     }
   }, [isLightboxOpen, lightboxImageSource]);
 
+  // Handler for clicking the author handle inside the lightbox details panel
+  // (fringematrix5-4a6o). We close the lightbox first so its exit animation
+  // runs, then push the author-detail hash. closeLightbox is idempotent and
+  // hashchange-driven routing keeps the URL as the source of truth.
+  const handleOpenAuthorGalleryFromLightbox = useCallback((handle: string) => {
+    closeLightbox();
+    navigateToAuthorDetail(handle);
+  }, [closeLightbox, navigateToAuthorDetail]);
+
   // Open the lightbox at the image flagged by `pendingLightboxImage` once the
   // matching campaign has finished loading. We wait for `isCampaignLoading`
   // to flip false so the lightbox renders against the fully-loaded image
@@ -826,6 +835,7 @@ export default function App() {
         setLightboxIndex={setLightboxIndex}
         closeLightbox={closeLightbox}
         isAnimatingRef={isAnimatingRef}
+        onOpenAuthorGallery={handleOpenAuthorGalleryFromLightbox}
       />
 
       {/* Settings Modal */}

--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -22,6 +22,13 @@ interface Props {
   setLightboxIndex: React.Dispatch<React.SetStateAction<number>>;
   closeLightbox: () => void;
   isAnimatingRef: MutableRefObject<boolean>;
+  /**
+   * Optional callback invoked when the user clicks the author handle in the
+   * details sidebar / drawer. Implementations should close the lightbox
+   * (animated) and navigate to the author's gallery page. Passed through to
+   * LightboxDetails. See fringematrix5-4a6o.
+   */
+  onOpenAuthorGallery?: (handle: string) => void;
 }
 
 export default function LightboxContainer({
@@ -33,6 +40,7 @@ export default function LightboxContainer({
   setLightboxIndex,
   closeLightbox,
   isAnimatingRef,
+  onOpenAuthorGallery,
 }: Props) {
   const swipeRef = useRef<{ startX: number; startY: number; startTime: number } | null>(null);
   const infoBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -253,7 +261,11 @@ export default function LightboxContainer({
             ref={sidebarRef}
             aria-label="Image details"
           >
-            <LightboxDetails campaign={activeCampaign} author={images[lightboxIndex]?.author ?? null} />
+            <LightboxDetails
+              campaign={activeCampaign}
+              author={images[lightboxIndex]?.author ?? null}
+              onOpenAuthorGallery={onOpenAuthorGallery}
+            />
           </aside>
         </div>
 
@@ -329,7 +341,11 @@ export default function LightboxContainer({
           >
             ✕
           </button>
-          <LightboxDetails campaign={activeCampaign} author={images[lightboxIndex]?.author ?? null} />
+          <LightboxDetails
+            campaign={activeCampaign}
+            author={images[lightboxIndex]?.author ?? null}
+            onOpenAuthorGallery={onOpenAuthorGallery}
+          />
         </div>
       )}
     </div>

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -8,6 +8,15 @@ import { getInitials } from '../utils/author';
 interface Props {
   campaign: Campaign | null;
   author?: ImageAuthor | null;
+  /**
+   * When provided, the resolved-author handle renders as an in-app navigation
+   * button that invokes this callback with the (raw, unencoded) handle. The
+   * caller is expected to close the lightbox and navigate to the author's
+   * gallery page. When omitted, the handle is rendered as plain text (or, when
+   * a safe twitterUrl is available, as the legacy external link) — used by
+   * tests and any context where in-app author navigation isn't applicable.
+   */
+  onOpenAuthorGallery?: (handle: string) => void;
 }
 
 interface RowProps {
@@ -32,12 +41,49 @@ function Row({ label, children }: RowProps) {
  *   3. No data (author null OR handle null AND no candidates) → return null
  *      so the caller can omit the row entirely.
  */
-function AuthorRow({ author }: { author: ImageAuthor }) {
+function AuthorRow({
+  author,
+  onOpenAuthorGallery,
+}: {
+  author: ImageAuthor;
+  onOpenAuthorGallery?: (handle: string) => void;
+}) {
   // Case 1: resolved (we have a handle).
   if (author.handle) {
     const initials = getInitials(author.handle) || '?';
     const isMedium = author.confidence === 'medium';
     const hasSafeUrl = isSafeUrl(author.twitterUrl);
+    const handle = author.handle;
+
+    // Design choice: when in-app navigation is available, the handle text
+    // becomes a button that navigates to the author's gallery page. The
+    // external Twitter link is preserved as a small icon-only link next to
+    // it, so users keep both affordances. When the callback isn't provided
+    // (legacy / test contexts), fall back to the previous render: the entire
+    // handle is the external link, or plain text when no safe URL exists.
+    const handleNode = onOpenAuthorGallery ? (
+      <button
+        type="button"
+        className="lightbox-details-link lightbox-author-handle lightbox-author-handle--button"
+        onClick={() => onOpenAuthorGallery(handle)}
+      >
+        {handle}
+      </button>
+    ) : hasSafeUrl && author.twitterUrl ? (
+      <a
+        className="lightbox-details-link lightbox-author-handle"
+        href={author.twitterUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {handle}
+        <span className="lightbox-details-external" aria-hidden={true}>↗</span>
+        <span className="visually-hidden"> (opens in new tab)</span>
+      </a>
+    ) : (
+      <span className="lightbox-author-handle">{handle}</span>
+    );
+
     return (
       <div className="lightbox-details-row lightbox-details-author">
         <div className="lightbox-details-label">AUTHOR</div>
@@ -49,20 +95,18 @@ function AuthorRow({ author }: { author: ImageAuthor }) {
           >
             {initials}
           </span>
-          {hasSafeUrl && author.twitterUrl ? (
+          {handleNode}
+          {onOpenAuthorGallery && hasSafeUrl && author.twitterUrl ? (
             <a
-              className="lightbox-details-link lightbox-author-handle"
+              className="lightbox-details-link lightbox-author-twitter"
               href={author.twitterUrl}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`Open ${handle} on Twitter (opens in new tab)`}
             >
-              {author.handle}
               <span className="lightbox-details-external" aria-hidden={true}>↗</span>
-              <span className="visually-hidden"> (opens in new tab)</span>
             </a>
-          ) : (
-            <span className="lightbox-author-handle">{author.handle}</span>
-          )}
+          ) : null}
           {isMedium ? (
             <span
               className="lightbox-author-badge"
@@ -119,7 +163,7 @@ function AuthorRow({ author }: { author: ImageAuthor }) {
  * author props haven't changed — e.g. during prev/next image navigation
  * within the same campaign.
  */
-function LightboxDetails({ campaign, author }: Props) {
+function LightboxDetails({ campaign, author, onOpenAuthorGallery }: Props) {
   if (!campaign) {
     return (
       <>
@@ -155,7 +199,7 @@ function LightboxDetails({ campaign, author }: Props) {
           </a>
         </Row>
       ) : null}
-      {author ? <AuthorRow author={author} /> : null}
+      {author ? <AuthorRow author={author} onOpenAuthorGallery={onOpenAuthorGallery} /> : null}
     </>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -520,6 +520,24 @@ footer.navbar {
 .lightbox-author-handle {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
+/* fringematrix5-4a6o: the handle renders as a <button> when in-app author
+   navigation is available. Strip browser button chrome so it visually matches
+   the surrounding link-styled handle. */
+.lightbox-author-handle--button {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+}
+.lightbox-author-twitter {
+  display: inline-flex;
+  align-items: center;
+  color: var(--theme-accent);
+  text-decoration: none;
+}
+.lightbox-author-twitter:hover { text-decoration: underline; }
 .lightbox-author-candidates {
   color: rgba(255, 255, 255, 0.65);
   font-size: 13px;

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import LightboxDetails from '../src/components/LightboxDetails';
 import type { Campaign, ImageAuthor } from '../src/types/api';
@@ -161,6 +161,115 @@ describe('LightboxDetails', () => {
       expect(screen.getByText('CH')).toBeTruthy();
       expect(screen.getByText('@cheribot')).toBeTruthy();
       expect(screen.queryByRole('link', { name: /cheribot/ })).toBeNull();
+    });
+
+    describe('onOpenAuthorGallery (fringematrix5-4a6o)', () => {
+      it('renders the handle as a button that fires onOpenAuthorGallery when provided', () => {
+        const onOpen = vi.fn();
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={resolvedHigh}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const handleBtn = screen.getByRole('button', { name: /SarahProost/ });
+        expect(handleBtn.tagName).toBe('BUTTON');
+        fireEvent.click(handleBtn);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onOpen).toHaveBeenCalledWith('@SarahProost');
+      });
+
+      it('still exposes the external Twitter link as a separate icon when callback is provided', () => {
+        const onOpen = vi.fn();
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={resolvedHigh}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const twitterLink = screen.getByRole('link', { name: /Twitter/i });
+        expect(twitterLink.getAttribute('href')).toBe('https://twitter.com/SarahProost');
+        expect(twitterLink.getAttribute('target')).toBe('_blank');
+        expect(twitterLink.getAttribute('rel')).toBe('noopener noreferrer');
+      });
+
+      it('omits the Twitter icon when twitterUrl is missing, even with callback provided', () => {
+        const onOpen = vi.fn();
+        const noUrl: ImageAuthor = {
+          handle: '@cheribot',
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'high',
+          candidates: [],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={noUrl}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        expect(screen.getByRole('button', { name: /cheribot/ })).toBeTruthy();
+        expect(screen.queryByRole('link', { name: /Twitter/i })).toBeNull();
+      });
+
+      it('omits the Twitter icon when twitterUrl is unsafe, even with callback provided', () => {
+        const onOpen = vi.fn();
+        const unsafe: ImageAuthor = {
+          handle: '@evil',
+          displayName: null,
+          // eslint-disable-next-line no-script-url
+          twitterUrl: 'javascript:alert(1)' as string,
+          confidence: 'high',
+          candidates: [],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={unsafe}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        expect(screen.getByRole('button', { name: /evil/ })).toBeTruthy();
+        expect(screen.queryByRole('link', { name: /Twitter/i })).toBeNull();
+      });
+
+      it('does not render a handle button for the unresolved (candidates-only) case', () => {
+        const onOpen = vi.fn();
+        const unresolvedAuthor: ImageAuthor = {
+          handle: null,
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'unresolved',
+          candidates: ['@AliceA', '@BobB'],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={unresolvedAuthor}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        expect(screen.queryByRole('button', { name: /AliceA|BobB/ })).toBeNull();
+        // Callback never invoked just by rendering.
+        expect(onOpen).not.toHaveBeenCalled();
+      });
+
+      it('handle button is focusable (participates in lightbox focus trap)', () => {
+        const onOpen = vi.fn();
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={resolvedHigh}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const handleBtn = screen.getByRole('button', { name: /SarahProost/ });
+        handleBtn.focus();
+        expect(document.activeElement).toBe(handleBtn);
+      });
     });
 
     it('rejects unsafe twitterUrl values and renders the handle as plain text', () => {

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -104,13 +104,18 @@ test.describe('Lightbox AUTHOR row — resolved (high confidence)', () => {
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveText('ZO');
 
-    // Handle rendered as a link pointing at the canonical Twitter URL.
-    const handleLink = authorRow.getByRole('link', { name: /Zort70/ });
-    await expect(handleLink).toBeVisible();
-    await expect(handleLink).toContainText('@Zort70');
-    await expect(handleLink).toHaveAttribute('href', 'https://twitter.com/Zort70');
-    await expect(handleLink).toHaveAttribute('target', '_blank');
-    await expect(handleLink).toHaveAttribute('rel', /noopener/);
+    // Handle rendered as an in-app navigation button (fringematrix5-4a6o).
+    // The handle text itself is now a <button> that opens the author gallery;
+    // the external Twitter link lives beside it as an icon-only <a>.
+    const handleButton = authorRow.getByRole('button', { name: /Zort70/ });
+    await expect(handleButton).toBeVisible();
+    await expect(handleButton).toContainText('@Zort70');
+
+    const twitterLink = authorRow.getByRole('link', { name: /Zort70/ });
+    await expect(twitterLink).toBeVisible();
+    await expect(twitterLink).toHaveAttribute('href', 'https://twitter.com/Zort70');
+    await expect(twitterLink).toHaveAttribute('target', '_blank');
+    await expect(twitterLink).toHaveAttribute('rel', /noopener/);
 
     // High-confidence images do NOT get the 'uncertain' badge.
     await expect(authorRow.locator('.lightbox-author-badge')).toHaveCount(0);


### PR DESCRIPTION
## Bead

fringematrix5-4a6o: Info box: link AUTHOR row to in-app author gallery

## Summary

- The lightbox AUTHOR row's handle now navigates to the in-app author gallery (`#authors/{handle}`) instead of (only) the external Twitter URL.
- Design choice: the handle renders as a `<button>` (in-app nav). The external `↗` is preserved as a separate small icon link beside it, so both affordances stay reachable from the same row.
- Click composes `closeLightbox()` + `navigateToAuthorDetail(handle)`, reusing the existing lightbox exit animation.
- Prop wiring: `App.tsx` -> `LightboxContainer` -> `LightboxDetails` via a new optional `onOpenAuthorGallery` callback. Both the inline sidebar and the mobile drawer instance get the callback.
- The button is a standard focusable element, so it participates in the existing lightbox focus trap (`FOCUSABLE_SELECTOR`) automatically. Verified focusable via a new test.
- Unresolved (candidates-only) case is unchanged — no clickable handle, no link.
- Legacy render preserved when the callback is absent (keeps existing tests / callers working).

## Test plan

- [x] Local CI passes (`npm run typecheck && npm run test`) — 107 server + 620 client tests pass.
- [x] New unit tests for: handle-as-button, click invokes callback with handle, separate Twitter icon link still works, unsafe / missing URL omits the icon, unresolved case has no button, button is focusable.
- [ ] Manual: open lightbox on an image with a resolved author, click the handle, lands on author detail page with lightbox closed; Twitter `↗` icon still opens externally in a new tab.

## Follow-ups

None — campaign-row gallery link is tracked separately in `fringematrix5-c320`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop