### PR TITLE
fringematrix5-u7gd: fix lightbox campaign link no-op from artist mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -548,19 +548,33 @@ export default function App() {
     navigateToAuthorDetail(handle);
   }, [closeLightbox, navigateToAuthorDetail]);
 
-  // Stable handler for the EPISODE NAME affordance in `LightboxDetails`.
-  // Hoisted into useCallback so `LightboxDetails` — which is React.memo'd —
-  // doesn't re-render on every App render just because a fresh inline arrow
-  // would change prop identity. (Spotted in Copilot review of fringematrix5-c320.)
+  // Stable handler for the EPISODE NAME / HASHTAG affordance in
+  // `LightboxDetails`. Hoisted into useCallback so `LightboxDetails` — which is
+  // React.memo'd — doesn't re-render on every App render just because a fresh
+  // inline arrow would change prop identity. (Spotted in Copilot review of
+  // fringematrix5-c320.)
+  //
+  // Routing semantics (fringematrix5-u7gd):
+  // Always force the route back to {type: 'gallery', campaignId} regardless of
+  // whether activeCampaignId already matches. The lightbox can be opened from
+  // artist-browse mode (route = author-detail) on an image whose source
+  // campaign equals the previously-active campaign id; in that case
+  // selectCampaign would early-return because the campaign isn't changing, and
+  // the route would stay stranded on the artist page. Updating the hash
+  // unconditionally guarantees the user lands on the campaign gallery view.
+  // selectCampaign is only invoked when the campaign actually needs to change.
   const handleOpenCampaignGallery = useCallback((campaignId: string) => {
-    // Always close the lightbox; if the gallery is already showing this
-    // campaign the selectCampaign call is a no-op and we just return to
-    // the existing view. When author-browse mode (fringematrix5-ik5)
-    // lands and the lightbox can show images from a non-active
-    // campaign, this same branch will perform a real switch.
     closeLightbox();
     if (campaignId !== activeCampaignId) {
+      // selectCampaign handles both the data fetch and the route update
+      // (it sets the hash and route via its inner callback).
       selectCampaign(campaignId);
+    } else {
+      // Same campaign as the currently-active one; selectCampaign would be a
+      // no-op so we update the hash + route ourselves to leave artist-browse
+      // mode (or any other non-gallery route) and return to the gallery view.
+      window.history.replaceState({}, '', `#${campaignId}`);
+      setRoute({ type: 'gallery', campaignId });
     }
   }, [closeLightbox, activeCampaignId, selectCampaign]);
 

