### PR TITLE
fringematrix5-pyd: resolve lightbox campaign per-image

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -832,6 +832,7 @@ export default function App() {
         isLightboxOpen={isLightboxOpen}
         hideLightboxImage={hideLightboxImage}
         activeCampaign={activeCampaign}
+        campaigns={campaigns}
         setLightboxIndex={setLightboxIndex}
         closeLightbox={closeLightbox}
         isAnimatingRef={isAnimatingRef}

--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
 import type { Campaign, ImageData } from '../types/api';
 import LightboxDetails from './LightboxDetails';
@@ -18,7 +18,24 @@ interface Props {
   lightboxIndex: number;
   isLightboxOpen: boolean;
   hideLightboxImage: boolean;
+  /**
+   * The campaign currently selected in the app shell. Used as the default /
+   * fallback for the IMAGE DETAILS panel when an image carries no
+   * `campaignId` (legacy path) or when its `campaignId` isn't in the loaded
+   * `campaigns` list (defensive fallback). In campaign-browse mode every
+   * image's `campaignId` matches this campaign, so the visible behavior is
+   * unchanged. In author-browse mode (fringematrix5-ik5) images can come
+   * from different campaigns, so the per-image lookup below produces the
+   * correct campaign for each navigation step. See fringematrix5-pyd.
+   */
   activeCampaign: Campaign | null;
+  /**
+   * Full list of campaigns loaded at app mount. Used to resolve each
+   * image's source campaign by id so the IMAGE DETAILS panel updates as
+   * the user navigates across images that may belong to different
+   * campaigns. See fringematrix5-pyd.
+   */
+  campaigns: Campaign[];
   setLightboxIndex: React.Dispatch<React.SetStateAction<number>>;
   closeLightbox: () => void;
   isAnimatingRef: MutableRefObject<boolean>;
@@ -37,11 +54,32 @@ export default function LightboxContainer({
   isLightboxOpen,
   hideLightboxImage,
   activeCampaign,
+  campaigns,
   setLightboxIndex,
   closeLightbox,
   isAnimatingRef,
   onOpenAuthorGallery,
 }: Props) {
+  // Index campaigns by id once per render of `campaigns` so the per-image
+  // lookup below is O(1). Memoizing also stabilizes the map reference so
+  // the resolved campaign reference stays equal across image navigation
+  // within a single source campaign — preserving LightboxDetails' memo
+  // benefits.
+  const campaignsById = useMemo(() => {
+    const map = new Map<string, Campaign>();
+    for (const c of campaigns) map.set(c.id, c);
+    return map;
+  }, [campaigns]);
+
+  // Resolve the campaign for the currently-visible image. Falls back to
+  // `activeCampaign` when the image has no `campaignId` (older / synthetic
+  // sources) or when the id doesn't match a loaded campaign — both are
+  // defensive paths; in normal operation every image carries a valid
+  // `campaignId` stamped by useCampaignLoader (fringematrix5-uyp).
+  const currentImage = images[lightboxIndex];
+  const currentCampaign: Campaign | null = currentImage?.campaignId
+    ? campaignsById.get(currentImage.campaignId) ?? activeCampaign
+    : activeCampaign;
   const swipeRef = useRef<{ startX: number; startY: number; startTime: number } | null>(null);
   const infoBtnRef = useRef<HTMLButtonElement | null>(null);
   const drawerCloseBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -262,7 +300,7 @@ export default function LightboxContainer({
             aria-label="Image details"
           >
             <LightboxDetails
-              campaign={activeCampaign}
+              campaign={currentCampaign}
               author={images[lightboxIndex]?.author ?? null}
               onOpenAuthorGallery={onOpenAuthorGallery}
             />

--- a/client/src/components/LightboxContainer.tsx
+++ b/client/src/components/LightboxContainer.tsx
@@ -301,7 +301,7 @@ export default function LightboxContainer({
           >
             <LightboxDetails
               campaign={currentCampaign}
-              author={images[lightboxIndex]?.author ?? null}
+              author={currentImage?.author ?? null}
               onOpenAuthorGallery={onOpenAuthorGallery}
             />
           </aside>
@@ -380,8 +380,8 @@ export default function LightboxContainer({
             ✕
           </button>
           <LightboxDetails
-            campaign={activeCampaign}
-            author={images[lightboxIndex]?.author ?? null}
+            campaign={currentCampaign}
+            author={currentImage?.author ?? null}
             onOpenAuthorGallery={onOpenAuthorGallery}
           />
         </div>


### PR DESCRIPTION
## Bead

fringematrix5-pyd: LightboxDetails: resolve active campaign per-image in author-browse mode

## Summary

- `LightboxContainer` now resolves the source campaign for the currently visible image via the per-image `campaignId` (added in fringematrix5-uyp), then passes the resolved `Campaign | null` to both `LightboxDetails` renders (inline sidebar + mobile drawer).
- Took option A: new `campaigns: Campaign[]` prop on the container alongside the existing `activeCampaign`. Indexed by id via `useMemo(Map)` so the per-image lookup is O(1) and the resolved reference stays stable within a single source campaign (preserves `React.memo` benefits on `LightboxDetails`).
- Defensive fallback: when an image has no `campaignId`, or its id isn't in the loaded list, falls back to `activeCampaign` — so campaign-browse mode behavior is unchanged and the existing empty-state line still appears if there's truly no campaign.
- `App.tsx` change limited to passing one extra prop, keeping the footprint minimal for the upcoming fringematrix5-ik5 rebase.

## Test plan

- [x] Local CI passes (`npm run typecheck && npm run test` — 622 client tests, 107 server tests)
- [x] Existing campaign-gallery navigation: EPISODE NAME etc. unchanged (every image in campaign-browse mode shares `activeCampaignId` so resolved campaign equals `activeCampaign`)
- [ ] Manual: open lightbox, advance images — details still match active campaign (no per-image variation yet, since author-browse mode lands in fringematrix5-ik5)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop