### PR TITLE
fringematrix5-lujv: hide per-artist image counts on all-artists page

### DIFF
--- a/client/src/components/AuthorsIndex.tsx
+++ b/client/src/components/AuthorsIndex.tsx
@@ -13,9 +13,13 @@ interface Props {
 }
 
 /**
- * Authors index page. Lists all known artists as cards (avatar + name + handle
- * + image count). Sorted by imageCount desc — the order is preserved from the
- * /api/authors response.
+ * Authors index page. Lists all known artists as cards (avatar + name +
+ * handle). Sorted by `imageCount` desc — the order is preserved from the
+ * /api/authors response. The per-artist count itself is NOT rendered in the
+ * UI (fringematrix5-lujv): attribution data has known gaps (see the
+ * disclaimer added by fringematrix5-z86p), so the raw number is misleading
+ * as a "popularity" signal even though sorting by volume is still a useful
+ * default for browsing.
  *
  * If the response includes a non-zero `unknownCount`, an additional pinned
  * "Unknown artist" card renders at the TOP of the grid (fringematrix5-obvh).
@@ -97,7 +101,6 @@ export default function AuthorsIndex({ onSelectAuthor, onBack }: Props) {
         >
           {unknownCount > 0 && (
             <UnknownArtistCard
-              imageCount={unknownCount}
               onClick={() => onSelectAuthor(UNKNOWN_ARTIST_HANDLE)}
             />
           )}
@@ -161,7 +164,7 @@ function AuthorCard({ author, onClick }: AuthorCardProps) {
         type="button"
         className="author-card-button"
         onClick={onClick}
-        aria-label={`Open ${author.name} (${author.imageCount} images)`}
+        aria-label={`Open ${author.name}`}
       >
         <div className="author-avatar" aria-hidden={true}>{initials}</div>
         <div className="author-name">{author.name}</div>
@@ -180,16 +183,20 @@ function AuthorCard({ author, onClick }: AuthorCardProps) {
         ) : (
           <span className="author-handle">{author.handle}</span>
         )}
-        <span className="author-count" aria-label={`${author.imageCount} images`}>
-          {author.imageCount} {author.imageCount === 1 ? 'image' : 'images'}
-        </span>
+        {/*
+          Per fringematrix5-lujv, the per-artist image count is intentionally
+          NOT rendered. The data is still used to sort the grid (descending),
+          but attribution gaps mean the raw number is misleading as a
+          standalone signal — see the disclaimer from fringematrix5-z86p.
+          The `imageCount` field stays on the response shape and on `author`
+          for future internal use (e.g. analytics, future surfaces).
+        */}
       </div>
     </article>
   );
 }
 
 interface UnknownArtistCardProps {
-  imageCount: number;
   onClick: () => void;
 }
 