--- a/client/test/App.openCampaignFromArtistMode.test.tsx
+++ b/client/test/App.openCampaignFromArtistMode.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import App from '../src/App';
+
+/**
+ * Regression test for fringematrix5-u7gd: when the user is in artist-browse
+ * mode (route = author-detail) and the lightbox is showing an image whose
+ * source campaign happens to equal `activeCampaignId` (which was set BEFORE
+ * the user entered artist mode), clicking the campaign link in the lightbox
+ * info box must navigate to that campaign's gallery view.
+ *
+ * Previously the handler short-circuited when `campaignId === activeCampaignId`
+ * and never updated the route off of `{type: 'author-detail'}`, leaving the
+ * user stranded on the artist page after the lightbox closed.
+ */
+
+const HANDLE = '@Zort70';
+const AUTHOR_HASH = `#authors/${encodeURIComponent(HANDLE)}`;
+const CAMPAIGN_ID = 'crosstheline';
+const OTHER_CAMPAIGN_ID = 'letters';
+
+// Author has images in TWO campaigns. The FIRST image's campaign matches the
+// app's initial activeCampaignId (`crosstheline`) — that's the bug path.
+const SAMPLE_AUTHOR_DETAIL = {
+  author: {
+    handle: HANDLE,
+    name: 'Sarah Proost',
+    twitterUrl: 'https://twitter.com/Zort70',
+    alternateHandles: [],
+    roles: ['artist'],
+  },
+  images: [
+    {
+      src: '/avatars/Season4/CrossTheLine/abc.jpg',
+      fileName: 'abc.jpg',
+      blobPath: 'avatars/Season4/CrossTheLine/abc.jpg',
+      campaignId: CAMPAIGN_ID,
+      confidence: 'high' as const,
+    },
+    {
+      src: '/avatars/Season4/Letters/ghi.jpg',
+      fileName: 'ghi.jpg',
+      blobPath: 'avatars/Season4/Letters/ghi.jpg',
+      campaignId: OTHER_CAMPAIGN_ID,
+      confidence: 'high' as const,
+    },
+  ],
+};
+
+const CAMPAIGNS = [
+  {
+    id: CAMPAIGN_ID,
+    episode: 'Cross The Line',
+    episode_id: 'S04E18',
+    hashtag: 'CrossTheLine',
+    date: '2012-04-13',
+    icon_path: 'Season4/CrossTheLine',
+  },
+  {
+    id: OTHER_CAMPAIGN_ID,
+    episode: 'Letters of Transit',
+    episode_id: 'S04E19',
+    hashtag: 'Letters',
+    date: '2012-04-20',
+    icon_path: 'Season4/Letters',
+  },
+];
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeFetchMock() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.startsWith('/api/campaigns/') && url.endsWith('/images')) {
+      // Empty image lists keep the campaign-load dance fast; the lightbox
+      // here is bound to the author's image list, not the campaign's.
+      return jsonResponse({ images: [] });
+    }
+    if (url === '/api/campaigns') {
+      return jsonResponse({ campaigns: CAMPAIGNS });
+    }
+    if (url === '/api/build-info') {
+      return jsonResponse({ commitHash: 'dev-local', deployedAt: null });
+    }
+    if (url === '/api/glyphs') {
+      return jsonResponse({ glyphs: [] });
+    }
+    if (url === `/api/authors/${encodeURIComponent(HANDLE)}`) {
+      return jsonResponse(SAMPLE_AUTHOR_DETAIL);
+    }
+
+    return jsonResponse({ error: `Unmocked URL: ${url}` }, 404);
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  window.localStorage.setItem(
+    'fringematrix-a11y',
+    JSON.stringify({ reduceMotion: true, reduceEffects: true, thumbnailSizeIndex: 0 }),
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.history.replaceState({}, '', window.location.pathname);
+});
+
+describe('App: campaign-link navigation from artist-browse lightbox (fringematrix5-u7gd)', () => {
+  it('navigates to the gallery when the lightbox image campaign equals activeCampaignId', async () => {
+    // Simulate the repro path: start on the campaign gallery so
+    // activeCampaignId becomes CAMPAIGN_ID, THEN enter artist-browse mode.
+    window.location.hash = CAMPAIGN_ID;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // Wait for the campaign to actually load (activeCampaignId becomes CAMPAIGN_ID).
+    // We can detect this indirectly by waiting until the campaigns fetch settled.
+    await waitFor(() => {
+      // The Home button is unconditionally rendered once campaigns load;
+      // checking it ensures App is past the loading screen.
+      expect(screen.queryByRole('button', { name: /go to home/i })).toBeTruthy();
+    });
+
+    // Now navigate into artist-browse mode by setting the hash. This mimics
+    // the user clicking an artist link from inside a campaign-gallery lightbox.
+    await act(async () => {
+      window.location.hash = AUTHOR_HASH;
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    // Wait for the author-detail grid to render.
+    const grid = await screen.findByTestId('author-images-grid');
+    const imgs = grid.querySelectorAll('img');
+    expect(imgs.length).toBe(2);
+
+    // Click the FIRST thumbnail — its source campaign matches the previously
+    // active campaign. This is the bug path.
+    await act(async () => {
+      fireEvent.click(imgs[0]!);
+    });
+
+    const lightbox = await screen.findByRole('dialog', { name: /image viewer/i });
+    expect(lightbox).toBeTruthy();
+
+    // Find and click the campaign-link button in the lightbox details. It
+    // carries the dedicated `lightbox-details-campaign-link` class.
+    const campaignLink = lightbox.querySelector(
+      'button.lightbox-details-campaign-link',
+    ) as HTMLButtonElement | null;
+    expect(campaignLink).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(campaignLink!);
+    });
+
+    // Expected: hash and route flip to the campaign gallery view. Previously
+    // the route stayed on #authors/<handle> because the handler short-circuited.
+    await waitFor(() => {
+      expect(window.location.hash).toBe(`#${CAMPAIGN_ID}`);
+    });
+
+    // The author-detail grid must no longer be on screen — confirming the
+    // route actually flipped to the gallery view.
+    await waitFor(() => {
+      expect(screen.queryByTestId('author-images-grid')).toBeNull();
+    });
+  });
+
+  it('still navigates correctly when the lightbox image campaign differs from activeCampaignId', async () => {
+    // Sanity-check the non-buggy path: clicking the campaign link for an
+    // image whose campaign differs from activeCampaignId continues to work.
+    window.location.hash = CAMPAIGN_ID;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /go to home/i })).toBeTruthy();
+    });
+
+    await act(async () => {
+      window.location.hash = AUTHOR_HASH;
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    const grid = await screen.findByTestId('author-images-grid');
+    const imgs = grid.querySelectorAll('img');
+
+    // Click the SECOND thumbnail — its campaign (`letters`) differs from
+    // the currently active campaign (`crosstheline`).
+    await act(async () => {
+      fireEvent.click(imgs[1]!);
+    });
+
+    const lightbox = await screen.findByRole('dialog', { name: /image viewer/i });
+    const campaignLink = lightbox.querySelector(
+      'button.lightbox-details-campaign-link',
+    ) as HTMLButtonElement | null;
+    expect(campaignLink).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(campaignLink!);
+    });
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe(`#${OTHER_CAMPAIGN_ID}`);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('author-images-grid')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Bead

