### PR TITLE
fringematrix5-jq33: share GalleryGrid with author detail + thread thumb-element

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -74,6 +74,10 @@ export default function App() {
   const [loadingDots, setLoadingDots] = useState<number>(0);
   const [loadingError, setLoadingError] = useState<boolean>(false);
   const galleryGridRef = useRef<GalleryGridHandle>(null);
+  // Ref to the AuthorDetail's inner GalleryGrid. App owns it (passed down as
+  // a prop) so `getThumbElement` below can route to the correct grid based on
+  // the active lightbox source. Null when not on the author-detail route.
+  const authorGridRef = useRef<GalleryGridHandle>(null);
   const shareBtnRef = useRef<HTMLButtonElement>(null);
   const buildBtnRef = useRef<HTMLButtonElement>(null);
   const [shareStyle, setShareStyle] = useState<React.CSSProperties>({});
@@ -454,10 +458,26 @@ export default function App() {
     return () => clearInterval(id);
   }, [isPreloading, isCampaignLoading]);
 
+  // Mirror lightboxImageSource into a ref so getThumbElement can read the
+  // current kind without itself becoming a new function reference on every
+  // source change (which would cascade into useLightboxAnimations re-creating
+  // its own callbacks).
+  const lightboxImageSourceRef = useRef(lightboxImageSource);
+  useEffect(() => {
+    lightboxImageSourceRef.current = lightboxImageSource;
+  }, [lightboxImageSource]);
+
   // Stable callback so the hook never re-creates its callbacks due to a new
