### PR TITLE
fringematrix5-ik5: open author-detail thumbnails in author-browse mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ import type {
   BuildInfoResponse,
   ContentPage,
   ContentResponse,
+  ImageData,
   LightboxImageSource,
 } from './types/api';
 
@@ -57,17 +58,9 @@ export default function App() {
   // been closed; we fall back to `currentImages` in that case so render code
   // does not have to handle a null source separately.
   //
-  // Author-mode source-setters live in fringematrix5-ik5; today only the
-  // campaign-mode setter (openLightboxForCampaign below) is wired up.
+  // Both source kinds are wired up: campaign-mode via openLightboxForCampaign
+  // and author-mode via openLightboxForAuthor (fringematrix5-ik5).
   const [lightboxImageSource, setLightboxImageSource] = useState<LightboxImageSource | null>(null);
-  // When the user clicks a thumbnail on the author-detail page we navigate to
-  // the containing campaign and remember which image to open in the lightbox.
-  // An effect below watches `currentImages` and opens the lightbox once the
-  // campaign has finished loading and the matching image is present. Stored
-  // as state (not a ref) so React re-renders trigger the effect.
-  const [pendingLightboxImage, setPendingLightboxImage] = useState<
-    { blobPath: string; campaignId: string } | null
-  >(null);
   const [hideLightboxImage, setHideLightboxImage] = useState<boolean>(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
   const [isBuildInfoOpen, setIsBuildInfoOpen] = useState<boolean>(false);
@@ -136,23 +129,6 @@ export default function App() {
   const navigateToAuthorDetail = useCallback((handle: string) => {
     window.location.hash = `authors/${encodeURIComponent(handle)}`;
   }, []);
-  // Click handler for author-detail thumbnails. Navigates to the source
-  // campaign and stashes the target image so the effect below can open the
-  // lightbox once `currentImages` arrives.
-  //
-  // Defensive: if matching ever fails (e.g. blobPath mismatch from an older
-  // server build), the effect simply clears `pendingLightboxImage` and the
-  // user lands on the campaign gallery rather than getting stuck.
-  const openImageFromAuthorPage = useCallback(
-    ({ blobPath, campaignId }: { blobPath: string; campaignId: string }) => {
-      setPendingLightboxImage({ blobPath, campaignId });
-      // Setting the hash drives the same route-sync effect that
-      // navigateToCampaign uses; the campaign loader will fire and
-      // `currentImages` updates downstream.
-      window.location.hash = campaignId;
-    },
-    [],
-  );
   const navigateToGalleryHome = useCallback(() => {
     // Drop the hash entirely so the gallery view falls back to its default
     // campaign on next mount; for the current session we just clear route.
@@ -516,6 +492,21 @@ export default function App() {
     openLightbox(index, thumbEl);
   }, [activeCampaignId, currentImages, openLightbox]);
 
+  // Opens the lightbox against an author's image list (author-browse mode,
+  // fringematrix5-ik5). The images may span multiple campaigns; each carries
+  // its own `campaignId` and a synthesized `author` block so LightboxDetails
+  // resolves the source campaign and AUTHOR row per-image as the user pages.
+  //
+  // No thumb element is passed: the close animation would otherwise try to
+  // collapse the image back to the originating thumbnail. The author-detail
+  // grid is still mounted underneath the lightbox, so closing returns the
+  // user there directly without a return-flight animation — the existing
+  // useLightboxAnimations close path tolerates a null/missing thumb.
+  const openLightboxForAuthor = useCallback((images: ImageData[], index: number, handle: string) => {
+    setLightboxImageSource({ kind: 'author', images, handle });
+    openLightbox(index);
+  }, [openLightbox]);
+
   // Clear the lightbox source once the lightbox has fully closed so we never
   // hand stale (e.g. a previous campaign's) images to the next open. Safe to
   // run here: closeLightbox only flips `isLightboxOpen` to false from its
@@ -535,48 +526,6 @@ export default function App() {
     closeLightbox();
     navigateToAuthorDetail(handle);
   }, [closeLightbox, navigateToAuthorDetail]);
-
-  // Open the lightbox at the image flagged by `pendingLightboxImage` once the
-  // matching campaign has finished loading. We wait for `isCampaignLoading`
-  // to flip false so the lightbox renders against the fully-loaded image
-  // array (placeholder rows have `src: null` and would briefly flash blank).
-  //
-  // Defensive: if `currentImages` contains no entry whose blobPath matches we
-  // still clear `pendingLightboxImage` so a transient mismatch does not trap
-  // the user in a half-open state — they land on the campaign gallery and
-  // can find the image manually.
-  //
-  // The `activeCampaignId === pendingLightboxImage.campaignId` guard prevents
-  // us from opening the lightbox on the wrong campaign mid-switch (e.g. if
-  // the user clicks one author thumbnail and then another while the first
-  // campaign is still loading).
-  useEffect(() => {
-    if (!pendingLightboxImage) return;
-    // If the user navigated away from the gallery before the campaign
-    // finished loading (e.g. back to the authors index), drop the pending
-    // request so we don't pop a lightbox over a non-gallery view.
-    if (route.type !== 'gallery') {
-      setPendingLightboxImage(null);
-      return;
-    }
-    if (activeCampaignId !== pendingLightboxImage.campaignId) return;
-    if (isCampaignLoading) return;
-    if (currentImages.length === 0) return;
-    const idx = currentImages.findIndex(
-      (img) => img.blobPath === pendingLightboxImage.blobPath,
-    );
-    if (idx >= 0) {
-      openLightboxForCampaign(idx);
-    }
-    setPendingLightboxImage(null);
-  }, [
-    pendingLightboxImage,
-    currentImages,
-    activeCampaignId,
-    isCampaignLoading,
-    route,
-    openLightboxForCampaign,
-  ]);
 
   // Stable handler for the EPISODE NAME affordance in `LightboxDetails`.
   // Hoisted into useCallback so `LightboxDetails` — which is React.memo'd —
@@ -775,7 +724,7 @@ export default function App() {
         <AuthorDetail
           handle={route.handle}
           onBack={navigateToAuthorsIndex}
-          onOpenImage={openImageFromAuthorPage}
+          onOpenImage={openLightboxForAuthor}
         />
       )}
 

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { fetchJSON } from '../utils/fetchJSON';
 import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
-import type { AuthorDetailResponse } from '../types/api';
+import type { AuthorDetailResponse, ImageData } from '../types/api';
 
 interface Props {
   /** Handle of the author whose detail page we're rendering (includes leading "@"). */
@@ -10,12 +10,19 @@ interface Props {
   /** Navigate back to the authors index page. */
   onBack: () => void;
   /**
-   * Open the lightbox at a specific image. The App-level handler selects the
-   * containing campaign and, once its images finish preloading, opens the
-   * lightbox at the matching index. If the lookup fails for any reason the
-   * handler still navigates to the campaign view so the user is not stranded.
+   * Open the lightbox in author-browse mode against this author's full image
+   * list. The App-level handler sets the lightbox image source to the
+   * provided list and opens it at `index`. The list spans whatever campaigns
+   * the author has attributed images in; per-image `campaignId` is carried so
+   * the IMAGE DETAILS panel can resolve the source campaign per-image (see
+   * fringematrix5-pyd).
+   *
+   * The list is `ImageData[]` (lightbox-ready) so App can stay agnostic to
+   * the AuthorDetail response shape. Each image carries a synthesized
+   * `author` derived from `data.author`, so the lightbox AUTHOR row renders
+   * without an extra lookup.
    */
-  onOpenImage: (params: { blobPath: string; campaignId: string }) => void;
+  onOpenImage: (images: ImageData[], index: number, handle: string) => void;
 }
 
 /**
@@ -64,6 +71,31 @@ export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
   }, [handle]);
 
   const isLoading = data === null && error === null;
+
+  // Map the author-detail response into the `ImageData` shape the lightbox
+  // expects. Each image gets a synthesized `author` block derived from the
+  // shared `data.author` (handle / displayName / twitterUrl) plus the
+  // per-image `confidence` from the attribution record. `candidates` stays
+  // empty — the AuthorDetail response only lists resolved attributions, so
+  // the unresolved-candidates branch in the lightbox AUTHOR row is never
+  // reached from this source. Memoized so the array reference is stable
+  // across re-renders that don't change `data` (e.g. parent re-renders).
+  const lightboxImages = useMemo<ImageData[]>(() => {
+    if (!data) return [];
+    return data.images.map((image) => ({
+      fileName: image.fileName,
+      src: image.src,
+      blobPath: image.blobPath,
+      campaignId: image.campaignId,
+      author: {
+        handle: data.author.handle,
+        displayName: data.author.name,
+        twitterUrl: data.author.twitterUrl,
+        confidence: image.confidence,
+        candidates: [],
+      },
+    }));
+  }, [data]);
 
   return (
     <main className="content authors-page author-detail">
@@ -125,12 +157,12 @@ export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
               aria-label={`Images by ${data.author.name}`}
               data-testid="author-images-grid"
             >
-              {data.images.map((image) => (
+              {data.images.map((image, index) => (
                 <div className="card" key={image.blobPath}>
                   <button
                     type="button"
                     className="author-image-button"
-                    onClick={() => onOpenImage({ blobPath: image.blobPath, campaignId: image.campaignId })}
+                    onClick={() => onOpenImage(lightboxImages, index, data.author.handle)}
                     aria-label={`Open image ${image.fileName}`}
                   >
                     <img

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -75,7 +75,7 @@ describe('AuthorDetail', () => {
     expect(grid.querySelectorAll('img').length).toBe(2);
   });
 
-  it('opens the lightbox for the clicked image (blobPath + campaignId)', async () => {
+  it('opens the lightbox in author-browse mode with the full image list + clicked index', async () => {
     globalThis.fetch = mockFetch(SAMPLE_DETAIL) as unknown as typeof fetch;
     const onOpenImage = vi.fn();
 
@@ -91,19 +91,39 @@ describe('AuthorDetail', () => {
     const buttons = grid.querySelectorAll('button');
     fireEvent.click(buttons[0]!);
 
-    expect(onOpenImage).toHaveBeenCalledWith({
+    // First arg: full image list mapped to ImageData with synthesized author
+    // and per-image campaignId; second arg: clicked index; third arg: handle.
+    expect(onOpenImage).toHaveBeenCalledTimes(1);
+    const [images0, index0, handle0] = onOpenImage.mock.calls[0]!;
+    expect(handle0).toBe('@Zort70');
+    expect(index0).toBe(0);
+    expect(images0).toHaveLength(2);
+    expect(images0[0]).toMatchObject({
+      fileName: 'abc.jpg',
+      src: '/avatars/Season4/CrossTheLine/abc.jpg',
       blobPath: 'avatars/Season4/CrossTheLine/abc.jpg',
       campaignId: 'crosstheline',
+      author: {
+        handle: '@Zort70',
+        displayName: 'Sarah Proost',
+        twitterUrl: 'https://twitter.com/Zort70',
+        confidence: 'high',
+        candidates: [],
+      },
     });
-
-    // Clicking a different thumbnail dispatches the matching blobPath, not the
-    // first image's. Guards against a regression where the click handler
-    // captures the wrong row from the map.
-    fireEvent.click(buttons[1]!);
-    expect(onOpenImage).toHaveBeenLastCalledWith({
+    expect(images0[1]).toMatchObject({
+      fileName: 'def.jpg',
       blobPath: 'avatars/Season4/CrossTheLine/def.jpg',
       campaignId: 'crosstheline',
     });
+
+    // Clicking a different thumbnail dispatches the matching index. Guards
+    // against a regression where the click handler captures the wrong row
+    // from the map.
+    fireEvent.click(buttons[1]!);
+    const [, index1, handle1] = onOpenImage.mock.calls[1]!;
+    expect(index1).toBe(1);
+    expect(handle1).toBe('@Zort70');
   });
 
   it('clears stale data and error when the handle prop changes', async () => {


### PR DESCRIPTION
## Bead

fringematrix5-ik5: Open author-detail thumbnails in author-browse mode

## Summary

- Replace the campaign-switch + `pendingLightboxImage` flow with a direct open: clicking a thumbnail on the author detail page now sets `lightboxImageSource = { kind: 'author', images, handle }` and opens the lightbox at the clicked index. No URL hash change, no campaign switch, no wait-and-open effect.
- `AuthorDetail` maps its response into `ImageData[]` (lightbox-ready) with a synthesized `author` block per image (handle / displayName / twitterUrl from `data.author`, plus per-image `confidence`), and passes the full list + clicked index + handle up to App.
- Each image carries its own `campaignId`, which `LightboxContainer` (from fringematrix5-pyd) uses to resolve the source campaign per-image — so EPISODE NAME / SEASON / AIR DATE / HASHTAG / IMDB and the AUTHOR row update as the user pages across images that may span multiple campaigns.
- Closing the lightbox returns the user to the author detail page with scroll position preserved (the page never unmounts).
- Removes the now-dead `pendingLightboxImage` state, the wait-and-open effect, and `openImageFromAuthorPage` in App.tsx.

## Test plan

- [x] Local CI passes (`npm run typecheck && npm run test` — 627 client + 107 server tests, all green)
- [ ] Manual: open author detail page; click a thumbnail; lightbox opens immediately; prev/next cycles across the author's images (which may belong to different campaigns); IMAGE DETAILS updates per image; close returns to author detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced author image browsing - lightbox now opens directly in author-browse mode, allowing seamless browsing of all images from an author.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->