### PR TITLE
fringematrix5-y6kl: extract artist/campaign navbar JSX into reusable component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from './config/gallery';
 import LoadingManager from './components/LoadingManager';
 import CampaignNavigation from './components/CampaignNavigation';
+import NavSwitcher from './components/NavSwitcher';
 import BuildInfoPopover from './components/BuildInfoPopover';
 import SharePopover from './components/SharePopover';
 import ContentModal from './components/ContentModal';
@@ -793,35 +794,27 @@ export default function App() {
       <header className="navbar" id="top-navbar">
         <div className="navbar-inner">
           {route.type === 'author-detail' ? (
-            <>
-              <button
-                className="nav-arrow"
-                aria-label="Previous artist"
-                onClick={goToPrevArtist}
-                disabled={!artists || artists.length <= 1}
-              >◀</button>
-              <div
-                className="current-campaign"
-                data-testid="current-artist-top"
-                title={artistNavTitle}
-              >
-                {artistNavTitle}
-              </div>
-              <button
-                className="nav-arrow"
-                aria-label="Next artist"
-                onClick={goToNextArtist}
-                disabled={!artists || artists.length <= 1}
-              >▶</button>
-            </>
+            <NavSwitcher
+              label={artistNavTitle}
+              title={artistNavTitle}
+              testId="current-artist-top"
+              prevLabel="Previous artist"
+              nextLabel="Next artist"
+              onPrev={goToPrevArtist}
+              onNext={goToNextArtist}
+              disabled={!artists || artists.length <= 1}
+            />
           ) : (
-            <>
-              <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
-              <div className="current-campaign" data-testid="current-campaign-top" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
-                {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
-              </div>
-              <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
-            </>
+            <NavSwitcher
+              label={activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              testId="current-campaign-top"
+              prevLabel="Previous campaign"
+              nextLabel="Next campaign"
+              onPrev={goToPrevCampaign}
+              onNext={goToNextCampaign}
+              disabled={isCampaignLoading}
+            />
           )}
         </div>
       </header>
@@ -949,35 +942,27 @@ export default function App() {
       <footer className="navbar" id="bottom-navbar">
         <div className="navbar-inner">
           {route.type === 'author-detail' ? (
-            <>
-              <button
-                className="nav-arrow"
-                aria-label="Previous artist"
-                onClick={goToPrevArtist}
-                disabled={!artists || artists.length <= 1}
-              >◀</button>
-              <div
-                className="current-campaign"
-                data-testid="current-artist-bottom"
-                title={artistNavTitle}
-              >
-                {artistNavTitle}
-              </div>
-              <button
-                className="nav-arrow"
-                aria-label="Next artist"
-                onClick={goToNextArtist}
-                disabled={!artists || artists.length <= 1}
-              >▶</button>
-            </>
+            <NavSwitcher
+              label={artistNavTitle}
+              title={artistNavTitle}
+              testId="current-artist-bottom"
+              prevLabel="Previous artist"
+              nextLabel="Next artist"
+              onPrev={goToPrevArtist}
+              onNext={goToNextArtist}
+              disabled={!artists || artists.length <= 1}
+            />
           ) : (
-            <>
-              <button className="nav-arrow" aria-label="Previous campaign" onClick={goToPrevCampaign} disabled={isCampaignLoading}>◀</button>
-              <div className="current-campaign" data-testid="current-campaign-bottom" title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}>
-                {activeCampaign ? `#${activeCampaign.hashtag}` : ''}
-              </div>
-              <button className="nav-arrow" aria-label="Next campaign" onClick={goToNextCampaign} disabled={isCampaignLoading}>▶</button>
-            </>
+            <NavSwitcher
+              label={activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              title={activeCampaign ? `#${activeCampaign.hashtag}` : ''}
+              testId="current-campaign-bottom"
+              prevLabel="Previous campaign"
+              nextLabel="Next campaign"
+              onPrev={goToPrevCampaign}
+              onNext={goToNextCampaign}
+              disabled={isCampaignLoading}
+            />
           )}
         </div>
       </footer>

--- a/client/src/components/NavSwitcher.tsx
+++ b/client/src/components/NavSwitcher.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+/**
+ * Generic prev/current/next switcher used by the top and bottom navbars.
+ *
+ * Renders three elements:
+ *   - A left arrow button that calls `onPrev`.
+ *   - A current-label div (with optional `data-testid` for E2E hooks).
+ *   - A right arrow button that calls `onNext`.
+ *
+ * Used in two modes (extracted from `App.tsx` in fringematrix5-y6kl):
+ *   - Campaign switcher (gallery route): cycles through campaigns.
+ *   - Artist switcher (author-detail route): cycles through artists.
+ *
+ * Each mode is rendered twice (top header + bottom footer) — the only
+ * difference between top/bottom is the `data-testid` suffix.
+ *
+ * Pure refactor: no behavior change vs. the inline JSX it replaces.
+ */
+interface NavSwitcherProps {
+  label: string;
+  title?: string;
+  testId?: string;
+  prevLabel: string;
+  nextLabel: string;
+  onPrev: () => void;
+  onNext: () => void;
+  disabled?: boolean;
+}
+
+function NavSwitcher({
+  label,
+  title,
+  testId,
+  prevLabel,
+  nextLabel,
+  onPrev,
+  onNext,
+  disabled = false,
+}: NavSwitcherProps) {
+  return (
+    <>
+      <button
+        className="nav-arrow"
+        aria-label={prevLabel}
+        onClick={onPrev}
+        disabled={disabled}
+      >◀</button>
+      <div
+        className="current-campaign"
+        data-testid={testId}
+        title={title}
+      >
+        {label}
+      </div>
+      <button
+        className="nav-arrow"
+        aria-label={nextLabel}
+        onClick={onNext}
+        disabled={disabled}
+      >▶</button>
+    </>
+  );
+}
+
+export default React.memo(NavSwitcher);

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -235,6 +235,12 @@ describe('ARIA Attributes in App.tsx', () => {
     // grep-style guard survives the extraction without losing its intent.
     expect(appContent).toMatch(/(?:aria-label|prevLabel)="Previous campaign"/);
     expect(appContent).toMatch(/(?:aria-label|nextLabel)="Next campaign"/);
+    // Also verify that NavSwitcher actually wires its prevLabel/nextLabel
+    // props through to real aria-label attributes — otherwise the assertions
+    // above would just be checking for prop names without proving the arrows
+    // are accessible at runtime.
+    expect(appContent).toMatch(/aria-label=\{prevLabel\}/);
+    expect(appContent).toMatch(/aria-label=\{nextLabel\}/);
   });
 
   it('sidebar should have aria-hidden attribute', () => {

--- a/client/test/accessibility.test.js
+++ b/client/test/accessibility.test.js
@@ -229,8 +229,12 @@ describe('ARIA Attributes in App.tsx', () => {
   });
 
   it('nav arrows should have aria-labels', () => {
-    expect(appContent).toMatch(/aria-label="Previous campaign"/);
-    expect(appContent).toMatch(/aria-label="Next campaign"/);
+    // After fringematrix5-y6kl the literal aria-label is set inside NavSwitcher
+    // via the `prevLabel` / `nextLabel` props, which carry the same strings.
+    // Accept either the inline attribute form or the prop-based form so this
+    // grep-style guard survives the extraction without losing its intent.
+    expect(appContent).toMatch(/(?:aria-label|prevLabel)="Previous campaign"/);
+    expect(appContent).toMatch(/(?:aria-label|nextLabel)="Next campaign"/);
   });
 
   it('sidebar should have aria-hidden attribute', () => {


### PR DESCRIPTION
## Summary

Pure refactor (follow-up to fringematrix5-urzh / PR #188). Extracts the four near-identical prev/current/next nav-switcher blocks in `client/src/App.tsx` (top header + bottom footer × campaign-mode + artist-mode) into a single small reusable component `client/src/components/NavSwitcher.tsx`.

- `App.tsx` shrinks (net -15 lines). The four duplicate JSX blocks (each ~10-20 lines) collapse to four short `<NavSwitcher .../>` call sites.
- New component is ~66 lines (including comments + memoization).
- No behavior change. No styling change. No new tests required.
- Existing `client/test/App.artistNavSwitcher.test.tsx` (behavioral regression net) passes unchanged.

## Component design

A single generic `NavSwitcher` was the right fit (over two siblings) because the JSX is structurally identical between the artist and campaign branches — they differ only in label text, aria-label strings, handlers, `data-testid`, and the disabled predicate. Each becomes a prop.

Props:
- `label` (string) — text shown in the center label
- `title` (string, optional) — `title=` attribute on the label
- `testId` (string, optional) — `data-testid` on the label (existing tests rely on these)
- `prevLabel` / `nextLabel` — `aria-label` for the prev/next buttons
- `onPrev` / `onNext` — click handlers
- `disabled` — disables both arrow buttons

Wrapped in `React.memo` to match the pattern of `CampaignNavigation`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 671 passed
- [x] `npm run test:e2e` — 53 passed, 38 skipped, 0 failed
- [x] `npm run build`

## Notes

- One small test update was required: `client/test/accessibility.test.js` was a grep-style guard that scanned `App.tsx` + all components for the literal strings `aria-label="Previous campaign"` / `aria-label="Next campaign"`. After the extraction those strings appear in `App.tsx` only as prop values (`prevLabel="Previous campaign"`). The regex was broadened to accept either form so the guard's intent (the label strings exist somewhere in the source tree) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)