-  // function reference.  galleryGridRef.current is read at call time, so the
-  // useCallback dep array is intentionally empty.
+  // function reference. The grid refs and source-kind are read at call time
+  // via refs, so the useCallback dep array is intentionally empty.
+  //
+  // Routes by the active lightbox source: author-browse mode reads from the
+  // AuthorDetail grid; everything else (campaign-mode + fallback) reads from
+  // the campaign GalleryGrid. fringematrix5-jq33.
   const getThumbElement = useCallback((index: number): HTMLImageElement | null => {
+    if (lightboxImageSourceRef.current?.kind === 'author') {
+      return authorGridRef.current?.getThumbElement(index) ?? null;
+    }
     return galleryGridRef.current?.getThumbElement(index) ?? null;
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -497,14 +517,15 @@ export default function App() {
   // its own `campaignId` and a synthesized `author` block so LightboxDetails
   // resolves the source campaign and AUTHOR row per-image as the user pages.
   //
-  // No thumb element is passed: the close animation would otherwise try to
-  // collapse the image back to the originating thumbnail. The author-detail
-  // grid is still mounted underneath the lightbox, so closing returns the
-  // user there directly without a return-flight animation — the existing
-  // useLightboxAnimations close path tolerates a null/missing thumb.
-  const openLightboxForAuthor = useCallback((images: ImageData[], index: number, handle: string) => {
+  // `thumbEl` is the clicked thumbnail `<img>` (forwarded from AuthorDetail's
+  // GalleryGrid). It seeds the zoom-in animation's source rect and lets the
+  // active-thumb-hide path know which cell to blank out — matching campaign
+  // gallery parity (fringematrix5-jq33). The hook's getThumbElement (above)
+  // routes back to authorGridRef for next/prev navigation while the lightbox
+  // is open.
+  const openLightboxForAuthor = useCallback((images: ImageData[], index: number, handle: string, thumbEl?: HTMLElement) => {
     setLightboxImageSource({ kind: 'author', images, handle });
-    openLightbox(index);
+    openLightbox(index, thumbEl);
   }, [openLightbox]);
 
   // Clear the lightbox source once the lightbox has fully closed so we never
@@ -725,6 +746,7 @@ export default function App() {
           handle={route.handle}
           onBack={navigateToAuthorsIndex}
           onOpenImage={openLightboxForAuthor}
+          gridRef={authorGridRef}
         />
       )}
 
@@ -754,12 +776,28 @@ export default function App() {
             )}
           </section>
 
-          <GalleryGrid
-            ref={galleryGridRef}
-            images={currentImages}
-            hasCampaign={!!activeCampaign}
-            onImageClick={openLightboxForCampaign}
-          />
+          {activeCampaign && currentImages.length === 0 ? (
+            // Caller-owned empty state, previously rendered inside GalleryGrid
+            // behind a `hasCampaign` prop. Hoisted up here in fringematrix5-jq33
+            // so GalleryGrid stays a pure list view reusable by AuthorDetail.
+            <section
+              id="gallery"
+              className="gallery-grid empty"
+              aria-live="polite"
+            >
+              <div className="empty-state" role="status" aria-live="polite">
+                <div className="empty-emoji" aria-hidden>🖼️</div>
+                <div className="empty-title">No Images In Campaign</div>
+                <div className="empty-desc">This campaign has no uploaded images yet.</div>
+              </div>
+            </section>
+          ) : (
+            <GalleryGrid
+              ref={galleryGridRef}
+              images={currentImages}
+              onImageClick={openLightboxForCampaign}
+            />
+          )}
         </main>
       )}
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -461,11 +461,11 @@ export default function App() {
   // Mirror lightboxImageSource into a ref so getThumbElement can read the
   // current kind without itself becoming a new function reference on every
   // source change (which would cascade into useLightboxAnimations re-creating
-  // its own callbacks).
+  // its own callbacks). Updated synchronously during render so the ref is
+  // always consistent with the rendered state — `getThumbElement` cannot
+  // observe a stale value between a state change and an effect flush.
   const lightboxImageSourceRef = useRef(lightboxImageSource);
-  useEffect(() => {
-    lightboxImageSourceRef.current = lightboxImageSource;
-  }, [lightboxImageSource]);
+  lightboxImageSourceRef.current = lightboxImageSource;
 
   // Stable callback so the hook never re-creates its callbacks due to a new
   // function reference. The grid refs and source-kind are read at call time

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react';
 import { fetchJSON } from '../utils/fetchJSON';
 import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
 import type { AuthorDetailResponse, ImageData } from '../types/api';
+import GalleryGrid, { type GalleryGridHandle } from './GalleryGrid';
 
 interface Props {
   /** Handle of the author whose detail page we're rendering (includes leading "@"). */
@@ -21,8 +22,20 @@ interface Props {
    * the AuthorDetail response shape. Each image carries a synthesized
    * `author` derived from `data.author`, so the lightbox AUTHOR row renders
    * without an extra lookup.
+   *
+   * The 4th arg `thumbEl` is the clicked thumbnail `<img>`. App forwards it
+   * to `useLightboxAnimations.openLightbox` so the zoom-in/zoom-out flight
+   * has a real source rect to animate from/to. Matches the campaign-mode
+   * `GalleryGrid.onImageClick(index, thumbEl)` contract — see
+   * fringematrix5-jq33 for the author-browse parity work.
    */
-  onOpenImage: (images: ImageData[], index: number, handle: string) => void;
+  onOpenImage: (images: ImageData[], index: number, handle: string, thumbEl: HTMLImageElement) => void;
+  /**
+   * Optional ref forwarded onto the inner `<GalleryGrid />`. App owns the ref
+   * and passes it down so `App.getThumbElement` can route to this grid when
+   * the lightbox is in author-browse mode (lightboxImageSource.kind === 'author').
+   */
+  gridRef?: RefObject<GalleryGridHandle | null>;
 }
 
 /**
@@ -33,7 +46,7 @@ interface Props {
  * Errors render an inline message rather than crashing the app — 404s from a
  * missing handle surface as "Failed to load author".
  */
-export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
+export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: Props) {
   const [data, setData] = useState<AuthorDetailResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,6 +110,22 @@ export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
     }));
   }, [data]);
 
