### PR TITLE
fringematrix5-uyp: generalize lightbox image source

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,8 @@ import type {
   CampaignsResponse,
   BuildInfoResponse,
   ContentPage,
-  ContentResponse
+  ContentResponse,
+  LightboxImageSource,
 } from './types/api';
 
 export default function App() {
@@ -49,6 +50,16 @@ export default function App() {
   } = useCampaignLoader();
   const [lightboxIndex, setLightboxIndex] = useState<number>(0);
   const [isLightboxOpen, setIsLightboxOpen] = useState<boolean>(false);
+  // The image list currently being browsed in the lightbox. Set by whichever
+  // view opens the lightbox (campaign gallery vs. author detail) so the
+  // lightbox can navigate across an arbitrary list — not just the active
+  // campaign's images. Null when the lightbox has never been opened or has
+  // been closed; we fall back to `currentImages` in that case so render code
+  // does not have to handle a null source separately.
+  //
+  // Author-mode source-setters live in fringematrix5-ik5; today only the
+  // campaign-mode setter (openLightboxForCampaign below) is wired up.
+  const [lightboxImageSource, setLightboxImageSource] = useState<LightboxImageSource | null>(null);
   // When the user clicks a thumbnail on the author-detail page we navigate to
   // the containing campaign and remember which image to open in the lightbox.
   // An effect below watches `currentImages` and opens the lightbox once the
@@ -475,9 +486,15 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Images the lightbox is currently navigating. When a source is set we use
+  // it; otherwise we fall back to the active campaign's images so existing
+  // callers (gallery thumbnail clicks) keep working without explicitly
+  // setting a source first.
+  const lightboxImages = lightboxImageSource?.images ?? currentImages;
+
   // Lightbox animations are provided by the useLightboxAnimations hook
   const { openLightbox, closeLightbox, isAnimatingRef } = useLightboxAnimations({
-    images: currentImages,
+    images: lightboxImages,
     isLightboxOpen,
     lightboxIndex,
     reduceMotion,
@@ -486,6 +503,18 @@ export default function App() {
     setHideLightboxImage,
     getThumbElement,
   });
+
+  // Opens the lightbox against the currently active campaign's images. This
+  // is the gallery-grid path; author-detail uses its own opener (added in
+  // fringematrix5-ik5). Sets the campaign-mode source before delegating to
+  // the animation hook's openLightbox so the lightbox renders against the
+  // same array we just stamped into state.
+  const openLightboxForCampaign = useCallback((index: number, thumbEl?: HTMLElement) => {
+    if (activeCampaignId) {
+      setLightboxImageSource({ kind: 'campaign', images: currentImages, campaignId: activeCampaignId });
+    }
+    openLightbox(index, thumbEl);
+  }, [activeCampaignId, currentImages, openLightbox]);
 
   // Open the lightbox at the image flagged by `pendingLightboxImage` once the
   // matching campaign has finished loading. We wait for `isCampaignLoading`
@@ -517,7 +546,7 @@ export default function App() {
       (img) => img.blobPath === pendingLightboxImage.blobPath,
     );
     if (idx >= 0) {
-      openLightbox(idx);
+      openLightboxForCampaign(idx);
     }
     setPendingLightboxImage(null);
   }, [
@@ -526,7 +555,7 @@ export default function App() {
     activeCampaignId,
     isCampaignLoading,
     route,
-    openLightbox,
+    openLightboxForCampaign,
   ]);
 
   // Centralized function to close all subwindows - add new subwindows here
@@ -744,7 +773,7 @@ export default function App() {
             ref={galleryGridRef}
             images={currentImages}
             hasCampaign={!!activeCampaign}
-            onImageClick={openLightbox}
+            onImageClick={openLightboxForCampaign}
           />
         </main>
       )}
@@ -778,7 +807,7 @@ export default function App() {
       </footer>
 
       <LightboxContainer
-        images={currentImages}
+        images={lightboxImages}
         lightboxIndex={lightboxIndex}
         isLightboxOpen={isLightboxOpen}
         hideLightboxImage={hideLightboxImage}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -516,6 +516,17 @@ export default function App() {
     openLightbox(index, thumbEl);
   }, [activeCampaignId, currentImages, openLightbox]);
 
