### PR TITLE
fringematrix5-urzh: artist name in nav bar + artist switcher in artist-browse mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -242,14 +242,16 @@ export default function App() {
     selectCampaignRef.current?.(route.campaignId);
   }, [route, campaigns, activeCampaignId]);
 
-  // Lazily fetch the artists list the first time we land on an authors route
-  // (index or detail). The artists switcher in the top/bottom navbars and the
-  // AuthorsIndex page both benefit from this cached list — but AuthorsIndex
-  // keeps its own fetch for backward compatibility (it surfaces its own
-  // loading / error state). We only fetch once per session; refetching would
-  // require invalidation logic that isn't worth the complexity here.
+  // Lazily fetch the artists list the first time we land on the author-detail
+  // route. Only the artist nav-switcher (in the top/bottom navbars) needs
+  // this list at the App level — AuthorsIndex keeps its own fetch with its
+  // own loading/error state. Scoped to `author-detail` so visiting the
+  // authors-index page does NOT trigger a duplicate /api/authors request
+  // alongside the one AuthorsIndex already makes. We only fetch once per
+  // session; refetching would require invalidation logic that isn't worth
+  // the complexity here.
   useEffect(() => {
-    if (route.type !== 'author-detail' && route.type !== 'authors-index') return;
+    if (route.type !== 'author-detail') return;
     if (artists !== null) return;
     const controller = new AbortController();
     let cancelled = false;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,8 @@ import type {
   ContentResponse,
   ImageData,
   LightboxImageSource,
+  AuthorWithCount,
+  AuthorsResponse,
 } from './types/api';
 
 export default function App() {
@@ -97,6 +99,15 @@ export default function App() {
   const settingsTriggerRef = useRef<HTMLElement | null>(null);
   const modalLoadAbortRef = useRef<AbortController | null>(null);
   const modalTriggerRef = useRef<HTMLElement | null>(null);
+
+  // Artists list cached at App-level so the artist switcher in the top/bottom
+  // navbars (used when route.type === 'author-detail') can render prev/next
+  // arrows + the current artist name without each navigation re-fetching the
+  // full list. Lazily fetched the first time we land on an author-detail
+  // route, then reused for the rest of the session. Reuses the existing
+  // `/api/authors` endpoint that powers AuthorsIndex — no new server work
+  // required for this bead.
+  const [artists, setArtists] = useState<AuthorWithCount[] | null>(null);
 
   // Route state: which top-level view to render. Driven by the URL hash so it
   // survives reloads and is bookmarkable. The hash also drives campaign
@@ -230,6 +241,80 @@ export default function App() {
     if (!exists) return;
     selectCampaignRef.current?.(route.campaignId);
   }, [route, campaigns, activeCampaignId]);
+
+  // Lazily fetch the artists list the first time we land on an authors route
+  // (index or detail). The artists switcher in the top/bottom navbars and the
+  // AuthorsIndex page both benefit from this cached list — but AuthorsIndex
+  // keeps its own fetch for backward compatibility (it surfaces its own
+  // loading / error state). We only fetch once per session; refetching would
+  // require invalidation logic that isn't worth the complexity here.
+  useEffect(() => {
+    if (route.type !== 'author-detail' && route.type !== 'authors-index') return;
+    if (artists !== null) return;
+    const controller = new AbortController();
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchJSON<AuthorsResponse>('/api/authors', { signal: controller.signal });
+        if (cancelled) return;
+        setArtists(data.authors ?? []);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load artists for nav switcher:', e);
+        // Set to empty array so we stop retrying. The nav switcher will fall
+        // back to showing just the handle from the route — better than
+        // looping fetches.
+        setArtists([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [route.type, artists]);
+
+  // Resolve the currently active artist (when on the author-detail route)
+  // from the cached artists list. Returns null if the list hasn't loaded yet
+  // or if the handle isn't in the list — callers fall back to the raw handle
+  // from the route.
+  const activeArtist = useMemo<AuthorWithCount | null>(() => {
+    if (route.type !== 'author-detail') return null;
+    if (!artists) return null;
+    return artists.find((a) => a.handle === route.handle) ?? null;
+  }, [route, artists]);
+
+  // Title shown in the top/bottom navbars when on the author-detail route.
+  // Prefers the resolved display name from the artists list; falls back to
+  // the URL handle so the bar is never empty while the list is still loading
+  // or if the handle isn't found.
+  const artistNavTitle = useMemo<string>(() => {
+    if (route.type !== 'author-detail') return '';
+    if (activeArtist) return activeArtist.name || activeArtist.handle;
+    return route.handle;
+  }, [route, activeArtist]);
+
+  const activeArtistIndex = useMemo<number>(() => {
+    if (route.type !== 'author-detail') return -1;
+    if (!artists) return -1;
+    return artists.findIndex((a) => a.handle === route.handle);
+  }, [route, artists]);
+
+  const goToNextArtist = useCallback(() => {
+    if (!artists || artists.length === 0) return;
+    const nextIdx = activeArtistIndex < 0 ? 0 : (activeArtistIndex + 1) % artists.length;
+    const next = artists[nextIdx];
+    if (next) navigateToAuthorDetail(next.handle);
+  }, [artists, activeArtistIndex, navigateToAuthorDetail]);
+
+  const goToPrevArtist = useCallback(() => {
+    if (!artists || artists.length === 0) return;
+    const prevIdx = activeArtistIndex < 0
+      ? artists.length - 1
+      : (activeArtistIndex - 1 + artists.length) % artists.length;
+    const prev = artists[prevIdx];
+    if (prev) navigateToAuthorDetail(prev.handle);
+  }, [artists, activeArtistIndex, navigateToAuthorDetail]);
 
   const activeIndex = useMemo(() => {
     if (!activeCampaignId) return -1;
@@ -691,11 +776,37 @@ export default function App() {
       </div>
       <header className="navbar" id="top-navbar">
         <div className="navbar-inner">
-          <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
-          <div className="current-campaign" data-testid="current-campaign-top" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
-            {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
-          </div>
-          <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
+          {route.type === 'author-detail' ? (
+            <>
+              <button
+                className="nav-arrow"
+                aria-label="Previous artist"
+                onClick={goToPrevArtist}
+                disabled={!artists || artists.length <= 1}
+              >◀</button>
+              <div
+                className="current-campaign"
+                data-testid="current-artist-top"
+                title={artistNavTitle}
+              >
+                {artistNavTitle}
+              </div>
+              <button
+                className="nav-arrow"
+                aria-label="Next artist"
+                onClick={goToNextArtist}
+                disabled={!artists || artists.length <= 1}
+              >▶</button>
+            </>
+          ) : (
+            <>
+              <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
+              <div className="current-campaign" data-testid="current-campaign-top" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
+                {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              </div>
+              <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
+            </>
+          )}
         </div>
       </header>
 
@@ -821,11 +932,37 @@ export default function App() {
 
       <footer className="navbar" id="bottom-navbar">
         <div className="navbar-inner">
-          <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
-          <div className="current-campaign" data-testid="current-campaign-bottom" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
-            {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
-          </div>
-          <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
+          {route.type === 'author-detail' ? (
+            <>
+              <button
+                className="nav-arrow"
+                aria-label="Previous artist"
+                onClick={goToPrevArtist}
+                disabled={!artists || artists.length <= 1}
+              >◀</button>
+              <div
+                className="current-campaign"
+                data-testid="current-artist-bottom"
+                title={artistNavTitle}
+              >
+                {artistNavTitle}
+              </div>
+              <button
+                className="nav-arrow"
+                aria-label="Next artist"
+                onClick={goToNextArtist}
+                disabled={!artists || artists.length <= 1}
+              >▶</button>
+            </>
+          ) : (
+            <>
+              <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
+              <div className="current-campaign" data-testid="current-campaign-bottom" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
+                {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              </div>
+              <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
+            </>
+          )}
         </div>
       </footer>
 

--- a/client/test/App.artistNavSwitcher.test.tsx
+++ b/client/test/App.artistNavSwitcher.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import App from '../src/App';
+
+/**
+ * App-level test for the artist nav-switcher added in fringematrix5-urzh:
+ *
+ * In artist-browse mode (route.type === 'author-detail'), the top and bottom
+ * navbars below the primary button toolbar should:
+ *   - Show the active artist's name (NOT the active campaign's hashtag).
+ *   - Provide prev/next arrows that cycle through the artists list and update
+ *     the URL hash to the next artist's detail page.
+ *
+ * In gallery mode the existing campaign-switching behavior must be preserved.
+ */
+
+const HANDLE_A = '@AliceArt';
+const HANDLE_B = '@BobArt';
+const HANDLE_C = '@CarolArt';
+const AUTHOR_HASH_A = `#authors/${encodeURIComponent(HANDLE_A)}`;
+const AUTHOR_HASH_B = `#authors/${encodeURIComponent(HANDLE_B)}`;
+const AUTHOR_HASH_C = `#authors/${encodeURIComponent(HANDLE_C)}`;
+
+const SAMPLE_AUTHORS = [
+  { handle: HANDLE_A, name: 'Alice Artist', twitterUrl: null, alternateHandles: [], roles: ['artist'], imageCount: 5 },
+  { handle: HANDLE_B, name: 'Bob Artist', twitterUrl: null, alternateHandles: [], roles: ['artist'], imageCount: 3 },
+  { handle: HANDLE_C, name: 'Carol Artist', twitterUrl: null, alternateHandles: [], roles: ['artist'], imageCount: 1 },
+];
+
+function authorDetailFor(handle: string, name: string) {
+  return {
+    author: { handle, name, twitterUrl: null, alternateHandles: [], roles: ['artist'] },
+    images: [],
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeFetchMock() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.startsWith('/api/campaigns/') && url.endsWith('/images')) {
+      return jsonResponse({ images: [] });
+    }
+    if (url === '/api/campaigns') {
+      return jsonResponse({
+        campaigns: [
+          {
+            id: 'crosstheline',
+            episode: 'Cross The Line',
+            episode_id: 'S04E18',
+            hashtag: 'CrossTheLine',
+            date: '2012-04-13',
+            icon_path: 'Season4/CrossTheLine',
+          },
+        ],
+      });
+    }
+    if (url === '/api/build-info') {
+      return jsonResponse({ commitHash: 'dev-local', deployedAt: null });
+    }
+    if (url === '/api/glyphs') {
+      return jsonResponse({ glyphs: [] });
+    }
+    if (url === '/api/authors') {
+      return jsonResponse({ authors: SAMPLE_AUTHORS });
+    }
+    if (url === `/api/authors/${encodeURIComponent(HANDLE_A)}`) {
+      return jsonResponse(authorDetailFor(HANDLE_A, 'Alice Artist'));
+    }
+    if (url === `/api/authors/${encodeURIComponent(HANDLE_B)}`) {
+      return jsonResponse(authorDetailFor(HANDLE_B, 'Bob Artist'));
+    }
+    if (url === `/api/authors/${encodeURIComponent(HANDLE_C)}`) {
+      return jsonResponse(authorDetailFor(HANDLE_C, 'Carol Artist'));
+    }
+
+    return jsonResponse({ error: `Unmocked URL: ${url}` }, 404);
+  });
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  window.localStorage.setItem(
+    'fringematrix-a11y',
+    JSON.stringify({ reduceMotion: true, reduceEffects: true, thumbnailSizeIndex: 0 }),
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  window.history.replaceState({}, '', window.location.pathname);
+});
+
+describe('App: artist nav-switcher in author-browse mode (fringematrix5-urzh)', () => {
+  it('renders the active artist name (not the campaign hashtag) in the top + bottom navbars', async () => {
+    window.location.hash = AUTHOR_HASH_A;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // Wait until the artists list resolves and the nav switcher displays
+    // the resolved display name.
+    const top = await waitFor(() => {
+      const el = screen.getByTestId('current-artist-top');
+      expect(el.textContent).toBe('Alice Artist');
+      return el;
+    });
+    expect(top.textContent).toBe('Alice Artist');
+
+    const bottom = screen.getByTestId('current-artist-bottom');
+    expect(bottom.textContent).toBe('Alice Artist');
+
+    // Campaign-mode test ids must not be in the DOM while we're on the
+    // author-detail route — proves we branched the navbar, not just added a
+    // second one.
+    expect(screen.queryByTestId('current-campaign-top')).toBeNull();
+    expect(screen.queryByTestId('current-campaign-bottom')).toBeNull();
+  });
+
+  it('falls back to the URL handle while the artists list is still loading', async () => {
+    window.location.hash = AUTHOR_HASH_A;
+
+    // Custom mock that hangs the /api/authors call so we can observe the
+    // pre-fetch fallback state.
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === '/api/authors') {
+        // Never resolves — emulates an in-flight fetch.
+        return new Promise<Response>(() => { /* hangs forever */ });
+      }
+      if (url.startsWith('/api/campaigns/') && url.endsWith('/images')) {
+        return jsonResponse({ images: [] });
+      }
+      if (url === '/api/campaigns') {
+        return jsonResponse({ campaigns: [] });
+      }
+      if (url === '/api/build-info') {
+        return jsonResponse({ commitHash: 'dev-local', deployedAt: null });
+      }
+      if (url === '/api/glyphs') {
+        return jsonResponse({ glyphs: [] });
+      }
+      if (url === `/api/authors/${encodeURIComponent(HANDLE_A)}`) {
+        return jsonResponse(authorDetailFor(HANDLE_A, 'Alice Artist'));
+      }
+      return jsonResponse({ error: `Unmocked URL: ${url}` }, 404);
+    }) as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    const top = await screen.findByTestId('current-artist-top');
+    expect(top.textContent).toBe(HANDLE_A);
+  });
+
+  it('clicking the next-artist arrow navigates to the next artist in the list', async () => {
+    window.location.hash = AUTHOR_HASH_A;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // Wait for the resolved name to appear so we know the artists list has
+    // loaded — only then are the arrows enabled.
+    await waitFor(() => {
+      expect(screen.getByTestId('current-artist-top').textContent).toBe('Alice Artist');
+    });
+
+    const nextBtn = screen.getAllByRole('button', { name: /next artist/i })[0]!;
+
+    await act(async () => {
+      fireEvent.click(nextBtn);
+    });
+
+    // Hash should have advanced to the next artist (Bob).
+    expect(window.location.hash).toBe(AUTHOR_HASH_B);
+
+    // And the nav title should reflect Bob after the hashchange.
+    await waitFor(() => {
+      expect(screen.getByTestId('current-artist-top').textContent).toBe('Bob Artist');
+    });
+  });
+
+  it('clicking next-artist on the last artist wraps to the first', async () => {
+    window.location.hash = AUTHOR_HASH_C;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-artist-top').textContent).toBe('Carol Artist');
+    });
+
+    const nextBtn = screen.getAllByRole('button', { name: /next artist/i })[0]!;
+    await act(async () => {
+      fireEvent.click(nextBtn);
+    });
+
+    expect(window.location.hash).toBe(AUTHOR_HASH_A);
+  });
+
+  it('clicking the prev-artist arrow navigates to the previous artist (with wrap)', async () => {
+    window.location.hash = AUTHOR_HASH_A;
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-artist-top').textContent).toBe('Alice Artist');
+    });
+
+    const prevBtn = screen.getAllByRole('button', { name: /previous artist/i })[0]!;
+    await act(async () => {
+      fireEvent.click(prevBtn);
+    });
+
+    // From Alice (first), prev wraps to Carol (last).
+    expect(window.location.hash).toBe(AUTHOR_HASH_C);
+  });
+
+  it('preserves the campaign nav-switcher in gallery mode', async () => {
+    window.location.hash = '#crosstheline';
+    globalThis.fetch = makeFetchMock() as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    // The campaign-mode test ids must still render in gallery mode.
+    const top = await screen.findByTestId('current-campaign-top');
+    expect(top.textContent).toBe('#CrossTheLine');
+
+    // And the artist-mode test ids must NOT be present.
+    expect(screen.queryByTestId('current-artist-top')).toBeNull();
+    expect(screen.queryByTestId('current-artist-bottom')).toBeNull();
+  });
+});

--- a/client/test/App.openLightboxForAuthor.test.tsx
+++ b/client/test/App.openLightboxForAuthor.test.tsx
@@ -103,6 +103,15 @@ function makeFetchMock() {
     if (url === `/api/authors/${encodeURIComponent(HANDLE)}`) {
       return jsonResponse(SAMPLE_AUTHOR_DETAIL);
     }
+    if (url === '/api/authors') {
+      // App lazily fetches the artists list when landing on an authors route
+      // so the nav-switcher in the top/bottom navbars can render prev/next +
+      // the active artist's name. Tests in this file mount the App directly
+      // onto an author-detail hash, which triggers that fetch — return an
+      // empty list to silence the "failed to load" log without changing
+      // assertions (the switcher just stays disabled with the URL handle).
+      return jsonResponse({ authors: [] });
+    }
 
     return jsonResponse({ error: `Unmocked URL: ${url}` }, 404);
   });


### PR DESCRIPTION
## Bead
fringematrix5-urzh — P2 bug: artist-browse mode shows the campaign name in the nav bar and offers no way to switch between artists.

## Summary
- In artist-browse mode (`route.type === 'author-detail'`), the top and bottom navbars (the bars just below the primary button toolbar) now show the active artist's name instead of the active campaign's hashtag.
- The prev/next arrows in those bars cycle through the artists list and update the URL hash to that artist's detail page, mirroring the campaign-switching UX in gallery mode.
- Reuses the existing `/api/authors` endpoint — no new server work. The list is lazily fetched once the user first lands on an authors route, then cached App-side for the rest of the session.
- Falls back to the URL handle in the title while the artists fetch is in flight; arrows are disabled until the list arrives (or if the list has ≤1 entry).

## Out of scope (per bead)
- No styling overhaul — the artist switcher reuses the campaign switcher's `.navbar` + `.nav-arrow` + `.current-campaign` styles.
- Internal `author` → `artist` rename was already done elsewhere (bdd2380); this PR only touches user-visible strings.

## Test plan
- [x] `npm run typecheck` (client) — passes.
- [x] `npm test` (server Jest + client Vitest, 647 tests) — all pass. Added 6 new tests in `client/test/App.artistNavSwitcher.test.tsx` covering: resolved display-name rendering, URL-handle fallback while list is in flight, next/prev arrow navigation with wrap-around, and the gallery-mode campaign switcher preserved.
- [x] `npm run build` — passes.
- [x] `npm run test:e2e` — 50 passed / 38 skipped (skipped are fixture-dependent suites, same as main).

## Follow-ups
- A "see all artists" dropdown/jump-list within the switcher bar would be a nice-to-have, but the bead explicitly scopes "mirroring the campaign-switching UX" which is prev/next + name. The full list lives on the Artists page (toolbar button) already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)