+  /**
+   * Per-thumbnail click handler delegated to the parent. GalleryGrid passes
+   * `(index, thumbEl)`; we forward the author-image list and handle so App's
+   * `openLightboxForAuthor` can both open the lightbox against the right
+   * source AND hand the thumbnail element to the zoom animation. Stable
+   * across renders while `lightboxImages` / `data.author.handle` don't
+   * change, keeping `React.memo(GalleryGrid)` effective.
+   */
+  const handleImageClick = useCallback(
+    (index: number, thumbEl: HTMLImageElement) => {
+      if (!data) return;
+      onOpenImage(lightboxImages, index, data.author.handle, thumbEl);
+    },
+    [data, lightboxImages, onOpenImage],
+  );
+
   return (
     <main className="content authors-page author-detail">
       <div className="authors-header">
@@ -152,28 +181,13 @@ export default function AuthorDetail({ handle, onBack, onOpenImage }: Props) {
               No images attributed to this author yet.
             </div>
           ) : (
-            <section
-              className="gallery-grid"
-              aria-label={`Images by ${data.author.name}`}
-              data-testid="author-images-grid"
-            >
-              {data.images.map((image, index) => (
-                <div className="card" key={image.blobPath}>
-                  <button
-                    type="button"
-                    className="author-image-button"
-                    onClick={() => onOpenImage(lightboxImages, index, data.author.handle)}
-                    aria-label={`Open image ${image.fileName}`}
-                  >
-                    <img
-                      src={image.src}
-                      alt={image.fileName}
-                      loading="lazy"
-                    />
-                  </button>
-                </div>
-              ))}
-            </section>
+            <GalleryGrid
+              ref={gridRef}
+              images={lightboxImages}
+              onImageClick={handleImageClick}
+              ariaLabel={`Images by ${data.author.name}`}
+              testId="author-images-grid"
+            />
           )}
         </>
       )}

