### PR TITLE
fringematrix5-8fwv: HASHTAG row links to in-app campaign gallery

### DIFF
--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -219,7 +219,30 @@ function LightboxDetails({ campaign, author, onOpenAuthorGallery, onOpenCampaign
       </Row>
       <Row label="SEASON / NUMBER">{seasonNumberLabel}</Row>
       <Row label="AIR DATE">{campaign.date}</Row>
-      <Row label="HASHTAG">{`#${campaign.hashtag}`}</Row>
+      <Row label="HASHTAG">
+        {handleOpenCampaign ? (
+          // Same hoisting pattern as EPISODE NAME: reuse the memoized
+          // `handleOpenCampaign` closure (computed once per campaign change)
+          // so React.memo on LightboxDetails keeps working across prev/next
+          // image navigation. Reuse the existing `.lightbox-details-campaign-link`
+          // class for visual parity with the EPISODE NAME affordance.
+          //
+          // Design choice: the `#` prefix lives INSIDE the button so the
+          // entire visible hashtag (including the sigil that visually
+          // identifies it as a hashtag) is a single uninterrupted click
+          // target.
+          <button
+            type="button"
+            className="lightbox-details-campaign-link"
+            onClick={handleOpenCampaign}
+            aria-label={`View campaign gallery for #${campaign.hashtag}`}
+          >
+            {`#${campaign.hashtag}`}
+          </button>
+        ) : (
+          `#${campaign.hashtag}`
+        )}
+      </Row>
       {isSafeUrl(campaign.imdb_link) && imdbLinkText ? (
         <Row label="IMDB">
           <a

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -113,8 +113,11 @@ describe('LightboxDetails', () => {
       render(
         <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
       );
+      // Scope to the EPISODE NAME button specifically — the HASHTAG row
+      // also exposes a "view campaign gallery for #..." button now
+      // (fringematrix5-8fwv), so an unanchored regex would match both.
       const btn = screen.getByRole('button', {
-        name: /view campaign gallery/i,
+        name: /view campaign gallery for back to where you've never been/i,
       });
       fireEvent.click(btn);
       expect(onOpen).toHaveBeenCalledTimes(1);
@@ -133,8 +136,10 @@ describe('LightboxDetails', () => {
       render(
         <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
       );
+      // Same scoping note as above — name the EPISODE NAME button
+      // explicitly to disambiguate from the HASHTAG button.
       const btn = screen.getByRole('button', {
-        name: /view campaign gallery/i,
+        name: /view campaign gallery for back to where you've never been/i,
       }) as HTMLButtonElement;
       // Focusable via .focus().
       btn.focus();
@@ -154,6 +159,75 @@ describe('LightboxDetails', () => {
       expect(link.tagName).toBe('A');
       expect(link.getAttribute('href')).toBe('http://www.imdb.com/title/tt2125636/');
       expect(link.getAttribute('target')).toBe('_blank');
+    });
+  });
+
+  describe('HASHTAG → campaign gallery link (fringematrix5-8fwv)', () => {
+    it('renders the hashtag as plain text when no onOpenCampaignGallery handler is provided', () => {
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} />);
+      // No button-role element for the hashtag value.
+      expect(screen.queryByRole('button', { name: /#CrossTheLine/ })).toBeNull();
+      // The hashtag value is still rendered (as plain text).
+      expect(screen.getByText('#CrossTheLine')).toBeTruthy();
+    });
+
+    it('renders the hashtag as a button when onOpenCampaignGallery is provided', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery for #crosstheline/i,
+      });
+      expect(btn).toBeTruthy();
+      expect(btn.tagName).toBe('BUTTON');
+      // Must be of type="button" so it never accidentally submits a form.
+      expect(btn.getAttribute('type')).toBe('button');
+      // The `#` sigil is INSIDE the button so the whole visible hashtag is
+      // a single click target.
+      expect(btn.textContent).toBe('#CrossTheLine');
+    });
+
+    it('invokes onOpenCampaignGallery with the campaign id when the hashtag is clicked', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery for #crosstheline/i,
+      });
+      fireEvent.click(btn);
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onOpen).toHaveBeenCalledWith('crosstheline');
+    });
+
+    it('reuses the same `.lightbox-details-campaign-link` class as the EPISODE NAME affordance', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const episodeBtn = screen.getByRole('button', {
+        name: /view campaign gallery for back to where you've never been/i,
+      });
+      const hashtagBtn = screen.getByRole('button', {
+        name: /view campaign gallery for #crosstheline/i,
+      });
+      expect(episodeBtn.className).toContain('lightbox-details-campaign-link');
+      expect(hashtagBtn.className).toContain('lightbox-details-campaign-link');
+    });
+
+    it('hashtag button is focusable (participates in lightbox focus trap)', () => {
+      const onOpen = vi.fn();
+      render(
+        <LightboxDetails campaign={SAMPLE_CAMPAIGN} onOpenCampaignGallery={onOpen} />
+      );
+      const btn = screen.getByRole('button', {
+        name: /view campaign gallery for #crosstheline/i,
+      }) as HTMLButtonElement;
+      btn.focus();
+      expect(document.activeElement).toBe(btn);
+      expect(btn.tagName).toBe('BUTTON');
+      expect(btn.hasAttribute('disabled')).toBe(false);
     });
   });
 