@@ -199,8 +206,13 @@ interface UnknownArtistCardProps {
  * recognize it as a virtual aggregate. Click navigates to the
  * `#authors/__unknown__` detail view, which lists every image without a
  * resolved attribution.
+ *
+ * Per fringematrix5-lujv the unattributed image count is NOT displayed on the
+ * card. The "Unattributed" handle is kept as a textual indicator without
+ * exposing a potentially misleading raw number; the count is still available
+ * on the AuthorDetail page (where the disclaimer also lives).
  */
-function UnknownArtistCard({ imageCount, onClick }: UnknownArtistCardProps) {
+function UnknownArtistCard({ onClick }: UnknownArtistCardProps) {
   return (
     <article
       className="author-card author-card--unknown"
@@ -210,7 +222,7 @@ function UnknownArtistCard({ imageCount, onClick }: UnknownArtistCardProps) {
         type="button"
         className="author-card-button"
         onClick={onClick}
-        aria-label={`Open ${UNKNOWN_ARTIST_NAME} (${imageCount} images)`}
+        aria-label={`Open ${UNKNOWN_ARTIST_NAME}`}
       >
         <div
           className="author-avatar author-avatar--unknown"
@@ -222,9 +234,6 @@ function UnknownArtistCard({ imageCount, onClick }: UnknownArtistCardProps) {
       </button>
       <div className="author-meta">
         <span className="author-handle author-handle--unknown">Unattributed</span>
-        <span className="author-count" aria-label={`${imageCount} images`}>
-          {imageCount} {imageCount === 1 ? 'image' : 'images'}
-        </span>
       </div>
     </article>
   );

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -2347,10 +2347,10 @@ html.reduce-effects .thumbnail-size-slider input[type='range']:hover:not(:disabl
 .authors-page .author-handle:hover {
   border-bottom-style: solid;
 }
-.authors-page .author-count {
-  white-space: nowrap;
-  color: var(--muted);
-}
+/* Note: `.authors-page .author-count` used to live here. fringematrix5-lujv
+   removed the per-artist count from the all-artists UI, so the corresponding
+   span is no longer rendered. The `.author-detail-info .author-count` rule
+   below is still used by the per-artist AuthorDetail header. */
 /* Unknown artist pinned card + detail-page header (fringematrix5-obvh).
    Distinct dashed border + muted avatar gradient so users can tell at a
    glance it's the virtual "Unknown artist" aggregate, not a real artist. */

--- a/client/test/AuthorsIndex.test.tsx
+++ b/client/test/AuthorsIndex.test.tsx
@@ -49,8 +49,44 @@ describe('AuthorsIndex', () => {
 
     expect(screen.getByText('Sarah Proost')).toBeTruthy();
     expect(screen.getByText('Someone Else')).toBeTruthy();
-    expect(screen.getByText('244 images')).toBeTruthy();
-    expect(screen.getByText('1 image')).toBeTruthy();
+  });
+
+  // fringematrix5-lujv: the per-artist count is intentionally hidden from
+  // the all-artists UI. Sort order (driven by imageCount desc, server-side)
+  // is preserved — see the "preserves the sort order" test below.
+  it('does not render per-artist image counts on the index', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('author-card')).toHaveLength(2);
+    });
+
+    // None of the per-artist counts from SAMPLE_AUTHORS should appear in
+    // the DOM, in either plural or singular form.
+    expect(screen.queryByText('244 images')).toBeNull();
+    expect(screen.queryByText('1 image')).toBeNull();
+    // Also no orphaned `.author-count` span should be rendered for real
+    // artists on the index page.
+    expect(document.querySelector('.authors-page .author-count')).toBeNull();
+    // And the button's accessible name must NOT carry the raw number either.
+    const sarahBtn = screen.getByRole('button', { name: /Open Sarah Proost/ });
+    expect(sarahBtn.getAttribute('aria-label')).toBe('Open Sarah Proost');
+  });
+
+  it('preserves the server-supplied sort order (by imageCount desc)', async () => {
+    globalThis.fetch = mockFetch({ authors: SAMPLE_AUTHORS }) as unknown as typeof fetch;
+    render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('author-card')).toHaveLength(2);
+    });
+
+    // SAMPLE_AUTHORS is ordered [244, 1] — the higher-volume artist must
+    // render first even though the count itself is no longer shown.
+    const cards = screen.getAllByTestId('author-card');
+    expect(cards[0].textContent).toContain('Sarah Proost');
+    expect(cards[1].textContent).toContain('Someone Else');
   });
 
   it('linkifies the @handle to the twitterUrl when present', async () => {
@@ -149,9 +185,15 @@ describe('AuthorsIndex', () => {
       expect(card).toBeTruthy();
       // Scope to the card — the disclaimer above the grid also mentions
       // "Unknown artist" (as a link), so an unscoped getByText would match
-      // multiple nodes.
+      // multiple nodes (fringematrix5-z86p).
       expect(within(card).getByText('Unknown artist')).toBeTruthy();
-      expect(within(card).getByText('42 images')).toBeTruthy();
+      // fringematrix5-lujv: the raw unattributed count is intentionally not
+      // rendered on the index. "Unattributed" stays as a textual indicator.
+      expect(within(card).queryByText('42 images')).toBeNull();
+      expect(within(card).getByText('Unattributed')).toBeTruthy();
+      // Likewise, the card's accessible name omits the number.
+      const btn = within(card).getByRole('button', { name: /Open Unknown artist/ });
+      expect(btn.getAttribute('aria-label')).toBe('Open Unknown artist');
     });
 
     it('pins the Unknown artist card before all real-artist cards', async () => {
@@ -181,12 +223,21 @@ describe('AuthorsIndex', () => {
       expect(screen.queryByTestId('unknown-artist-card')).toBeNull();
     });
 
-    it('uses singular "image" copy when unknownCount is exactly 1', async () => {
+    // fringematrix5-lujv: was "uses singular 'image' copy when unknownCount
+    // is exactly 1". The singular/plural copy disappeared along with the
+    // count itself, so the test now asserts that no count text renders even
+    // in the edge case of a single unattributed image. The card still shows.
+    it('still hides the unattributed count when unknownCount is exactly 1', async () => {
       globalThis.fetch = mockFetch({ authors: [], unknownCount: 1 }) as unknown as typeof fetch;
       render(<AuthorsIndex onSelectAuthor={() => {}} onBack={() => {}} />);
 
-      await screen.findByTestId('unknown-artist-card');
-      expect(screen.getByText('1 image')).toBeTruthy();
+      const card = await screen.findByTestId('unknown-artist-card');
+      // Scope to the card so we don't pick up the disclaimer's prose
+      // (fringematrix5-z86p mentions "Unattributed images" above the grid).
+      expect(within(card).queryByText('1 image')).toBeNull();
+      expect(within(card).queryByText('1 images')).toBeNull();
+      // The "Unattributed" textual indicator is still present on the card.
+      expect(within(card).getByText('Unattributed')).toBeTruthy();
     });
 
     it('calls onSelectAuthor with the sentinel handle when the card is clicked', async () => {


### PR DESCRIPTION
## Bead

`fringematrix5-lujv` — Hide attributed-image counts on all-artists page (keep count-based sort).

## Summary

- Removed the per-artist image count rendered by `AuthorCard` and `UnknownArtistCard` on the all-artists index. The raw number was misleading given known attribution gaps (see the disclaimer from `fringematrix5-z86p`), and a popularity signal isn't the value the page is meant to provide.
- Sort order is unchanged: the server still returns artists ordered by `imageCount desc`, and `AuthorsIndex` continues to render them in that order. Only the visible number is gone.
- The "Unknown artist" pinned card keeps its existing "Unattributed" handle indicator (no new wording invented), but the raw count is removed and the `aria-label` trimmed to match.
- `aria-label` on `AuthorCard` was also trimmed so the count isn't exposed via assistive tech either ("Open Sarah Proost" rather than "Open Sarah Proost (244 images)").
- No backend or data-shape changes. `imageCount` / `unknownCount` stay on the response — they're consumed for sort and pin behavior, just not rendered.
- Dropped orphaned `.authors-page .author-count` CSS rule with a breadcrumb comment. `.author-detail-info .author-count` (used by the per-artist page) is untouched.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 670 client + 112 server tests pass
- [x] `npm run test:e2e` — 53 passed, 38 skipped, 0 failed
- [x] `npm run build`
- [x] Updated unit tests: count-text assertions replaced with negative assertions ("count is NOT rendered"); added an explicit sort-order test so the requirement is locked in independently of the count being visible; singular-copy edge case converted into a hidden-count assertion so the boundary is still covered.
- [ ] Manual smoke: open `#authors`, confirm cards no longer show "X images"; confirm the most-prolific artist still appears first; confirm the pinned Unknown card shows "Unattributed" without a number.

## Follow-ups

None planned. The data shape is preserved so a future "show counts (admin only)" toggle could be added without a migration.