### PR TITLE
fringematrix5-zh88: 'attribution lost' disclaimer on empty artist pages

### DIFF
--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -3,7 +3,7 @@ import { fetchJSON } from '../utils/fetchJSON';
 import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
 import type { AuthorDetailResponse, ImageData } from '../types/api';
-import { UNKNOWN_ARTIST_HANDLE } from '../types/api';
+import { UNKNOWN_ARTIST_HANDLE, UNKNOWN_ARTIST_NAME } from '../types/api';
 import GalleryGrid, { type GalleryGridHandle } from './GalleryGrid';
 
 interface Props {
@@ -212,11 +212,41 @@ export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: P
           </header>
 
           {data.images.length === 0 ? (
-            <div className="authors-status" role="status" aria-live="polite">
-              {isUnknownArtist
-                ? 'No unattributed images — every image has an artist.'
-                : 'No images attributed to this artist yet.'}
-            </div>
+            isUnknownArtist ? (
+              <div className="authors-status" role="status" aria-live="polite">
+                No unattributed images — every image has an artist.
+              </div>
+            ) : (
+              // Regular-artist empty state. Attribution metadata is hand-curated
+              // and incomplete: some images have lost their attribution and now
+              // live under the synthetic "Unknown artist" category. We surface a
+              // short disclaimer + a link so users have a place to look for
+              // possibly-misfiled work. See fringematrix5-zh88. The Unknown
+              // target is reached via a hash link (`#authors/__unknown__`),
+              // which the App-level hashchange listener picks up; no extra
+              // navigation callback is plumbed through for this branch.
+              <div
+                className="authors-disclaimer"
+                role="status"
+                aria-live="polite"
+                data-testid="author-empty-disclaimer"
+              >
+                <p>
+                  No images are currently attributed to this artist.
+                </p>
+                <p>
+                  Attribution for some images has been lost over time. This
+                  artist&rsquo;s work may still be present in the{' '}
+                  <a
+                    className="authors-disclaimer-link"
+                    href={`#authors/${UNKNOWN_ARTIST_HANDLE}`}
+                  >
+                    {UNKNOWN_ARTIST_NAME}
+                  </a>{' '}
+                  category.
+                </p>
+              </div>
+            )
           ) : (
             <GalleryGrid
               ref={gridRef}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2211,6 +2211,36 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
 .authors-error {
   color: #ff8b8b;
 }
+/* Empty-state disclaimer on a regular artist's detail page when they have no
+   attributed images. Explains that attribution may have been lost and links
+   to the synthetic "Unknown artist" gallery. See fringematrix5-zh88. */
+.authors-disclaimer {
+  max-width: 640px;
+  margin: 24px auto 80px;
+  padding: 20px 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+  background: var(--bg-elev);
+  border: 1px solid rgba(124,77,255,0.2);
+  border-radius: 12px;
+}
+.authors-disclaimer p {
+  margin: 0 0 8px;
+}
+.authors-disclaimer p:last-child {
+  margin-bottom: 0;
+}
+.authors-disclaimer-link {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.authors-disclaimer-link:hover,
+.authors-disclaimer-link:focus {
+  color: var(--accent);
+  text-decoration: none;
+}
 .authors-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));

--- a/client/test/AuthorDetail.test.tsx
+++ b/client/test/AuthorDetail.test.tsx
@@ -174,6 +174,99 @@ describe('AuthorDetail', () => {
     errSpy.mockRestore();
   });
 
+  // fringematrix5-zh88
+  describe('Regular artist empty state (attribution-lost disclaimer)', () => {
+    const EMPTY_DETAIL = {
+      author: {
+        handle: '@Zort70',
+        name: 'Sarah Proost',
+        twitterUrl: 'https://twitter.com/Zort70',
+        alternateHandles: [],
+        roles: ['artist'],
+      },
+      images: [],
+    };
+
+    it('shows the attribution-lost disclaimer when a regular artist has no images', async () => {
+      globalThis.fetch = mockFetch(EMPTY_DETAIL) as unknown as typeof fetch;
+
+      render(
+        <AuthorDetail
+          handle="@Zort70"
+          onBack={() => {}}
+          onOpenImage={() => {}}
+        />,
+      );
+
+      await screen.findByText('Sarah Proost');
+
+      const disclaimer = await screen.findByTestId('author-empty-disclaimer');
+      expect(disclaimer).toBeTruthy();
+      // Mentions that attribution has been lost — wording check is loose so
+      // copy edits don't force a test update, but the substance must remain.
+      expect(disclaimer.textContent || '').toMatch(/attribution.*lost/i);
+      // Mentions the Unknown artist category by name (UNKNOWN_ARTIST_NAME).
+      expect(disclaimer.textContent || '').toMatch(/unknown artist/i);
+
+      // Link points at the stable Unknown-artist hash route.
+      const link = disclaimer.querySelector('a');
+      expect(link).toBeTruthy();
+      expect(link!.getAttribute('href')).toBe('#authors/__unknown__');
+
+      // The Unknown-artist-specific empty copy must NOT collide with this one.
+      expect(
+        screen.queryByText(/no unattributed images — every image has an artist\./i),
+      ).toBeNull();
+
+      // No gallery grid renders when there are no images.
+      expect(screen.queryByTestId('author-images-grid')).toBeNull();
+    });
+
+    it('does NOT render the attribution-lost disclaimer when the artist has images', async () => {
+      globalThis.fetch = mockFetch(SAMPLE_DETAIL) as unknown as typeof fetch;
+
+      render(
+        <AuthorDetail
+          handle="@Zort70"
+          onBack={() => {}}
+          onOpenImage={() => {}}
+        />,
+      );
+
+      await screen.findByText('Sarah Proost');
+      expect(screen.queryByTestId('author-empty-disclaimer')).toBeNull();
+    });
+
+    it('does NOT render the regular disclaimer on the Unknown-artist empty state', async () => {
+      globalThis.fetch = mockFetch({
+        author: {
+          handle: '__unknown__',
+          name: 'Unknown artist',
+          twitterUrl: null,
+          alternateHandles: [],
+          roles: [],
+        },
+        images: [],
+      }) as unknown as typeof fetch;
+
+      render(
+        <AuthorDetail
+          handle="__unknown__"
+          onBack={() => {}}
+          onOpenImage={() => {}}
+        />,
+      );
+
+      await screen.findByText('Unknown artist');
+      // The two empty states are distinct: the unknown-artist branch keeps
+      // its dedicated copy and does NOT show the regular disclaimer.
+      expect(screen.queryByTestId('author-empty-disclaimer')).toBeNull();
+      expect(
+        screen.getByText(/no unattributed images — every image has an artist\./i),
+      ).toBeTruthy();
+    });
+  });
+
   it('shows an inline error message when the request fails (e.g. 404)', async () => {
     globalThis.fetch = mockFetch({ error: 'not found' }, 404) as unknown as typeof fetch;
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Bead

fringematrix5-zh88 — Show 'attribution lost' disclaimer on empty artist pages (P2 feature).

## Summary

- When a regular artist's detail page has zero attributed images, replace the terse "No images attributed to this artist yet." with a short disclaimer that explains attribution has been lost for some images and links to the synthetic "Unknown artist" category where the artist's work may live.
- The Unknown-artist branch's existing empty-state copy ("No unattributed images — every image has an artist.") is unchanged. The two empty states stay distinct via the existing ``isUnknownArtist`` gate.
- The link uses the stable ``#authors/__unknown__`` hash route (sourced from ``UNKNOWN_ARTIST_HANDLE``) so the App-level hashchange listener handles navigation — no new callback prop is plumbed through ``AuthorDetail``.

## Test plan

- [x] ``npm run typecheck``
- [x] ``npm test`` (server + client; 666 client + 112 server tests pass, including 3 new ``AuthorDetail`` cases)
- [x] ``npm run test:e2e`` (53 passed, 38 skipped — all green)
- [x] ``npm run build``
- [ ] Manual: visit a regular artist with zero attributed images → disclaimer renders, link goes to ``#authors/__unknown__``
- [ ] Manual: visit ``#authors/__unknown__`` with zero images → keeps existing "every image has an artist" copy
- [ ] Manual: visit a regular artist with images → no disclaimer, gallery grid renders normally

## Follow-ups

- None at this time. ``fringematrix5-z86p`` (in-flight) covers the all-artists-page disclaimer; wording can be aligned in a follow-up if z86p lands with materially different phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)