fringematrix5-u7gd — Lightbox campaign link is a no-op when current artist-browse came from same campaign

## Summary

When the lightbox was opened from artist-browse mode (`#authors/<handle>`) on an image whose source campaign equals the previously-active `activeCampaignId`, clicking the campaign link in the lightbox info box (EPISODE NAME or HASHTAG) closed the lightbox but left the route stranded on `#authors/<handle>` — the user stayed in artist mode.

**Root cause:** `handleOpenCampaignGallery` in `client/src/App.tsx` only called `selectCampaign` when `campaignId !== activeCampaignId`, and relied on `selectCampaign`'s inner `setRoute` to update the route off of `{type: 'author-detail'}`. When the IDs matched, `selectCampaign` was skipped and nothing updated the route.

**Fix:** When the campaign is already active, push the gallery hash + route ourselves (`window.history.replaceState` + `setRoute`); otherwise call `selectCampaign` as before. Also updated the stale comment that referred to author-browse as future work — it has landed.

## Test plan

- [x] New Vitest regression test `client/test/App.openCampaignFromArtistMode.test.tsx` reproduces the exact bug path (artist mode → image whose campaignId equals activeCampaignId → click campaign link → expect hash to become `#<campaignId>` and author grid to unmount). Verified the test fails against the buggy code and passes with the fix.
- [x] Sanity-check test in the same file covers the non-buggy "different campaign" path so the fix doesn't regress it.
- [x] `npm run typecheck` clean
- [x] `npm test` — 643 / 643 client unit tests pass
- [x] `npm run test:e2e` — 50 passed, 38 skipped, 0 failed
- [x] `npm run build` clean

## Follow-ups

Broader unit-test coverage of artist/campaign navigation across all origin modes is tracked by **fringematrix5-z874** — this PR adds targeted coverage for the u7gd bug path only and intentionally does not duplicate that wider matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lightbox campaign-link behavior so clicking an episode name/hashtag reliably returns users to the correct campaign gallery (including when already viewing that campaign), and ensures the URL and view update from artist-browse/author modes.

* **Tests**
  * Added regression tests to verify campaign navigation from artist-browse/lightbox and to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikolai3d/fringematrix5/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->