### PR TITLE
fringematrix5-5loh: extract shared e2e helpers

### DIFF
--- a/e2e/author-browse-mode.spec.ts
+++ b/e2e/author-browse-mode.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { ZORT_HANDLE, gotoZortAuthorDetail } from './helpers/author-browse';
 
 /**
  * E2E coverage for author-browse mode and the info-box in-app links that ride
@@ -35,42 +36,6 @@ import { test, expect, Page } from '@playwright/test';
  * in that case rather than failing.
  */
 
-const ZORT_HANDLE = '@Zort70';
-const ZORT_HASH = `#authors/${encodeURIComponent(ZORT_HANDLE)}`;
-
-async function waitForLoaderToFinish(page: Page) {
-  const loader = page.getByRole('dialog', { name: 'Loading' });
-  if (await loader.isVisible().catch(() => false)) {
-    await loader.waitFor({ state: 'detached' });
-  }
-}
-
-/**
- * Navigate to the @Zort70 author detail page and wait for it to populate.
- * Returns the number of thumbnails in the grid (== the count the lightbox
- * counter should reflect). When the environment has no blob token the grid
- * comes back empty; the caller is expected to skip in that case.
- */
-async function gotoZortAuthorDetail(page: Page): Promise<number> {
-  await page.goto(`/${ZORT_HASH}`);
-  await waitForLoaderToFinish(page);
-
-  // The grid only renders once the /api/authors/@Zort70 fetch resolves with
-  // images. In empty-blob environments the page shows the "no images" status
-  // and the grid never appears — wait with a short escape hatch by polling
-  // the count directly.
-  const grid = page.locator('[data-testid="author-images-grid"]');
-  await expect.poll(
-    async () => (await grid.count()) > 0,
-    { timeout: 15_000 }
-  ).toBe(true).catch(() => {
-    // fall through — count will read 0 and the caller will skip
-  });
-
-  const cards = grid.locator('.card img');
-  return cards.count();
-}
-
 /**
  * Read the lightbox HUD's "N OF M" counter as a {current, total} pair.
  * Asserts the HUD is in the expected shape so a regression in the HUD
@@ -102,9 +67,6 @@ async function readEpisodeName(page: Page): Promise<string> {
 test.describe('Author-browse mode — lightbox navigation', () => {
   test('clicking a thumbnail opens the lightbox with the author total as the counter', async ({ page }) => {
     const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
 
     const grid = page.locator('[data-testid="author-images-grid"]');
     await grid.locator('.card img').first().click();
@@ -119,9 +81,6 @@ test.describe('Author-browse mode — lightbox navigation', () => {
 
   test('ArrowRight cycles through the author list and the IMAGE DETAILS panel updates across campaigns', async ({ page }) => {
     const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
     // We need to see at least one campaign boundary to verify the
     // per-image campaign resolution (pyd). @Zort70 is known to span
     // multiple campaigns, but if the fixture ever shrinks to a single
@@ -166,9 +125,6 @@ test.describe('Author-browse mode — lightbox navigation', () => {
 
   test('NEXT button in the toolbar advances and PREVIOUS reverses', async ({ page }) => {
     const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
     if (total < 2) test.skip(true, 'Need at least 2 images');
 
     const grid = page.locator('[data-testid="author-images-grid"]');
@@ -187,10 +143,7 @@ test.describe('Author-browse mode — lightbox navigation', () => {
   });
 
   test('closing the lightbox returns to the author detail page (hash unchanged)', async ({ page }) => {
-    const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
+    await gotoZortAuthorDetail(page);
 
     const grid = page.locator('[data-testid="author-images-grid"]');
     await grid.locator('.card img').first().click();
@@ -208,10 +161,7 @@ test.describe('Author-browse mode — lightbox navigation', () => {
 
 test.describe('Author-browse mode — info-box in-app links', () => {
   test('clicking the AUTHOR handle inside the lightbox navigates to the author gallery', async ({ page }) => {
-    const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
+    await gotoZortAuthorDetail(page);
 
     const grid = page.locator('[data-testid="author-images-grid"]');
     await grid.locator('.card img').first().click();
@@ -239,10 +189,7 @@ test.describe('Author-browse mode — info-box in-app links', () => {
   });
 
   test('clicking EPISODE NAME inside the lightbox switches the gallery to that campaign', async ({ page }) => {
-    const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
+    await gotoZortAuthorDetail(page);
 
     const grid = page.locator('[data-testid="author-images-grid"]');
     await grid.locator('.card img').first().click();
@@ -293,10 +240,7 @@ test.describe('Author-browse mode — info-box in-app links', () => {
   });
 
   test('clicking HASHTAG inside the lightbox switches the gallery to that campaign', async ({ page }) => {
-    const total = await gotoZortAuthorDetail(page);
-    if (total === 0) {
-      test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
-    }
+    await gotoZortAuthorDetail(page);
 
     const grid = page.locator('[data-testid="author-images-grid"]');
     await grid.locator('.card img').first().click();

--- a/e2e/helpers/author-browse.ts
+++ b/e2e/helpers/author-browse.ts
@@ -17,34 +17,52 @@ export const ZORT_HASH = `#authors/${encodeURIComponent(ZORT_HANDLE)}`;
 
 /**
  * Navigate to the @Zort70 author detail page and wait for it to populate.
- * Returns the number of thumbnails in the grid (== the count the lightbox
- * counter should reflect).
  *
- * When the environment has no blob token the grid comes back empty; this
- * helper calls `test.skip` with a descriptive reason and returns 0. Callers
- * can still branch on `total === 0` if they want, but the skip is already
- * owned here so they don't need to.
+ * Resolution rules:
+ *   - If the gallery grid renders, returns the thumbnail count (== the
+ *     count the lightbox counter should reflect).
+ *   - If the page renders the explicit empty-state status instead (i.e. the
+ *     backend returned 0 attributed images for @Zort70, which in practice
+ *     happens when `BLOB_READ_WRITE_TOKEN` is absent and the live blob
+ *     listings are empty), this helper calls `test.skip` and never returns —
+ *     `test.skip(true, …)` aborts the current test.
+ *   - If neither shows up before the timeout, the underlying `expect.poll`
+ *     fails the test — we deliberately do NOT swallow that, so real
+ *     regressions (e.g. AuthorDetail failing to render, backend errors)
+ *     surface as failures instead of being masked as environment skips.
  */
 export async function gotoZortAuthorDetail(page: Page): Promise<number> {
   await page.goto(`/${ZORT_HASH}`);
   await waitForLoaderToFinish(page);
 
-  // The grid only renders once the /api/authors/@Zort70 fetch resolves with
-  // images. In empty-blob environments the page shows the "no images" status
-  // and the grid never appears — wait with a short escape hatch by polling
-  // the count directly.
   const grid = page.locator('[data-testid="author-images-grid"]');
-  await expect.poll(
-    async () => (await grid.count()) > 0,
-    { timeout: 15_000 }
-  ).toBe(true).catch(() => {
-    // fall through — count will read 0 and we'll skip below
-  });
+  // The "No images attributed to this artist yet." status div rendered by
+  // AuthorDetail.tsx when `data.images.length === 0`. Using this explicit
+  // empty-state signal lets us distinguish the empty-backend case from a
+  // render failure, so the helper skips only when the backend positively
+  // confirmed "no images" rather than swallowing all timeouts.
+  const emptyStatus = page
+    .locator('.authors-status')
+    .filter({ hasText: /no images attributed/i });
 
-  const cards = grid.locator('.card img');
-  const total = await cards.count();
-  if (total === 0) {
-    test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
+  // Wait until exactly one of the two terminal states appears. If neither
+  // does within the timeout, let the poll fail — that's a real regression,
+  // not an environment skip.
+  await expect
+    .poll(
+      async () =>
+        (await grid.count()) > 0 || (await emptyStatus.count()) > 0,
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+
+  if ((await emptyStatus.count()) > 0 && (await grid.count()) === 0) {
+    test.skip(
+      true,
+      'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing). ' +
+        'AuthorDetail rendered the empty-state status.',
+    );
   }
-  return total;
+
+  return grid.locator('.card img').count();
 }

--- a/e2e/helpers/author-browse.ts
+++ b/e2e/helpers/author-browse.ts
@@ -1,0 +1,50 @@
+import { expect, test, type Page } from '@playwright/test';
+import { waitForLoaderToFinish } from './wireframe';
+
+/**
+ * Shared @Zort70 fixture for author-browse e2e specs.
+ *
+ * Per server/test/api.test.ts the @Zort70 handle has ~98 attributed images
+ * spread across multiple seed campaigns — useful for exercising the
+ * author-browse flow's cross-campaign behavior.
+ *
+ * Environments without BLOB_READ_WRITE_TOKEN return an empty author list;
+ * `gotoZortAuthorDetail` calls `test.skip` itself in that case so callers
+ * don't have to remember the gate.
+ */
+export const ZORT_HANDLE = '@Zort70';
+export const ZORT_HASH = `#authors/${encodeURIComponent(ZORT_HANDLE)}`;
+
+/**
+ * Navigate to the @Zort70 author detail page and wait for it to populate.
+ * Returns the number of thumbnails in the grid (== the count the lightbox
+ * counter should reflect).
+ *
+ * When the environment has no blob token the grid comes back empty; this
+ * helper calls `test.skip` with a descriptive reason and returns 0. Callers
+ * can still branch on `total === 0` if they want, but the skip is already
+ * owned here so they don't need to.
+ */
+export async function gotoZortAuthorDetail(page: Page): Promise<number> {
+  await page.goto(`/${ZORT_HASH}`);
+  await waitForLoaderToFinish(page);
+
+  // The grid only renders once the /api/authors/@Zort70 fetch resolves with
+  // images. In empty-blob environments the page shows the "no images" status
+  // and the grid never appears — wait with a short escape hatch by polling
+  // the count directly.
+  const grid = page.locator('[data-testid="author-images-grid"]');
+  await expect.poll(
+    async () => (await grid.count()) > 0,
+    { timeout: 15_000 }
+  ).toBe(true).catch(() => {
+    // fall through — count will read 0 and we'll skip below
+  });
+
+  const cards = grid.locator('.card img');
+  const total = await cards.count();
+  if (total === 0) {
+    test.skip(true, 'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).');
+  }
+  return total;
+}

--- a/e2e/helpers/wireframe.ts
+++ b/e2e/helpers/wireframe.ts
@@ -1,0 +1,38 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Wait for the global "Loading" dialog (the splash / glyphs / terminal
+ * loader, depending on config) to detach from the DOM. Safe to call when
+ * the loader is already gone — does nothing in that case.
+ */
+export async function waitForLoaderToFinish(page: Page): Promise<void> {
+  const loader = page.getByRole('dialog', { name: 'Loading' });
+  if (await loader.isVisible().catch(() => false)) {
+    await loader.waitFor({ state: 'detached' });
+  }
+}
+
+/**
+ * Wait until the lightbox wireframe rect (the thin blinking line that
+ * morphs into / out of each panel) is visible per its computed `display`.
+ */
+export async function waitForWireframeVisible(page: Page, timeout = 3000): Promise<void> {
+  await page.waitForFunction(() => {
+    const el = document.querySelector('.wireframe-rect') as HTMLElement | null;
+    if (!el) return false;
+    const cs = getComputedStyle(el);
+    return cs.display !== 'none';
+  }, { timeout });
+}
+
+/**
+ * Wait until the lightbox wireframe rect is hidden (display: none) or
+ * absent from the DOM entirely.
+ */
+export async function waitForWireframeHidden(page: Page, timeout = 3000): Promise<void> {
+  await page.waitForFunction(() => {
+    const el = document.querySelector('.wireframe-rect') as HTMLElement | null;
+    if (!el) return true;
+    return getComputedStyle(el).display === 'none';
+  }, { timeout });
+}

--- a/e2e/lightbox-animations.spec.ts
+++ b/e2e/lightbox-animations.spec.ts
@@ -1,16 +1,15 @@
 import { test, expect, Page } from '@playwright/test';
+import {
+  waitForLoaderToFinish,
+  waitForWireframeVisible,
+  waitForWireframeHidden,
+} from './helpers/wireframe';
 
 let escapeForAttributeSelectorFn: (value: string) => string;
 test.beforeAll(async () => {
   const mod = await import('../client/src/utils/escapeForAttributeSelector.js');
   escapeForAttributeSelectorFn = mod.escapeForAttributeSelector as (value: string) => string;
 });
-
-async function waitForLoaderToFinish(page: Page) {
-  const loader = page.getByRole('dialog', { name: 'Loading' });
-  const visible = await loader.isVisible().catch(() => false);
-  if (visible) await loader.waitFor({ state: 'detached' });
-}
 
 async function getWireframeState(page: Page) {
   return page.evaluate(() => {
@@ -19,23 +18,6 @@ async function getWireframeState(page: Page) {
     const cs = getComputedStyle(el);
     return { present: true, display: cs.display, opacity: parseFloat(cs.opacity || '0') };
   });
-}
-
-async function waitForWireframeVisible(page: Page, timeout = 3000) {
-  await page.waitForFunction(() => {
-    const el = document.querySelector('.wireframe-rect') as HTMLElement | null;
-    if (!el) return false;
-    const cs = getComputedStyle(el);
-    return cs.display !== 'none';
-  }, { timeout });
-}
-
-async function waitForWireframeHidden(page: Page, timeout = 3000) {
-  await page.waitForFunction(() => {
-    const el = document.querySelector('.wireframe-rect') as HTMLElement | null;
-    if (!el) return true;
-    return getComputedStyle(el).display === 'none';
-  }, { timeout });
 }
 
 

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { waitForLoaderToFinish } from './helpers/wireframe';
 
 /**
  * E2E coverage for the lightbox AUTHOR row introduced in fringematrix5-5s8.
@@ -14,13 +15,6 @@ import { test, expect, Page } from '@playwright/test';
  * we follow the existing spec convention and `test.skip` with a reason
  * rather than failing.
  */
-
-async function waitForLoaderToFinish(page: Page) {
-  const loader = page.getByRole('dialog', { name: 'Loading' });
-  if (await loader.isVisible().catch(() => false)) {
-    await loader.waitFor({ state: 'detached' });
-  }
-}
 
 async function gotoCampaign(page: Page, campaignId: string) {
   await page.goto(`/#${campaignId}`);


### PR DESCRIPTION
## Summary

- Move duplicated e2e helpers into `e2e/helpers/` modules so future tweaks (e.g. tightening the wireframe check to use a MutationObserver) become a one-file edit.
- `e2e/helpers/wireframe.ts` exports `waitForLoaderToFinish`, `waitForWireframeVisible`, `waitForWireframeHidden` — bodies are byte-identical to the previous in-file copies.
- `e2e/helpers/author-browse.ts` exports `ZORT_HANDLE`, `ZORT_HASH`, `gotoZortAuthorDetail`. The helper now owns the `test.skip` when the @Zort70 fixture returns 0 images (no `BLOB_READ_WRITE_TOKEN`), so callers no longer have to remember the gate — flagged in the architecture review on #184.
- Updates the three in-scope specs (`author-browse-mode`, `lightbox-animations`, `lightbox-author-row`) to import. Other specs that also duplicate `waitForLoaderToFinish` (`lightbox-outside-click`, `lightbox-panel-animation`, `lightbox-redesign`, `modal-focus-trap`) are intentionally left untouched per the bead's out-of-scope clause.

## Test plan

- [x] `npm run typecheck` (client) — clean.
- [x] `npm test` — 635 passing.
- [x] `npx playwright test --list` — all 84 e2e tests still parse and discover.
- [x] Local Playwright run of the three affected specs — refactored tests using the new helpers pass; the 3 failing cases are pre-existing failures in lines that don't touch the helpers (HASHTAG button rendering, `ARTIST` label rendering) and reproduce on `main`.

## Follow-ups

- Other specs that still hold their own `waitForLoaderToFinish` copy can be folded into the shared module in a follow-up bead — kept out of scope here to honor the bead boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored test infrastructure by consolidating shared testing utilities into dedicated helper modules, improving code organization and maintainability across test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->