+  // Clear the lightbox source once the lightbox has fully closed so we never
+  // hand stale (e.g. a previous campaign's) images to the next open. Safe to
+  // run here: closeLightbox only flips `isLightboxOpen` to false from its
+  // finally block, after all close animations have settled, so nothing is
+  // still reading `lightboxImages` when this fires.
+  useEffect(() => {
+    if (!isLightboxOpen && lightboxImageSource) {
+      setLightboxImageSource(null);
+    }
+  }, [isLightboxOpen, lightboxImageSource]);
+
   // Open the lightbox at the image flagged by `pendingLightboxImage` once the
   // matching campaign has finished loading. We wait for `isCampaignLoading`
   // to flip false so the lightbox renders against the fully-loaded image

--- a/client/src/hooks/useCampaignLoader.ts
+++ b/client/src/hooks/useCampaignLoader.ts
@@ -105,6 +105,10 @@ export function useCampaignLoader(): CampaignLoaderState {
       // authors page) can match while images are still preloading and avoid a
       // race where it sees the placeholder array first and clears the pending
       // request prematurely.
+      // campaignId is populated here from the active load's `id` so the
+      // lightbox can resolve the source campaign per-image without an extra
+      // lookup. The API does not echo the campaign id in CampaignImagesResponse
+      // (it's already in the request path), so we stamp it on the client.
       const placeholderImages = campaignImages.map((img: ApiImageData) => ({
         fileName: img.fileName,
         originalSrc: img.src,
@@ -112,6 +116,7 @@ export function useCampaignLoader(): CampaignLoaderState {
         isLoading: true,
         loadedSrc: null,
         blobPath: img.blobPath,
+        campaignId: id,
       }));
       setCurrentImages(placeholderImages);
 
@@ -123,7 +128,8 @@ export function useCampaignLoader(): CampaignLoaderState {
       const fullyLoadedImages = campaignImages.map((img: ApiImageData) => ({
         ...img,
         isLoading: false,
-        loadedSrc: img.src
+        loadedSrc: img.src,
+        campaignId: id,
       }));
 
       setCurrentImages(fullyLoadedImages);

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -23,6 +23,12 @@ export interface ApiImageData {
   // Populated by the server's attribution enrichment. Optional + nullable so
   // the client stays defensive against older responses or unresolved authors.
   author?: ImageAuthor | null;
+  // Source campaign id for the image. Author-detail responses populate this
+  // server-side so the lightbox can resolve the source campaign per-image when
+  // browsing across campaigns. Campaign-image responses do NOT populate this
+  // field; the client populates it from the active campaign id when mapping
+  // ApiImageData -> ImageData.
+  campaignId?: string;
 }
 
 // Our internal state can have loading states with null src
@@ -39,6 +45,11 @@ export interface ImageData {
   // Carried through from the server's attribution enrichment so the lightbox
   // AUTHOR row can render without an extra lookup.
   author?: ImageAuthor | null;
+  // Source campaign id for the image. Populated for both campaign-mode
+  // (from the active campaign id) and author-mode (from the author detail
+  // response). Optional + defensive: lightbox consumers that need it must
+  // tolerate older responses where it is missing.
+  campaignId?: string;
 }
 
 export interface BuildInfo {
@@ -91,3 +102,17 @@ export interface AuthorDetailResponse {
     confidence: AttributionConfidence;
   }>;
 }
+
+// Discriminated union describing the image list currently being browsed in
+// the lightbox. The lightbox itself only cares about the `images` array for
+// prev/next/swipe/arrow/counter behavior — the `kind` + extra fields let
+// downstream consumers (e.g. LightboxDetails) resolve view-specific context
+// such as the source campaign or the originating author handle.
+//
+// Today the App opens the lightbox in `campaign` mode from the gallery grid.
+// `author` mode is reserved for the upcoming author-browse flow (filed under
+// fringematrix5-ik5) where the user pages through one author's images across
+// multiple campaigns.
+export type LightboxImageSource =
+  | { kind: 'campaign'; images: ImageData[]; campaignId: string }
+  | { kind: 'author'; images: ImageData[]; handle: string };

--- a/client/test/useCampaignLoader.test.ts
+++ b/client/test/useCampaignLoader.test.ts
@@ -660,3 +660,48 @@ describe('useCampaignLoader — selectCampaign cache-hit (renderHook)', () => {
     expect(result.current.isCampaignLoading).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 10. campaignId stamping (fringematrix5-uyp)
+// ---------------------------------------------------------------------------
+
+describe('useCampaignLoader — campaignId stamping', () => {
+  it('stamps the loading campaign id onto every fully-loaded ImageData', async () => {
+    fetchSpy.mockResolvedValueOnce(makeImagesResponse([
+      { fileName: 'a.jpg', src: 'https://cdn.example.com/a.jpg' },
+      { fileName: 'b.jpg', src: 'https://cdn.example.com/b.jpg' },
+    ]));
+
+    const { result } = renderHook(() => useCampaignLoader());
+    const controller = new AbortController();
+
+    await act(async () => {
+      await result.current.loadCampaignImages('S04E11', controller.signal);
+    });
+
+    expect(result.current.currentImages).toHaveLength(2);
+    expect(result.current.currentImages[0].campaignId).toBe('S04E11');
+    expect(result.current.currentImages[1].campaignId).toBe('S04E11');
+  });
+
+  it('stamps the campaign id even when an image errors during preload', async () => {
+    // Source mapping must be independent of preload outcomes — the fully-
+    // loaded mapping runs even when hasError=true.
+    imageFireMap.set('https://cdn.example.com/bad.jpg', 'error');
+
+    fetchSpy.mockResolvedValueOnce(makeImagesResponse([
+      { fileName: 'bad.jpg', src: 'https://cdn.example.com/bad.jpg' },
+    ]));
+
+    const { result } = renderHook(() => useCampaignLoader());
+    const controller = new AbortController();
+
+    await act(async () => {
+      await result.current.loadCampaignImages('S05E01', controller.signal);
+    });
+
+    expect(result.current.campaignLoadError).toBe(true);
+    expect(result.current.currentImages).toHaveLength(1);
+    expect(result.current.currentImages[0].campaignId).toBe('S05E01');
+  });
+});


### PR DESCRIPTION
## Bead

fringematrix5-uyp: Generalize lightbox to browse arbitrary image lists (campaign or author)

## Summary

- Add optional `campaignId` to `ApiImageData`/`ImageData` so the lightbox can resolve the source campaign per-image. `useCampaignLoader` stamps the loading campaign id onto both placeholder and fully-loaded entries (the API does not echo it in the response body).
- Add `LightboxImageSource` discriminated union (`campaign` | `author`) and a `lightboxImageSource` state in `App.tsx` next to `lightboxIndex` / `isLightboxOpen`.
- Derive `lightboxImages` from the source (falling back to `currentImages`) and route it into both `useLightboxAnimations` and `LightboxContainer`.
- Add `openLightboxForCampaign` that stamps the campaign-mode source before delegating to the animation hook's `openLightbox`; gallery thumbnails and the `pendingLightboxImage` flow now go through it.
- `LightboxContainer`'s prev/next/swipe/arrow/counter behavior is unchanged — only the array driving it can now span campaigns.

## Test plan

- [x] Local CI passes (`npm run typecheck && npm test`) — 616 client tests, 107 server tests.
- [x] Added two `useCampaignLoader` tests pinning the `campaignId` stamping behavior (happy path + image-error path).
- [ ] Existing campaign-gallery lightbox e2e behavior unchanged (relies on CI Playwright run).

## Follow-ups

- `fringematrix5-ik5` opens author-detail thumbnails in author-browse mode and wires the `author`-kind source-setter / removes `pendingLightboxImage`.
- `fringematrix5-pyd` updates `LightboxDetails` to resolve the active campaign per-image in author-browse mode using `image.campaignId`.

Both downstream beads were already blocked on this one and are unchanged.

Generated with [Claude Code](https://claude.com/claude-code) via beads-loop