--- a/e2e/author-browse-mode.spec.ts
+++ b/e2e/author-browse-mode.spec.ts
@@ -291,4 +291,51 @@ test.describe('Author-browse mode — info-box in-app links', () => {
     await expect(page.locator('[data-testid="author-images-grid"]')).toHaveCount(0);
     await expect(page.locator('#campaign-info')).toBeVisible();
   });
+
+  test('clicking HASHTAG inside the lightbox switches the gallery to that campaign', async ({ page }) => {
+    const total = await gotoZortAuthorDetail(page);
+    if (total === 0) {
+      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+
+    const grid = page.locator('[data-testid="author-images-grid"]');
+    await grid.locator('.card img').first().click();
+    await expect(page.locator('#lightbox')).toBeVisible();
+
+    // Scope to the first .lightbox-details instance (the inline sidebar)
+    // so we don't accidentally pick up the mobile drawer copy.
+    const sidebar = page.locator('.lightbox-details').first();
+    const hashtagRow = sidebar
+      .locator('.lightbox-details-row')
+      .filter({ hasText: 'HASHTAG' })
+      .first();
+    // The new button reuses `.lightbox-details-campaign-link` — same as
+    // EPISODE NAME — and lives inside the HASHTAG row's value cell.
+    const hashtagButton = hashtagRow.locator('.lightbox-details-campaign-link');
+    await expect(hashtagButton).toBeVisible();
+
+    // Capture the hashtag label so we can sanity-check it begins with `#`
+    // (the `#` sigil lives inside the button per the implementation).
+    const hashtagLabel = (await hashtagButton.textContent())?.trim() ?? '';
+    expect(hashtagLabel.startsWith('#')).toBe(true);
+    expect(hashtagLabel.length).toBeGreaterThan(1);
+
+    await hashtagButton.click();
+
+    // Lightbox closes …
+    await expect(page.locator('#lightbox')).toBeHidden();
+
+    // … the URL hash becomes #<campaignId>. We don't know the id up-front
+    // (it's derived from the image's source campaign), but the hash must
+    // NOT still be the author-detail hash, and it must not be empty / #authors.
+    const hash = new URL(page.url()).hash;
+    expect(hash).not.toBe('');
+    expect(hash).not.toBe('#authors');
+    expect(hash.startsWith('#authors/')).toBe(false);
+    expect(hash.startsWith('#')).toBe(true);
+
+    // And we're on the campaign view, not the author detail view.
+    await expect(page.locator('[data-testid="author-images-grid"]')).toHaveCount(0);
+    await expect(page.locator('#campaign-info')).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Bead: fringematrix5-8fwv (P2)
- In `client/src/components/LightboxDetails.tsx`, the HASHTAG row now mirrors the existing EPISODE NAME affordance: when `onOpenCampaignGallery` is provided, the value renders as a `<button>` with the `lightbox-details-campaign-link` class; when absent, it stays plain text (test contexts, etc).
- Reuses the same `useCallback`-style hoisting (`handleOpenCampaign`) so `React.memo` on `LightboxDetails` keeps working across prev/next image navigation — no inline closures.
- The `#` sigil lives inside the button so the whole visible hashtag is a single click target.

## Scope

- No new callback API. Reuses `onOpenCampaignGallery` (already plumbed through `LightboxContainer` and `App.tsx`).
- No styling changes beyond reusing the existing `.lightbox-details-campaign-link` class.
- IMDB row untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — full suite (635 unit tests) green; new HASHTAG branch tests cover plain-text fallback, button presence, click handler, shared class with EPISODE NAME, focusability.
- [x] `npm run test:e2e` for `author-browse-mode.spec.ts` — all 7 tests pass, including the new "clicking HASHTAG inside the lightbox switches the gallery to that campaign" case that mirrors the existing EPISODE NAME e2e and asserts URL hash change.
- [x] EPISODE NAME unit tests updated to disambiguate from the new HASHTAG button (they previously matched `/view campaign gallery/i` unanchored).

## Follow-ups

- None planned in this bead's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hashtags in the details panel are now interactive links that open the campaign gallery when available, matching the functionality of episode name links.

* **Tests**
  * Added comprehensive test coverage for hashtag gallery interactions and E2E test for campaign navigation via hashtag links in author-browse mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->