### PR TITLE
fringematrix5-pgll: rename user-visible "author/authors" to "artist/artists"

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -665,7 +665,7 @@ export default function App() {
             onClick={navigateToAuthorsIndex}
             disabled={isCampaignLoading}
           >
-            Authors
+            Artists
           </button>
           <button
             className="toolbar-button"

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -74,7 +74,7 @@ export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: P
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Failed to load author detail:', e);
         setData(null);
-        setError('Failed to load author');
+        setError('Failed to load artist');
       }
     })();
     return () => {
@@ -132,15 +132,15 @@ export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: P
         <button
           className="toolbar-button authors-back"
           onClick={onBack}
-          aria-label="Back to authors"
+          aria-label="Back to artists"
         >
-          ← All authors
+          ← All artists
         </button>
       </div>
 
       {isLoading && (
         <div className="authors-status" role="status" aria-live="polite">
-          Loading author…
+          Loading artist…
         </div>
       )}
 
@@ -178,7 +178,7 @@ export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: P
 
           {data.images.length === 0 ? (
             <div className="authors-status" role="status" aria-live="polite">
-              No images attributed to this author yet.
+              No images attributed to this artist yet.
             </div>
           ) : (
             <GalleryGrid

--- a/client/src/components/AuthorsIndex.tsx
+++ b/client/src/components/AuthorsIndex.tsx
@@ -32,7 +32,7 @@ export default function AuthorsIndex({ onSelectAuthor, onBack }: Props) {
         if (cancelled) return;
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Failed to load authors:', e);
-        setError('Failed to load authors');
+        setError('Failed to load artists');
       }
     })();
     return () => {
@@ -55,7 +55,7 @@ export default function AuthorsIndex({ onSelectAuthor, onBack }: Props) {
 
       {isLoading && (
         <div className="authors-status" role="status" aria-live="polite">
-          Loading authors…
+          Loading artists…
         </div>
       )}
 
@@ -67,14 +67,14 @@ export default function AuthorsIndex({ onSelectAuthor, onBack }: Props) {
 
       {isEmpty && (
         <div className="authors-status" role="status" aria-live="polite">
-          No authors found.
+          No artists found.
         </div>
       )}
 
       {authors && authors.length > 0 && (
         <section
           className="authors-grid"
-          aria-label="Authors"
+          aria-label="Artists"
           data-testid="authors-grid"
         >
           {authors.map((author) => (

--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -98,7 +98,7 @@ function AuthorRow({
 
     return (
       <div className="lightbox-details-row lightbox-details-author">
-        <div className="lightbox-details-label">AUTHOR</div>
+        <div className="lightbox-details-label">ARTIST</div>
         <div className="lightbox-details-value lightbox-details-author-value">
           <span
             className="lightbox-author-avatar"
@@ -137,7 +137,7 @@ function AuthorRow({
   if (author.candidates && author.candidates.length > 0) {
     return (
       <div className="lightbox-details-row lightbox-details-author">
-        <div className="lightbox-details-label">AUTHOR</div>
+        <div className="lightbox-details-label">ARTIST</div>
         <div className="lightbox-details-value lightbox-details-author-value">
           <span
             className="lightbox-author-avatar lightbox-author-avatar--unresolved"

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -169,7 +169,7 @@ describe('AuthorDetail', () => {
 
     // Second fetch resolves to 404 — error alert appears.
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load author/i);
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load artist/i);
     });
     errSpy.mockRestore();
   });
@@ -187,7 +187,7 @@ describe('AuthorDetail', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load author/i);
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load artist/i);
     });
     errSpy.mockRestore();
   });

--- a/client/test/AuthorsIndex.test.tsx
+++ b/client/test/AuthorsIndex.test.tsx
@@ -89,7 +89,7 @@ describe('AuthorsIndex', () => {
     render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load authors/i);
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to load artists/i);
     });
     errSpy.mockRestore();
   });
@@ -99,7 +99,7 @@ describe('AuthorsIndex', () => {
     render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/no authors found/i)).toBeTruthy();
+      expect(screen.getByText(/no artists found/i)).toBeTruthy();
     });
     expect(screen.queryByTestId('authors-grid')).toBeNull();
   });

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -69,12 +69,12 @@ describe('LightboxDetails', () => {
 
   it('omits the AUTHOR row when no author prop is provided', () => {
     render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} />);
-    expect(screen.queryByText(/^author$/i)).toBeNull();
+    expect(screen.queryByText(/^artist$/i)).toBeNull();
   });
 
   it('omits the AUTHOR row when author is null', () => {
     render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={null} />);
-    expect(screen.queryByText(/^author$/i)).toBeNull();
+    expect(screen.queryByText(/^artist$/i)).toBeNull();
   });
 
   it('renders an empty-state message when no campaign is provided', () => {

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -256,7 +256,7 @@ describe('LightboxDetails', () => {
 
     it('renders an AUTHOR row with avatar initials and a link for resolved high-confidence authors', () => {
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={resolvedHigh} />);
-      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('ARTIST')).toBeTruthy();
       // Avatar initials derived from camelCase
       expect(screen.getByText('SP')).toBeTruthy();
       const link = screen.getByRole('link', { name: /SarahProost/ });
@@ -269,7 +269,7 @@ describe('LightboxDetails', () => {
 
     it('renders an "uncertain" badge for medium-confidence authors', () => {
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={resolvedMedium} />);
-      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('ARTIST')).toBeTruthy();
       expect(screen.getByText('ZO')).toBeTruthy();
       expect(screen.getByText(/uncertain/i)).toBeTruthy();
       expect(screen.getByRole('link', { name: /Zort70/ })).toBeTruthy();
@@ -277,7 +277,7 @@ describe('LightboxDetails', () => {
 
     it('renders "Possibly: @A, @B, @C" with a "?" avatar for unresolved authors with candidates', () => {
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={unresolved} />);
-      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('ARTIST')).toBeTruthy();
       expect(screen.getByText('?')).toBeTruthy();
       expect(screen.getByText(/Possibly:\s*@AliceA,\s*@BobB,\s*@Carol_C/)).toBeTruthy();
       // No link in unresolved state.
@@ -293,7 +293,7 @@ describe('LightboxDetails', () => {
         candidates: [],
       };
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={empty} />);
-      expect(screen.queryByText(/^author$/i)).toBeNull();
+      expect(screen.queryByText(/^artist$/i)).toBeNull();
     });
 
     it('does not render a link when twitterUrl is missing for a resolved author', () => {
@@ -305,7 +305,7 @@ describe('LightboxDetails', () => {
         candidates: [],
       };
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={noUrl} />);
-      expect(screen.getByText('AUTHOR')).toBeTruthy();
+      expect(screen.getByText('ARTIST')).toBeTruthy();
       expect(screen.getByText('CH')).toBeTruthy();
       expect(screen.getByText('@cheribot')).toBeTruthy();
       expect(screen.queryByRole('link', { name: /cheribot/ })).toBeNull();

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -95,7 +95,7 @@ test.describe('Lightbox AUTHOR row — resolved (high confidence)', () => {
     // AUTHOR row should be present.
     const authorRow = sidebar.locator('.lightbox-details-author');
     await expect(authorRow).toBeVisible();
-    await expect(authorRow.getByText('AUTHOR', { exact: true })).toBeVisible();
+    await expect(authorRow.getByText('ARTIST', { exact: true })).toBeVisible();
 
     // Avatar element with initials derived from '@Zort70' → 'ZO' (one
     // uppercase letter in the handle, so getInitials() falls through to the
@@ -143,7 +143,7 @@ test.describe('Lightbox AUTHOR row — unresolved with candidates', () => {
     const sidebar = page.locator('.lightbox-details').first();
     const authorRow = sidebar.locator('.lightbox-details-author');
     await expect(authorRow).toBeVisible();
-    await expect(authorRow.getByText('AUTHOR', { exact: true })).toBeVisible();
+    await expect(authorRow.getByText('ARTIST', { exact: true })).toBeVisible();
 
     // Unresolved avatar shows a literal '?'.
     const avatar = authorRow.locator('.lightbox-author-avatar--unresolved');


### PR DESCRIPTION
## Summary

Renames every user-facing occurrence of "author/authors/AUTHOR" to "artist/artists/ARTIST" while keeping identifiers (API routes, TypeScript types, file names, CSS classes, data-testids, URL hash routes, code comments) untouched.

User-visible changes:
- Lightbox info-box label `AUTHOR` → `ARTIST` (both resolved and unresolved branches).
- Toolbar button `Authors` → `Artists`.
- Author detail page: `← All authors` → `← All artists`; aria-label `Back to authors` → `Back to artists`; `Loading author…` → `Loading artist…`; `Failed to load author` → `Failed to load artist`; `No images attributed to this author yet.` → `… to this artist yet.`
- Authors index page: `Loading authors…` → `Loading artists…`; `No authors found.` → `No artists found.`; `Failed to load authors` → `Failed to load artists`; grid `aria-label="Authors"` → `"Artists"`. (Heading was already `Artists`.)

Internal-only — unchanged on purpose:
- API routes `/api/authors`, `/api/authors/:handle`.
- TS types `Author`, `AuthorWithCount`, `ImageAuthor`.
- Component files `AuthorDetail.tsx`, `AuthorsIndex.tsx`.
- CSS classes (`.lightbox-details-author`, `.author-card`, `.author-handle`, …).
- `data-testid` attributes.
- URL hash routes `#authors` / `#authors/<handle>` (bookmark stability).
- Code comments, JSDoc, bead identifiers.

Tests updated in lockstep where they assert on visible text:
- `client/test/LightboxDetails.test.tsx` — `getByText('AUTHOR')` → `'ARTIST'` (5 places).
- `client/test/AuthorsIndex.test.tsx` — error / empty-state regexes.
- `client/test/AuthorDetail.test.tsx` — error message regex.
- `e2e/lightbox-author-row.spec.ts` — `getByText('AUTHOR')` → `'ARTIST'`.

## Test plan

- [x] `npm run typecheck` (client) — clean.
- [x] `npm run test:server` — 107 passing.
- [x] `npm run test:client` — 635 passing.
- [x] `npm run build` — clean.
- [x] `npm run test:e2e` — 46 passing, 38 skipped (campaign-data-dependent), 0 failing.

## Follow-ups

None planned — bead scope is strictly visible-label rename.

Closes fringematrix5-pgll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)