--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -14,10 +14,19 @@ export interface GalleryGridHandle {
 
 interface GalleryGridProps {
   images: ImageData[];
-  /** Whether an active campaign is selected (used to show the empty state) */
-  hasCampaign: boolean;
   /** Stable callback — receives the image index and the thumbnail element */
   onImageClick: (index: number, thumbEl: HTMLImageElement) => void;
+  /**
+   * Optional ARIA label for the underlying <section>. Defaults to nothing
+   * (the campaign gallery doesn't need one because it has an h1 above it).
+   * Author detail provides a per-author label.
+   */
+  ariaLabel?: string;
+  /**
+   * Optional data-testid for the underlying <section>. Lets callers tag the
+   * grid for tests (e.g. the author-detail grid uses `author-images-grid`).
+   */
+  testId?: string;
 }
 
 /**
@@ -25,11 +34,16 @@ interface GalleryGridProps {
  *
  * App re-renders at 2.5 Hz while loadingDots ticks during image preload.
  * Wrapping this section in React.memo prevents the entire N-card VDOM diff
- * from running on every tick — it only re-renders when images, hasCampaign,
- * or onImageClick actually change.
+ * from running on every tick — it only re-renders when images or
+ * onImageClick actually change.
+ *
+ * Callers are responsible for rendering their own empty-state UI (the
+ * campaign view renders "No Images In Campaign" and AuthorDetail renders
+ * "No images attributed to this author yet."). This keeps the grid a pure
+ * list view, reusable across both call sites.
  */
 const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridProps>(
-  function GalleryGrid({ images, hasCampaign, onImageClick }, ref) {
+  function GalleryGrid({ images, onImageClick, ariaLabel, testId }, ref) {
     /** Tracks the <img> DOM element for each image index. */
     const thumbMapRef = useRef<Map<number, HTMLImageElement>>(new Map());
 
@@ -113,30 +127,22 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
       [],
     );
 
-    const isEmpty = hasCampaign && images.length === 0;
-
     return (
       <section
         id="gallery"
-        className={`gallery-grid${isEmpty ? ' empty' : ''}`}
+        className="gallery-grid"
         aria-live="polite"
+        aria-label={ariaLabel}
+        data-testid={testId}
       >
-        {isEmpty ? (
-          <div className="empty-state" role="status" aria-live="polite">
-            <div className="empty-emoji" aria-hidden>🖼️</div>
-            <div className="empty-title">No Images In Campaign</div>
-            <div className="empty-desc">This campaign has no uploaded images yet.</div>
-          </div>
-        ) : (
-          images.map((img, i) => (
-            <ImageCard
-              key={`${img.src}-${i}`}
-              image={img}
-              imgRef={setThumbRef(i)}
-              onClick={getClickCallback(i)}
-            />
-          ))
-        )}
+        {images.map((img, i) => (
+          <ImageCard
+            key={`${img.src}-${i}`}
+            image={img}
+            imgRef={setThumbRef(i)}
+            onClick={getClickCallback(i)}
+          />
+        ))}
       </section>
     );
   }

--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -34,8 +34,11 @@ interface GalleryGridProps {
  *
  * App re-renders at 2.5 Hz while loadingDots ticks during image preload.
  * Wrapping this section in React.memo prevents the entire N-card VDOM diff
- * from running on every tick — it only re-renders when images or
- * onImageClick actually change.
+ * from running on every tick — React.memo's shallow prop compare means the
+ * grid re-renders only when any prop (images, onImageClick, ariaLabel,
+ * testId) changes identity. Keep `images` and `onImageClick` stable across
+ * renders to retain the benefit; `ariaLabel`/`testId` are typically string
+ * literals so they're effectively stable.
  *
  * Callers are responsible for rendering their own empty-state UI (the
  * campaign view renders "No Images In Campaign" and AuthorDetail renders
@@ -131,7 +134,6 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
       <section
         id="gallery"
         className="gallery-grid"
-        aria-live="polite"
         aria-label={ariaLabel}
         data-testid={testId}
       >

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2304,22 +2304,3 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
   margin-top: 6px;
   font-size: 14px;
 }
-/* Author-detail thumbnail wrapper: a button for keyboard/screen-reader access
-   that visually behaves like the bare <img> in the campaign GalleryGrid. */
-.author-image-button {
-  display: block;
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  margin: 0;
-  border: 0;
-  background: transparent;
-  cursor: zoom-in;
-  color: inherit;
-  font: inherit;
-}
-.author-image-button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-

--- a/client/test/App.openLightboxForAuthor.test.tsx
+++ b/client/test/App.openLightboxForAuthor.test.tsx
@@ -139,9 +139,11 @@ describe('App: openLightboxForAuthor wiring (fringematrix5-w18z)', () => {
     });
 
     // Wait for the author-detail grid to render after /api/authors resolves.
+    // Post-jq33 the grid is the shared GalleryGrid, which attaches onClick to
+    // the <img> directly (no wrapping <button>).
     const grid = await screen.findByTestId('author-images-grid');
-    const buttons = grid.querySelectorAll('button');
-    expect(buttons.length).toBe(3);
+    const imgs = grid.querySelectorAll('img');
+    expect(imgs.length).toBe(3);
 
     const hashBeforeClick = window.location.hash;
     expect(hashBeforeClick).toBe(AUTHOR_HASH);
@@ -150,7 +152,7 @@ describe('App: openLightboxForAuthor wiring (fringematrix5-w18z)', () => {
     // the author's image list at that index — not against the (empty) active
     // campaign's images.
     await act(async () => {
-      fireEvent.click(buttons[1]!);
+      fireEvent.click(imgs[1]!);
     });
 
     // The lightbox dialog renders once isLightboxOpen flips. With
@@ -186,10 +188,10 @@ describe('App: openLightboxForAuthor wiring (fringematrix5-w18z)', () => {
     });
 
     const grid = await screen.findByTestId('author-images-grid');
-    const buttons = grid.querySelectorAll('button');
+    const imgs = grid.querySelectorAll('img');
 
     await act(async () => {
-      fireEvent.click(buttons[0]!);
+      fireEvent.click(imgs[0]!);
     });
 
     const lightbox = await screen.findByRole('dialog', { name: /image viewer/i });
@@ -215,10 +217,10 @@ describe('App: openLightboxForAuthor wiring (fringematrix5-w18z)', () => {
     });
 
     const grid = await screen.findByTestId('author-images-grid');
-    const buttons = grid.querySelectorAll('button');
+    const imgs = grid.querySelectorAll('img');
 
     await act(async () => {
-      fireEvent.click(buttons[0]!);
+      fireEvent.click(imgs[0]!);
     });
 
     const lightbox = await screen.findByRole('dialog', { name: /image viewer/i });

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -75,7 +75,7 @@ describe('AuthorDetail', () => {
     expect(grid.querySelectorAll('img').length).toBe(2);
   });
 
-  it('opens the lightbox in author-browse mode with the full image list + clicked index', async () => {
+  it('opens the lightbox in author-browse mode with the full image list + clicked index + thumb element', async () => {
     globalThis.fetch = mockFetch(SAMPLE_DETAIL) as unknown as typeof fetch;
     const onOpenImage = vi.fn();
 
@@ -88,15 +88,22 @@ describe('AuthorDetail', () => {
     );
 
     const grid = await screen.findByTestId('author-images-grid');
-    const buttons = grid.querySelectorAll('button');
-    fireEvent.click(buttons[0]!);
+    // AuthorDetail now renders the shared GalleryGrid, which attaches the
+    // click handler directly to the <img> (no wrapping <button>). Drive the
+    // click off the <img> tags. (fringematrix5-jq33.)
+    const imgs = grid.querySelectorAll('img');
+    expect(imgs.length).toBe(2);
+    fireEvent.click(imgs[0]!);
 
-    // First arg: full image list mapped to ImageData with synthesized author
-    // and per-image campaignId; second arg: clicked index; third arg: handle.
+    // 1st arg: full image list mapped to ImageData with synthesized author
+    // and per-image campaignId. 2nd: clicked index. 3rd: handle. 4th: the
+    // <img> element clicked — forwarded so App.openLightboxForAuthor can
+    // seed the zoom-in flight's source rect (parity with campaign gallery).
     expect(onOpenImage).toHaveBeenCalledTimes(1);
-    const [images0, index0, handle0] = onOpenImage.mock.calls[0]!;
+    const [images0, index0, handle0, thumb0] = onOpenImage.mock.calls[0]!;
     expect(handle0).toBe('@Zort70');
     expect(index0).toBe(0);
+    expect(thumb0).toBe(imgs[0]);
     expect(images0).toHaveLength(2);
     expect(images0[0]).toMatchObject({
       fileName: 'abc.jpg',
@@ -120,10 +127,11 @@ describe('AuthorDetail', () => {
     // Clicking a different thumbnail dispatches the matching index. Guards
     // against a regression where the click handler captures the wrong row
     // from the map.
-    fireEvent.click(buttons[1]!);
-    const [, index1, handle1] = onOpenImage.mock.calls[1]!;
+    fireEvent.click(imgs[1]!);
+    const [, index1, handle1, thumb1] = onOpenImage.mock.calls[1]!;
     expect(index1).toBe(1);
     expect(handle1).toBe('@Zort70');
+    expect(thumb1).toBe(imgs[1]);
   });
 
   it('clears stale data and error when the handle prop changes', async () => {

--- a/client/test/GalleryGrid.test.tsx
+++ b/client/test/GalleryGrid.test.tsx
@@ -28,7 +28,6 @@ describe('GalleryGridHandle.getThumbElement — loaded images', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png'), makeImage('b.png'), makeImage('c.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -43,7 +42,6 @@ describe('GalleryGridHandle.getThumbElement — loaded images', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png', '/a.png'), makeImage('b.png', '/b.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -58,7 +56,6 @@ describe('GalleryGridHandle.getThumbElement — loaded images', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png'), makeImage('b.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -82,7 +79,6 @@ describe('GalleryGridHandle.getThumbElement — null cases', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -96,7 +92,6 @@ describe('GalleryGridHandle.getThumbElement — null cases', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -110,7 +105,6 @@ describe('GalleryGridHandle.getThumbElement — null cases', () => {
       <GalleryGrid
         ref={ref}
         images={[makeLoading('x.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -126,7 +120,6 @@ describe('GalleryGridHandle.getThumbElement — null cases', () => {
       <GalleryGrid
         ref={ref}
         images={[]}
-        hasCampaign={false}
         onImageClick={noop}
       />,
     );
@@ -147,7 +140,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png'), makeImage('b.png'), makeImage('c.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -161,7 +153,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
         <GalleryGrid
           ref={ref}
           images={[makeImage('x.png')]}
-          hasCampaign
           onImageClick={noop}
         />,
       );
@@ -179,7 +170,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('old.png', '/old.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -189,7 +179,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
         <GalleryGrid
           ref={ref}
           images={[makeImage('new.png', '/new.png')]}
-          hasCampaign
           onImageClick={noop}
         />,
       );
@@ -206,7 +195,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png'), makeImage('b.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -218,7 +206,6 @@ describe('GalleryGridHandle.getThumbElement — after campaign switch', () => {
         <GalleryGrid
           ref={ref}
           images={[makeLoading('a.png'), makeLoading('b.png')]}
-          hasCampaign
           onImageClick={noop}
         />,
       );
@@ -247,7 +234,6 @@ describe('GalleryGridHandle — setThumbRef callback caching', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png'), makeImage('b.png')]}
-        hasCampaign
         onImageClick={onClick}
       />,
     );
@@ -258,7 +244,6 @@ describe('GalleryGridHandle — setThumbRef callback caching', () => {
         <GalleryGrid
           ref={ref}
           images={[makeImage('a.png'), makeImage('b.png')]}
-          hasCampaign
           onImageClick={onClick}
         />,
       );
@@ -276,7 +261,6 @@ describe('GalleryGridHandle — setThumbRef callback caching', () => {
       <GalleryGrid
         ref={ref}
         images={[makeImage('a.png')]}
-        hasCampaign
         onImageClick={noop}
       />,
     );
@@ -286,7 +270,6 @@ describe('GalleryGridHandle — setThumbRef callback caching', () => {
         <GalleryGrid
           ref={ref}
           images={[makeImage('a.png'), makeImage('b.png')]}
-          hasCampaign
           onImageClick={noop}
         />,
       );
@@ -304,13 +287,13 @@ describe('GalleryGridHandle — setThumbRef callback caching', () => {
 describe('GalleryGrid — image card rendering', () => {
   it('renders one card per image', () => {
     const images = [makeImage('a.png'), makeImage('b.png'), makeImage('c.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.getAllByRole('img')).toHaveLength(3);
   });
 
   it('does not render a visible filename label for each image card', () => {
     const images = [makeImage('fringe-avatar.png'), makeImage('walter-bishop.jpg')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     // Filename text must not appear as visible text — only used for img alt.
     expect(screen.queryByText('fringe-avatar.png')).toBeNull();
     expect(screen.queryByText('walter-bishop.jpg')).toBeNull();
@@ -318,14 +301,14 @@ describe('GalleryGrid — image card rendering', () => {
 
   it('renders the image src as the img element src', () => {
     const images = [makeImage('specific.png', 'https://cdn.example.com/specific.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     const img = screen.getByRole('img');
     expect(img.getAttribute('src')).toBe('https://cdn.example.com/specific.png');
   });
 
   it('uses the fileName as the img alt text', () => {
     const images = [makeImage('my-avatar.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.getByAltText('my-avatar.png')).toBeTruthy();
   });
 });
@@ -338,7 +321,7 @@ describe('GalleryGrid — click handler', () => {
   it('calls onImageClick with correct index when first image is clicked', () => {
     const onImageClick = vi.fn();
     const images = [makeImage('first.png'), makeImage('second.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={onImageClick} />);
+    render(<GalleryGrid images={images} onImageClick={onImageClick} />);
     const imgs = screen.getAllByRole('img');
     fireEvent.click(imgs[0]);
     expect(onImageClick).toHaveBeenCalledTimes(1);
@@ -348,7 +331,7 @@ describe('GalleryGrid — click handler', () => {
   it('calls onImageClick with correct index when a middle image is clicked', () => {
     const onImageClick = vi.fn();
     const images = [makeImage('first.png'), makeImage('second.png'), makeImage('third.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={onImageClick} />);
+    render(<GalleryGrid images={images} onImageClick={onImageClick} />);
     const imgs = screen.getAllByRole('img');
     fireEvent.click(imgs[1]);
     expect(onImageClick).toHaveBeenCalledTimes(1);
@@ -358,7 +341,7 @@ describe('GalleryGrid — click handler', () => {
   it('calls onImageClick with the img element as the second argument', () => {
     const onImageClick = vi.fn();
     const images = [makeImage('avatar.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={onImageClick} />);
+    render(<GalleryGrid images={images} onImageClick={onImageClick} />);
     const img = screen.getByRole('img');
     fireEvent.click(img);
     expect(onImageClick.mock.calls[0][1]).toBe(img);
@@ -366,34 +349,48 @@ describe('GalleryGrid — click handler', () => {
 });
 
 // =============================================================================
-// 7. Empty state — hasCampaign=true + images=[] shows the empty-state UI
+// 7. Empty list — GalleryGrid is a pure list view; the caller renders the
+// empty-state UI. (fringematrix5-jq33 dropped the in-grid `hasCampaign`
+// empty-state branch so the same component is reusable from AuthorDetail.)
 // =============================================================================
 
-describe('GalleryGrid — empty state', () => {
-  it('renders the empty state when hasCampaign=true and images=[]', () => {
-    render(<GalleryGrid images={[]} hasCampaign={true} onImageClick={noop} />);
-    expect(screen.getByRole('status')).toBeTruthy();
-    expect(screen.getByText('No Images In Campaign')).toBeTruthy();
-    expect(screen.getByText('This campaign has no uploaded images yet.')).toBeTruthy();
-  });
-
-  it('adds the "empty" class to the gallery section when in empty state', () => {
-    const { container } = render(<GalleryGrid images={[]} hasCampaign={true} onImageClick={noop} />);
+describe('GalleryGrid — empty list', () => {
+  it('renders an empty <section> when images=[] (no in-grid empty-state UI)', () => {
+    const { container } = render(<GalleryGrid images={[]} onImageClick={noop} />);
     const section = container.querySelector('section#gallery');
-    expect(section?.classList.contains('empty')).toBe(true);
-  });
-
-  it('does NOT render empty state when hasCampaign=false and images=[]', () => {
-    render(<GalleryGrid images={[]} hasCampaign={false} onImageClick={noop} />);
-    expect(screen.queryByRole('status')).toBeNull();
+    expect(section).toBeTruthy();
+    // Grid no longer owns the "No Images In Campaign" copy — the campaign
+    // view in App.tsx and AuthorDetail each render their own empty state.
     expect(screen.queryByText('No Images In Campaign')).toBeNull();
+    expect(screen.queryByText('This campaign has no uploaded images yet.')).toBeNull();
+    // No image cards rendered either.
+    expect(container.querySelectorAll('.card').length).toBe(0);
   });
 
-  it('does NOT render empty state when images are present', () => {
+  it('does NOT render a status role when images=[] (caller owns aria-live empty state)', () => {
+    render(<GalleryGrid images={[]} onImageClick={noop} />);
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('renders image cards (not an empty state) when images are present', () => {
     const images = [makeImage('avatar.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
-    expect(screen.queryByRole('status')).toBeNull();
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.queryByText('No Images In Campaign')).toBeNull();
+    expect(screen.getByRole('img')).toBeTruthy();
+  });
+
+  it('applies the optional ariaLabel and testId to the underlying section', () => {
+    const { container } = render(
+      <GalleryGrid
+        images={[]}
+        onImageClick={noop}
+        ariaLabel="Images by Sarah"
+        testId="author-images-grid"
+      />,
+    );
+    const section = container.querySelector('section#gallery');
+    expect(section?.getAttribute('aria-label')).toBe('Images by Sarah');
+    expect(section?.getAttribute('data-testid')).toBe('author-images-grid');
   });
 });
 
@@ -404,28 +401,28 @@ describe('GalleryGrid — empty state', () => {
 describe('GalleryGrid — loading placeholder', () => {
   it('renders a loading placeholder (not an img) when isLoading=true', () => {
     const images = [makeLoading('pending.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.queryByRole('img')).toBeNull();
     expect(screen.getByText('Loading...')).toBeTruthy();
   });
 
   it('does not render a visible filename alongside the loading placeholder', () => {
     const images = [makeLoading('pending.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     // Filename text must not appear as visible text in loading state either.
     expect(screen.queryByText('pending.png')).toBeNull();
   });
 
   it('renders an img (not a placeholder) when isLoading=false', () => {
     const images = [makeImage('loaded.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.getByRole('img')).toBeTruthy();
     expect(screen.queryByText('Loading...')).toBeNull();
   });
 
   it('renders mixed loaded and loading cards correctly', () => {
     const images = [makeImage('loaded.png'), makeLoading('loading.png')];
-    render(<GalleryGrid images={images} hasCampaign={true} onImageClick={noop} />);
+    render(<GalleryGrid images={images} onImageClick={noop} />);
     expect(screen.getAllByRole('img')).toHaveLength(1);
     expect(screen.getByText('Loading...')).toBeTruthy();
   });


### PR DESCRIPTION
## Summary
- Generalizes `GalleryGrid` so AuthorDetail can mount it: drops the `hasCampaign` prop, adds optional `ariaLabel` / `testId` props. Callers (App.tsx campaign view, AuthorDetail) now render their own empty state — `GalleryGrid` is a pure list view.
- AuthorDetail replaces its inline `<button>`/`<img>` markup with `<GalleryGrid />` and accepts a `gridRef` prop from App. `onOpenImage` gains a 4th `thumbEl` arg.
- App owns both `galleryGridRef` and the new `authorGridRef`. `getThumbElement` now routes by `lightboxImageSource.kind` (read through a ref so the callback stays stable for `useLightboxAnimations`). `openLightboxForAuthor` accepts and forwards `thumbEl` so the author-browse lightbox gets the same hide-active-thumb + zoom-in/out animation parity the campaign gallery has.

Implements bead `fringematrix5-jq33` (child of epic `fringematrix5-0tzn`). Unblocks `fringematrix5-gxw7` (e2e parity test, separate bead).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:client` — 630/630 passing (incl. updated `GalleryGrid.test.tsx`, `AuthorDetail.test.tsx`, `App.openLightboxForAuthor.test.tsx`)
- [x] `npm run test:server` — 107/107 passing
- [x] `npm run build` — production build succeeds
- [x] `npm run test:e2e -- --reporter=line` — 45 passed, 38 skipped (env-gated), 0 failed; existing `author-browse-mode.spec.ts` still green
- [ ] Manual: open author detail → click thumb → clicked cell empty during lightbox; next/prev moves the empty cell; close runs zoom-out; original cell visible again
- [ ] Manual: campaign gallery unchanged

## Notes
- Per-spec, the wrapping `<button>` for keyboard activation on author thumbnails is intentionally dropped to match the campaign-gallery `<img>`-with-onClick pattern. If a screen-reader regression surfaces this will be filed as a follow-up bead.
- `.author-image-button` CSS removed (dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)