### PR TITLE
fringematrix5-0y9l: 'Unknown artist' link for unattributed images

### DIFF
--- a/client/src/components/LightboxDetails.tsx
+++ b/client/src/components/LightboxDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Campaign, ImageAuthor } from '../types/api';
+import { UNKNOWN_ARTIST_HANDLE, UNKNOWN_ARTIST_NAME } from '../types/api';
 import { parseEpisodeId } from '../utils/parseEpisodeId';
 import { extractImdbId } from '../utils/extractImdbId';
 import { isSafeUrl } from '../utils/isSafeUrl';
@@ -46,12 +47,18 @@ function Row({ label, children }: RowProps) {
 }
 
 /**
- * Renders the AUTHOR row content based on the three states defined in
- * fringematrix5-5s8:
+ * Renders the AUTHOR row content based on the states defined in
+ * fringematrix5-5s8 + fringematrix5-0y9l:
  *   1. Resolved (handle present, confidence 'high' | 'medium')
- *   2. Unresolved (handle null, candidates.length > 0)
- *   3. No data (author null OR handle null AND no candidates) → return null
- *      so the caller can omit the row entirely.
+ *   2. Unresolved (handle is null on the attribution record, regardless of
+ *      whether candidates exist) → render a single "unknown" affordance that
+ *      links to the synthetic Unknown artist gallery (`#authors/__unknown__`).
+ *      The previous "Possibly: @A, @B" candidate list was removed in
+ *      fringematrix5-0y9l; the Unknown artist page collects every
+ *      attribution record whose handle is null, so the lightbox now points
+ *      users there instead of repeating uncertain candidate guesses.
+ *   3. No attribution data at all (author null) → return null so the caller
+ *      can omit the row entirely.
  */
 function AuthorRow({
   author,
@@ -133,28 +140,45 @@ function AuthorRow({
     );
   }
 
-  // Case 2: unresolved with candidates.
-  if (author.candidates && author.candidates.length > 0) {
-    return (
-      <div className="lightbox-details-row lightbox-details-author">
-        <div className="lightbox-details-label">ARTIST</div>
-        <div className="lightbox-details-value lightbox-details-author-value">
-          <span
-            className="lightbox-author-avatar lightbox-author-avatar--unresolved"
-            aria-hidden={true}
+  // Case 2: unresolved (handle is null). Both sub-cases — "no handle +
+  // candidates" and "no handle + no candidates" — collapse into a single
+  // "unknown" affordance that links to the synthetic Unknown artist gallery
+  // (`#authors/__unknown__`). See fringematrix5-0y9l: we no longer surface
+  // the candidate list in the lightbox; users follow the link to browse all
+  // unattributed images instead.
+  //
+  // The unknown link uses the same in-app navigation hook as the resolved
+  // case (`onOpenAuthorGallery`) — the App-level handler closes the lightbox
+  // and pushes the author-detail hash. When no callback is provided
+  // (legacy / test contexts) we fall back to a plain '?' affordance with
+  // the unknown label rendered as static text so the row is still
+  // informative without dangling navigation.
+  const unknownLabel = `${UNKNOWN_ARTIST_NAME.toLowerCase()}`;
+  return (
+    <div className="lightbox-details-row lightbox-details-author">
+      <div className="lightbox-details-label">ARTIST</div>
+      <div className="lightbox-details-value lightbox-details-author-value">
+        <span
+          className="lightbox-author-avatar lightbox-author-avatar--unresolved"
+          aria-hidden={true}
+        >
+          ?
+        </span>
+        {onOpenAuthorGallery ? (
+          <button
+            type="button"
+            className="lightbox-details-link lightbox-author-handle lightbox-author-handle--button lightbox-author-unknown"
+            onClick={() => onOpenAuthorGallery(UNKNOWN_ARTIST_HANDLE)}
+            aria-label={`View all images by ${UNKNOWN_ARTIST_NAME}`}
           >
-            ?
-          </span>
-          <span className="lightbox-author-candidates">
-            Possibly: {author.candidates.join(', ')}
-          </span>
-        </div>
+            {unknownLabel}
+          </button>
+        ) : (
+          <span className="lightbox-author-unknown">{unknownLabel}</span>
+        )}
       </div>
-    );
-  }
-
-  // Case 3: no data → omit (handled by the caller).
-  return null;
+    </div>
+  );
 }
 
 /**
@@ -164,8 +188,9 @@ function AuthorRow({
  *
  * The AUTHOR row is conditionally rendered based on the `author` prop:
  *   - high/medium confidence → handle as link (with avatar + optional badge)
- *   - unresolved with candidates → "Possibly: @A, @B" with a '?' avatar
- *   - null / no candidates → row is omitted entirely
+ *   - unresolved (handle null, with or without candidates) → "unknown" link
+ *     to the synthetic Unknown artist gallery (fringematrix5-0y9l)
+ *   - author === null (no attribution data) → row is omitted entirely
  *
  * If no active campaign is available the component renders a single
  * empty-state line so the sidebar is not a confusing blank panel.

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -574,10 +574,15 @@ footer.navbar {
   text-decoration: none;
 }
 .lightbox-author-twitter:hover { text-decoration: underline; }
-.lightbox-author-candidates {
-  color: rgba(255, 255, 255, 0.65);
-  font-size: 13px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+/* fringematrix5-0y9l: the "unknown" affordance shown in the AUTHOR row for
+   images without a resolved handle. Subtler than a real handle (italicized
+   + muted) so it visually reads as a state rather than a real artist name,
+   while still being clearly clickable when in-app navigation is wired up.
+   Note: the previous `.lightbox-author-candidates` style was removed when
+   the lightbox stopped surfacing the "Possibly: @A, @B" candidate list. */
+.lightbox-author-unknown {
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.75);
 }
 .lightbox-author-badge {
   display: inline-flex;

--- a/client/test/LightboxDetails.test.tsx
+++ b/client/test/LightboxDetails.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import LightboxDetails from '../src/components/LightboxDetails';
 import type { Campaign, ImageAuthor } from '../src/types/api';
+import { UNKNOWN_ARTIST_HANDLE } from '../src/types/api';
 
 const SAMPLE_CAMPAIGN: Campaign = {
   id: 'crosstheline',
@@ -275,16 +276,23 @@ describe('LightboxDetails', () => {
       expect(screen.getByRole('link', { name: /Zort70/ })).toBeTruthy();
     });
 
-    it('renders "Possibly: @A, @B, @C" with a "?" avatar for unresolved authors with candidates', () => {
+    // fringematrix5-0y9l: unresolved images (no handle) now render a single
+    // "unknown" affordance regardless of whether candidates exist. The
+    // previous "Possibly: @A, @B" candidate list was removed in favor of a
+    // link to the Unknown artist gallery (`#authors/__unknown__`).
+    it('renders "unknown" (not the candidate list) with a "?" avatar for unresolved authors with candidates', () => {
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={unresolved} />);
       expect(screen.getByText('ARTIST')).toBeTruthy();
       expect(screen.getByText('?')).toBeTruthy();
-      expect(screen.getByText(/Possibly:\s*@AliceA,\s*@BobB,\s*@Carol_C/)).toBeTruthy();
-      // No link in unresolved state.
-      expect(screen.queryByRole('link', { name: /AliceA/ })).toBeNull();
+      expect(screen.getByText(/^unknown artist$/i)).toBeTruthy();
+      // Candidates are NOT surfaced in the lightbox anymore.
+      expect(screen.queryByText(/Possibly:/i)).toBeNull();
+      expect(screen.queryByText(/AliceA/)).toBeNull();
+      expect(screen.queryByText(/BobB/)).toBeNull();
+      expect(screen.queryByText(/Carol_C/)).toBeNull();
     });
 
-    it('omits the AUTHOR row entirely when handle is null and there are no candidates', () => {
+    it('renders "unknown" with a "?" avatar for unresolved authors with NO candidates', () => {
       const empty: ImageAuthor = {
         handle: null,
         displayName: null,
@@ -293,6 +301,19 @@ describe('LightboxDetails', () => {
         candidates: [],
       };
       render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={empty} />);
+      // The AUTHOR row IS now rendered (it used to be omitted before
+      // fringematrix5-0y9l). It surfaces the "unknown" affordance so the
+      // user can jump to the all-unattributed gallery.
+      expect(screen.getByText('ARTIST')).toBeTruthy();
+      expect(screen.getByText('?')).toBeTruthy();
+      expect(screen.getByText(/^unknown artist$/i)).toBeTruthy();
+    });
+
+    it('still omits the AUTHOR row entirely when author is null (no attribution record)', () => {
+      // When the server returns no attribution data at all (author === null),
+      // we don't know that the image even has an attribution record, so we
+      // keep the row hidden rather than guess.
+      render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={null} />);
       expect(screen.queryByText(/^artist$/i)).toBeNull();
     });
 
@@ -384,7 +405,7 @@ describe('LightboxDetails', () => {
         expect(screen.queryByRole('link', { name: /Twitter/i })).toBeNull();
       });
 
-      it('does not render a handle button for the unresolved (candidates-only) case', () => {
+      it('does not render a candidate-named button for unresolved authors (candidates are no longer surfaced)', () => {
         const onOpen = vi.fn();
         const unresolvedAuthor: ImageAuthor = {
           handle: null,
@@ -400,9 +421,96 @@ describe('LightboxDetails', () => {
             onOpenAuthorGallery={onOpen}
           />,
         );
+        // The candidate handles are NOT rendered as buttons (or as text).
         expect(screen.queryByRole('button', { name: /AliceA|BobB/ })).toBeNull();
         // Callback never invoked just by rendering.
         expect(onOpen).not.toHaveBeenCalled();
+      });
+
+      // fringematrix5-0y9l: the unresolved "unknown" affordance is a button
+      // that invokes the same `onOpenAuthorGallery` callback used by resolved
+      // handles — but with the UNKNOWN_ARTIST_HANDLE sentinel. The App-level
+      // handler then closes the lightbox and navigates to `#authors/__unknown__`,
+      // which the server serves via /api/authors/__unknown__.
+      it('renders the "unknown" affordance as a button that fires onOpenAuthorGallery with the sentinel handle (unresolved + candidates)', () => {
+        const onOpen = vi.fn();
+        const unresolvedAuthor: ImageAuthor = {
+          handle: null,
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'unresolved',
+          candidates: ['@AliceA', '@BobB'],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={unresolvedAuthor}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const btn = screen.getByRole('button', { name: /view all images by unknown artist/i });
+        expect(btn.tagName).toBe('BUTTON');
+        expect(btn.getAttribute('type')).toBe('button');
+        fireEvent.click(btn);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onOpen).toHaveBeenCalledWith(UNKNOWN_ARTIST_HANDLE);
+      });
+
+      it('renders the "unknown" affordance for unresolved authors with NO candidates and fires the sentinel callback', () => {
+        const onOpen = vi.fn();
+        const noCandidates: ImageAuthor = {
+          handle: null,
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'unresolved',
+          candidates: [],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={noCandidates}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const btn = screen.getByRole('button', { name: /view all images by unknown artist/i });
+        fireEvent.click(btn);
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onOpen).toHaveBeenCalledWith(UNKNOWN_ARTIST_HANDLE);
+      });
+
+      it('renders the "unknown" affordance as plain text (no button) when no onOpenAuthorGallery callback is provided', () => {
+        const unresolvedAuthor: ImageAuthor = {
+          handle: null,
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'unresolved',
+          candidates: ['@AliceA', '@BobB'],
+        };
+        render(<LightboxDetails campaign={SAMPLE_CAMPAIGN} author={unresolvedAuthor} />);
+        expect(screen.getByText(/^unknown artist$/i)).toBeTruthy();
+        // No button — falls back to static text.
+        expect(screen.queryByRole('button', { name: /unknown/i })).toBeNull();
+      });
+
+      it('"unknown" button is focusable (participates in lightbox focus trap)', () => {
+        const onOpen = vi.fn();
+        const unresolvedAuthor: ImageAuthor = {
+          handle: null,
+          displayName: null,
+          twitterUrl: null,
+          confidence: 'unresolved',
+          candidates: [],
+        };
+        render(
+          <LightboxDetails
+            campaign={SAMPLE_CAMPAIGN}
+            author={unresolvedAuthor}
+            onOpenAuthorGallery={onOpen}
+          />,
+        );
+        const btn = screen.getByRole('button', { name: /view all images by unknown artist/i }) as HTMLButtonElement;
+        btn.focus();
+        expect(document.activeElement).toBe(btn);
       });
 
       it('handle button is focusable (participates in lightbox focus trap)', () => {

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -116,8 +116,13 @@ test.describe('Lightbox AUTHOR row — resolved (high confidence)', () => {
   });
 });
 
-test.describe('Lightbox AUTHOR row — unresolved with candidates', () => {
-  test('shows "Possibly: …" candidate list for an unresolved ObserveItLive image', async ({ page }) => {
+test.describe('Lightbox AUTHOR row — unresolved (unknown artist)', () => {
+  // fringematrix5-0y9l: the lightbox no longer surfaces the "Possibly: @A,
+  // @B" candidate list for unresolved images. Both unresolved sub-cases
+  // ("no handle + candidates" and "no handle + no candidates") now collapse
+  // into a single "unknown" affordance that links to the synthetic Unknown
+  // artist gallery (`#authors/__unknown__`).
+  test('shows the "unknown artist" link for an unresolved ObserveItLive image', async ({ page }) => {
     await gotoCampaign(page, 'observeitlive');
 
     // Any image inside the fully-unresolved `oil/` folder works; pick the
@@ -139,20 +144,28 @@ test.describe('Lightbox AUTHOR row — unresolved with candidates', () => {
     await expect(authorRow).toBeVisible();
     await expect(authorRow.getByText('ARTIST', { exact: true })).toBeVisible();
 
-    // Unresolved avatar shows a literal '?'.
+    // Unresolved avatar still shows a literal '?'.
     const avatar = authorRow.locator('.lightbox-author-avatar--unresolved');
     await expect(avatar).toBeVisible();
     await expect(avatar).toHaveText('?');
 
-    // "Possibly:" label + each expected candidate handle.
-    const candidates = authorRow.locator('.lightbox-author-candidates');
-    await expect(candidates).toBeVisible();
-    await expect(candidates).toContainText('Possibly:');
-    await expect(candidates).toContainText('@Cheribot');
-    await expect(candidates).toContainText('@SarahProost');
-    await expect(candidates).toContainText('@Zort70');
+    // The "unknown" affordance is rendered as a button (in-app navigation
+    // to the Unknown artist gallery is available in the running app).
+    const unknownBtn = authorRow.getByRole('button', { name: /view all images by unknown artist/i });
+    await expect(unknownBtn).toBeVisible();
+    await expect(unknownBtn).toContainText(/unknown artist/i);
 
-    // Unresolved state must NOT render an attribution link.
-    await expect(authorRow.locator('a')).toHaveCount(0);
+    // Candidate list is gone — no "Possibly:" label, no candidate handles.
+    await expect(authorRow.locator('.lightbox-author-candidates')).toHaveCount(0);
+    await expect(authorRow).not.toContainText('Possibly:');
+    await expect(authorRow).not.toContainText('@Cheribot');
+    await expect(authorRow).not.toContainText('@SarahProost');
+    await expect(authorRow).not.toContainText('@Zort70');
+
+    // Clicking the "unknown" button navigates to the synthetic Unknown
+    // artist detail page.
+    await unknownBtn.click();
+    await page.waitForFunction(() => window.location.hash.includes('authors/__unknown__'));
+    expect(page.url()).toContain('authors/__unknown__');
   });
 });


### PR DESCRIPTION
## Summary

For images that have no resolved handle, the lightbox AUTHOR row now shows a single "unknown artist" affordance that links to the synthetic Unknown artist gallery (`#authors/__unknown__`) instead of the previous "Possibly: @A, @B, @C" candidate list. Closes fringematrix5-0y9l.

## What changed

- `client/src/components/LightboxDetails.tsx` — Both unresolved sub-cases (no handle + candidates, no handle + no candidates) collapse into one "unknown artist" button that fires `onOpenAuthorGallery(UNKNOWN_ARTIST_HANDLE)`. Uses `UNKNOWN_ARTIST_HANDLE` / `UNKNOWN_ARTIST_NAME` constants from `shared/types.ts` — no hardcoded sentinels.
- `client/src/styles.css` — Removed `.lightbox-author-candidates` (no longer rendered); added `.lightbox-author-unknown` (italic + muted) so the affordance reads as a state, not a real artist.
- `client/test/LightboxDetails.test.tsx` — Added/updated tests:
  - "unknown" rendered (not candidates) when handle is null + candidates present
  - "unknown" rendered when handle is null + no candidates (previously the row was omitted)
  - row still omitted entirely when `author === null` (no attribution record)
  - button fires `onOpenAuthorGallery` with `UNKNOWN_ARTIST_HANDLE` in both unresolved sub-cases
  - static-text fallback when no callback is provided
  - focusability
- `e2e/lightbox-author-row.spec.ts` — Replaced the "Possibly: …" assertions with assertions that the "unknown artist" button is visible, candidates are gone, and clicking it navigates to `#authors/__unknown__`.

## Design notes

- The existing `onOpenAuthorGallery` callback in `App.handleOpenAuthorGalleryFromLightbox` already routes any handle (real or sentinel) through `navigateToAuthorDetail` → URL-encoded hash. The server's `/api/authors/__unknown__` endpoint (from fringematrix5-obvh / PR #189) already serves the unknown gallery, so no backend changes are needed.
- `author === null` (no attribution data at all) deliberately still omits the row — we don't know whether the image is actually unattributed in that case.
- User-visible text says "artist"; internals still say "author" (per the fringematrix5-pgll vocabulary split).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 663 client tests + 112 server tests pass
- [x] `npm run test:e2e` — 53 passed, 38 skipped (skips are BLOB_READ_WRITE_TOKEN-gated; the updated `lightbox-author-row.spec.ts > unknown artist` test ran and passed)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)