### PR TITLE
fringematrix5-batm: move thumbnail size slider into Settings modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,6 @@ import BuildInfoPopover from './components/BuildInfoPopover';
 import SharePopover from './components/SharePopover';
 import ContentModal from './components/ContentModal';
 import SettingsModal from './components/SettingsModal';
-import ThumbnailSizeSlider from './components/ThumbnailSizeSlider';
 import LightboxContainer from './components/LightboxContainer';
 import GalleryGrid, { type GalleryGridHandle } from './components/GalleryGrid';
 import AuthorsIndex from './components/AuthorsIndex';
@@ -776,11 +775,6 @@ export default function App() {
           >
             Legal
           </button>
-          <ThumbnailSizeSlider
-            value={thumbnailSizeIndex}
-            steps={GALLERY_THUMBNAIL_SIZES.length}
-            onChange={setThumbnailSizeIndex}
-          />
           <button
             className="toolbar-button"
             aria-pressed={isSettingsOpen}

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import ThumbnailSizeSlider from './ThumbnailSizeSlider';
+import { GALLERY_THUMBNAIL_SIZES } from '../config/gallery';
 
 // =============================================================================
 // Focus Management Contract (SettingsModal):
@@ -21,11 +23,6 @@ interface Props {
   isReduceEffects: boolean;
   onToggleReduceMotion: () => void;
   onToggleReduceEffects: () => void;
-  /**
-   * Current index into GALLERY_THUMBNAIL_SIZES (guaranteed in range by App).
-   * Wired in fringematrix5-xjh ahead of the slider UI widget — the slider
-   * itself will be added in a follow-up bead that consumes these props.
-   */
   thumbnailSizeIndex: number;
   onChangeThumbnailSizeIndex: (index: number) => void;
 }
@@ -37,10 +34,8 @@ export default function SettingsModal({
   isReduceEffects,
   onToggleReduceMotion,
   onToggleReduceEffects,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  thumbnailSizeIndex: _thumbnailSizeIndex,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onChangeThumbnailSizeIndex: _onChangeThumbnailSizeIndex,
+  thumbnailSizeIndex,
+  onChangeThumbnailSizeIndex,
 }: Props) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
@@ -115,6 +110,12 @@ export default function SettingsModal({
               <span className="settings-toggle-knob"></span>
             </button>
           </div>
+          <h3>Display</h3>
+          <ThumbnailSizeSlider
+            value={thumbnailSizeIndex}
+            steps={GALLERY_THUMBNAIL_SIZES.length}
+            onChange={onChangeThumbnailSizeIndex}
+          />
         </div>
       </div>
     </div>

--- a/client/test/SettingsModal.test.tsx
+++ b/client/test/SettingsModal.test.tsx
@@ -124,4 +124,32 @@ describe('SettingsModal', () => {
       expect(screen.getByRole('switch', { name: /reduce effects/i }).getAttribute('aria-checked')).toBe('true');
     });
   });
+
+  describe('thumbnail size slider', () => {
+    it('renders the slider inside the modal', () => {
+      renderModal({ thumbnailSizeIndex: 1 });
+      const slider = screen.getByLabelText(/thumbnail size/i);
+      expect(slider).toBeDefined();
+      expect((slider as HTMLInputElement).type).toBe('range');
+    });
+
+    it('slider reflects the thumbnailSizeIndex prop', () => {
+      renderModal({ thumbnailSizeIndex: 2 });
+      const slider = screen.getByLabelText(/thumbnail size/i) as HTMLInputElement;
+      expect(Number(slider.value)).toBe(2);
+    });
+
+    it('calls onChangeThumbnailSizeIndex when slider changes', () => {
+      const { props } = renderModal({ thumbnailSizeIndex: 0 });
+      const slider = screen.getByLabelText(/thumbnail size/i);
+      fireEvent.change(slider, { target: { value: '1' } });
+      expect(props.onChangeThumbnailSizeIndex).toHaveBeenCalledTimes(1);
+      expect(props.onChangeThumbnailSizeIndex).toHaveBeenCalledWith(1);
+    });
+
+    it('does not render the slider when modal is closed', () => {
+      renderModal({ isOpen: false });
+      expect(screen.queryByLabelText(/thumbnail size/i)).toBeNull();
+    });
+  });
 });

--- a/e2e/thumbnail-polish.spec.ts
+++ b/e2e/thumbnail-polish.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 
 /**
  * E2E tests for the thumbnail polish epic, covering three work items:
@@ -7,14 +7,12 @@ import { test, expect, type Page } from '@playwright/test';
  * - fringematrix5-ruy: Gallery gap driven by --grid-gap CSS variable per scale step.
  * - fringematrix5-7us: Zoom in / Zoom out buttons flank the ThumbnailSizeSlider.
  *
- * All tests target the main toolbar's ThumbnailSizeSlider widget
- * (aria-label "Zoom in" / "Zoom out") and the gallery grid (#gallery /
- * .gallery-grid).
+ * The ThumbnailSizeSlider now lives inside the Settings modal (fringematrix5-batm).
+ * Tests that interact with the slider open Settings first, then close it when done.
  */
 
 // Reliably drive a React-controlled <input type="range"> from Playwright.
-async function setSliderValue(page: Page, sliderLabel: string, value: string) {
-  const slider = page.getByLabel(sliderLabel);
+async function setSliderValue(slider: Locator, value: string) {
   await slider.evaluate((el, v) => {
     const input = el as HTMLInputElement;
     const setter = Object.getOwnPropertyDescriptor(
@@ -29,6 +27,18 @@ async function setSliderValue(page: Page, sliderLabel: string, value: string) {
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
   }, value);
+}
+
+async function openSettings(page: Page): Promise<Locator> {
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const modal = page.getByRole('dialog', { name: 'Settings' });
+  await expect(modal).toBeVisible();
+  return modal;
+}
+
+async function closeSettings(page: Page) {
+  await page.getByRole('button', { name: /close settings/i }).click();
+  await expect(page.getByRole('dialog', { name: 'Settings' })).not.toBeVisible();
 }
 
 async function waitForLoader(page: Page) {
@@ -149,16 +159,18 @@ test.describe('Thumbnail polish epic', () => {
   // -------------------------------------------------------------------------
 
   test('grid gap (--grid-gap) is strictly smaller at the smallest scale step than the largest', async ({ page }) => {
-    // Read the slider's max to know the number of steps.
-    const slider = page.getByLabel('THUMBNAIL SIZE');
+    // Open Settings to access the slider.
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     await expect(slider).toBeVisible();
     const maxStr = await slider.evaluate((el) => (el as HTMLInputElement).max);
     const max = Number(maxStr);
     expect(max).toBeGreaterThan(0); // needs at least 2 steps
 
-    // Move to the largest scale and read the gap.
-    await setSliderValue(page, 'THUMBNAIL SIZE', maxStr);
+    // Move to the largest scale and close Settings to read the gap.
+    await setSliderValue(slider, maxStr);
     await expect(slider).toHaveValue(maxStr);
+    await closeSettings(page);
 
     const largeGap = await page.evaluate(() => {
       const raw = document.documentElement.style.getPropertyValue('--grid-gap');
@@ -166,8 +178,11 @@ test.describe('Thumbnail polish epic', () => {
     });
 
     // Move to the smallest scale and re-read.
-    await setSliderValue(page, 'THUMBNAIL SIZE', '0');
-    await expect(slider).toHaveValue('0');
+    const modal2 = await openSettings(page);
+    const slider2 = modal2.getByLabel('THUMBNAIL SIZE');
+    await setSliderValue(slider2, '0');
+    await expect(slider2).toHaveValue('0');
+    await closeSettings(page);
 
     const smallGap = await page.evaluate(() => {
       const raw = document.documentElement.style.getPropertyValue('--grid-gap');
@@ -180,12 +195,14 @@ test.describe('Thumbnail polish epic', () => {
   });
 
   test('no horizontal overflow at the smallest scale step', async ({ page }) => {
-    const slider = page.getByLabel('THUMBNAIL SIZE');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     await expect(slider).toBeVisible();
 
-    // Move to the smallest step.
-    await setSliderValue(page, 'THUMBNAIL SIZE', '0');
+    // Move to the smallest step and close Settings.
+    await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
+    await closeSettings(page);
 
     // The document body must not overflow horizontally.
     const overflow = await page.evaluate(() => {
@@ -205,21 +222,23 @@ test.describe('Thumbnail polish epic', () => {
       test.skip(true, 'No gallery cards available; skipping zoom-in width check');
     }
 
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
-
     // Start at the smallest step so there is room to zoom in.
-    await setSliderValue(page, 'THUMBNAIL SIZE', '0');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
+    await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
+    await closeSettings(page);
 
     const firstCard = page.locator('.gallery-grid .card').first();
     const baseBox = await firstCard.boundingBox();
     expect(baseBox).not.toBeNull();
     const baseW = baseBox!.width;
 
-    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    const modal2 = await openSettings(page);
+    const zoomIn = modal2.getByRole('button', { name: 'Zoom in' });
     await expect(zoomIn).toBeEnabled();
     await zoomIn.click();
+    await closeSettings(page);
 
     // Width must increase after clicking Zoom in.
     await expect.poll(async () => {
@@ -234,22 +253,24 @@ test.describe('Thumbnail polish epic', () => {
       test.skip(true, 'No gallery cards available; skipping zoom-out width check');
     }
 
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
-
     // Start at the largest step so there is room to zoom out.
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     const maxStr = await slider.evaluate((el) => (el as HTMLInputElement).max);
-    await setSliderValue(page, 'THUMBNAIL SIZE', maxStr);
+    await setSliderValue(slider, maxStr);
     await expect(slider).toHaveValue(maxStr);
+    await closeSettings(page);
 
     const firstCard = page.locator('.gallery-grid .card').first();
     const baseBox = await firstCard.boundingBox();
     expect(baseBox).not.toBeNull();
     const baseW = baseBox!.width;
 
-    const zoomOut = toolbar.getByRole('button', { name: 'Zoom out' });
+    const modal2 = await openSettings(page);
+    const zoomOut = modal2.getByRole('button', { name: 'Zoom out' });
     await expect(zoomOut).toBeEnabled();
     await zoomOut.click();
+    await closeSettings(page);
 
     // Width must decrease after clicking Zoom out.
     await expect.poll(async () => {
@@ -259,34 +280,34 @@ test.describe('Thumbnail polish epic', () => {
   });
 
   test('Zoom out button is disabled at the minimum scale step', async ({ page }) => {
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
 
     // Drive slider to the minimum step via the slider (reliable).
-    await setSliderValue(page, 'THUMBNAIL SIZE', '0');
+    await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
 
-    const zoomOut = toolbar.getByRole('button', { name: 'Zoom out' });
+    const zoomOut = modal.getByRole('button', { name: 'Zoom out' });
     await expect(zoomOut).toBeDisabled();
 
     // Zoom in must still be enabled at the minimum.
-    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    const zoomIn = modal.getByRole('button', { name: 'Zoom in' });
     await expect(zoomIn).toBeEnabled();
   });
 
   test('Zoom in button is disabled at the maximum scale step', async ({ page }) => {
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
 
     const maxStr = await slider.evaluate((el) => (el as HTMLInputElement).max);
-    await setSliderValue(page, 'THUMBNAIL SIZE', maxStr);
+    await setSliderValue(slider, maxStr);
     await expect(slider).toHaveValue(maxStr);
 
-    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    const zoomIn = modal.getByRole('button', { name: 'Zoom in' });
     await expect(zoomIn).toBeDisabled();
 
     // Zoom out must still be enabled at the maximum.
-    const zoomOut = toolbar.getByRole('button', { name: 'Zoom out' });
+    const zoomOut = modal.getByRole('button', { name: 'Zoom out' });
     await expect(zoomOut).toBeEnabled();
   });
 });

--- a/e2e/thumbnail-size.spec.ts
+++ b/e2e/thumbnail-size.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Locator, type Page } from '@playwright/test';
 
 /**
- * E2E tests for the ThumbnailSizeSlider placed in the main toolbar.
+ * E2E tests for the ThumbnailSizeSlider placed inside the Settings modal.
  *
  * The slider is a controlled native `<input type="range">` whose value
  * (0..steps-1) drives the `--thumbnail-min-size` CSS variable on
@@ -50,6 +50,19 @@ async function gotoClean(page: Page) {
   await waitForLoader(page);
 }
 
+async function openSettings(page: Page) {
+  const settingsBtn = page.getByRole('button', { name: 'Settings' });
+  await settingsBtn.click();
+  const modal = page.getByRole('dialog', { name: 'Settings' });
+  await expect(modal).toBeVisible();
+  return modal;
+}
+
+async function closeSettings(page: Page) {
+  await page.getByRole('button', { name: /close settings/i }).click();
+  await expect(page.getByRole('dialog', { name: 'Settings' })).not.toBeVisible();
+}
+
 /**
  * Walk the campaign sidebar until we land on a campaign that has at least
  * one rendered `.gallery-grid .card`. Returns true if cards are available.
@@ -85,17 +98,21 @@ async function findCampaignWithCards(page: Page): Promise<boolean> {
   return false;
 }
 
-test.describe('Thumbnail size slider (toolbar)', () => {
+test.describe('Thumbnail size slider (Settings modal)', () => {
   test.beforeEach(async ({ page }) => {
     await gotoClean(page);
   });
 
-  test('slider is visible in the toolbar with the expected label', async ({ page }) => {
+  test('slider is NOT visible in the toolbar', async ({ page }) => {
     const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
     await expect(toolbar).toBeVisible();
+    const sliderInToolbar = toolbar.getByLabel('THUMBNAIL SIZE');
+    await expect(sliderInToolbar).not.toBeVisible();
+  });
 
-    // The slider lives inside the primary-actions toolbar.
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+  test('slider is visible inside the open Settings modal with the expected label', async ({ page }) => {
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     await expect(slider).toBeVisible();
     await expect(slider).toHaveAttribute('type', 'range');
   });
@@ -105,20 +122,27 @@ test.describe('Thumbnail size slider (toolbar)', () => {
     if (!hasCards) {
       test.skip(true, 'No gallery cards available to measure');
     }
-    const firstCard = page.locator('.gallery-grid .card').first();
 
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
+    // First set to minimum so we have a reliable baseline.
+    await setSliderValue(slider, '0');
+    await expect(slider).toHaveValue('0');
+    await closeSettings(page);
+
+    const firstCard = page.locator('.gallery-grid .card').first();
     const baseBox = await firstCard.boundingBox();
     expect(baseBox).not.toBeNull();
     const baseW = baseBox!.width;
 
-    const slider = page.getByLabel('THUMBNAIL SIZE');
-    const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
+    const modal2 = await openSettings(page);
+    const slider2 = modal2.getByLabel('THUMBNAIL SIZE');
+    const max = await slider2.evaluate((el) => (el as HTMLInputElement).max);
     expect(Number(max)).toBeGreaterThan(0);
-    await setSliderValue(slider, max);
-    await expect(slider).toHaveValue(max);
+    await setSliderValue(slider2, max);
+    await expect(slider2).toHaveValue(max);
+    await closeSettings(page);
 
-    // Allow the React effect that writes --thumbnail-min-size to apply,
-    // then re-measure. boundingBox() reads layout, so a poll loop suffices.
     await expect.poll(async () => {
       const b = await firstCard.boundingBox();
       return b ? b.width : 0;
@@ -130,15 +154,25 @@ test.describe('Thumbnail size slider (toolbar)', () => {
     if (!hasCards) {
       test.skip(true, 'No gallery cards available to measure');
     }
-    const firstCard = page.locator('.gallery-grid .card').first();
 
+    // Start from max for a clear baseline.
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
+    const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
+    await setSliderValue(slider, max);
+    await expect(slider).toHaveValue(max);
+    await closeSettings(page);
+
+    const firstCard = page.locator('.gallery-grid .card').first();
     const baseBox = await firstCard.boundingBox();
     expect(baseBox).not.toBeNull();
     const baseW = baseBox!.width;
 
-    const slider = page.getByLabel('THUMBNAIL SIZE');
-    await setSliderValue(slider, '0');
-    await expect(slider).toHaveValue('0');
+    const modal2 = await openSettings(page);
+    const slider2 = modal2.getByLabel('THUMBNAIL SIZE');
+    await setSliderValue(slider2, '0');
+    await expect(slider2).toHaveValue('0');
+    await closeSettings(page);
 
     await expect.poll(async () => {
       const b = await firstCard.boundingBox();
@@ -146,12 +180,28 @@ test.describe('Thumbnail size slider (toolbar)', () => {
     }, { timeout: 5000 }).toBeLessThan(baseW * 0.9);
   });
 
-  test('selected size index is restored from localStorage after reload', async ({ page, context }) => {
-    const slider = page.getByLabel('THUMBNAIL SIZE');
+  test('selected size index persists after closing and reopening Settings', async ({ page }) => {
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
     expect(Number(max)).toBeGreaterThan(0);
 
-    // Move to the largest step and confirm it was persisted.
+    await setSliderValue(slider, max);
+    await expect(slider).toHaveValue(max);
+    await closeSettings(page);
+
+    // Reopen and confirm value was preserved (state lives in App).
+    const modal2 = await openSettings(page);
+    const slider2 = modal2.getByLabel('THUMBNAIL SIZE');
+    await expect(slider2).toHaveValue(max);
+  });
+
+  test('selected size index is restored from localStorage after reload', async ({ page, context }) => {
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
+    const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
+    expect(Number(max)).toBeGreaterThan(0);
+
     await setSliderValue(slider, max);
     await expect(slider).toHaveValue(max);
 
@@ -172,82 +222,67 @@ test.describe('Thumbnail size slider (toolbar)', () => {
     await freshPage.goto('/');
     await waitForLoader(freshPage);
 
-    const freshSlider = freshPage.getByLabel('THUMBNAIL SIZE');
+    const freshModal = await openSettings(freshPage);
+    const freshSlider = freshModal.getByLabel('THUMBNAIL SIZE');
     await expect(freshSlider).toHaveValue(max);
 
     await freshPage.close();
   });
 
   test('slider step count equals GALLERY_THUMBNAIL_SIZES.length from config', async ({ page }) => {
-    const slider = page.getByLabel('THUMBNAIL SIZE');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     const max = await slider.evaluate((el) => Number((el as HTMLInputElement).max));
 
-    // The number of steps is rendered as one tick per size in the
-    // adjacent ticks container; reading that gives us the configured length
-    // as observed by the running app.
     const tickCount = await page.locator('.thumbnail-size-slider-tick').count();
 
-    // max = steps - 1, so steps derived from the range input must match
-    // the tick count, which in turn equals GALLERY_THUMBNAIL_SIZES.length.
     expect(tickCount).toBeGreaterThan(1);
     expect(max + 1).toBe(tickCount);
   });
 
-  test('zoom-in button is visible and clicking it increases slider value', async ({ page }) => {
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    await expect(toolbar).toBeVisible();
-
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
-    await expect(slider).toBeVisible();
-
-    // Move to the minimum step so there is room to zoom in.
+  test('zoom-in button is visible in Settings modal and clicking it increases slider value', async ({ page }) => {
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
 
-    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    const zoomIn = modal.getByRole('button', { name: 'Zoom in' });
     await expect(zoomIn).toBeVisible();
     await expect(zoomIn).toBeEnabled();
 
     await zoomIn.click();
-
-    // After one click the slider value should have advanced by 1.
     await expect(slider).toHaveValue('1');
   });
 
-  test('zoom-out button is visible and clicking it decreases slider value', async ({ page }) => {
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
-
-    // Move to a non-zero step so there is room to zoom out.
+  test('zoom-out button is visible in Settings modal and clicking it decreases slider value', async ({ page }) => {
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
     await setSliderValue(slider, max);
     await expect(slider).toHaveValue(max);
 
-    const zoomOut = toolbar.getByRole('button', { name: 'Zoom out' });
+    const zoomOut = modal.getByRole('button', { name: 'Zoom out' });
     await expect(zoomOut).toBeVisible();
     await expect(zoomOut).toBeEnabled();
 
     await zoomOut.click();
-
     await expect(slider).toHaveValue(String(Number(max) - 1));
   });
 
   test('zoom-in button is disabled at max and zoom-out is disabled at min', async ({ page }) => {
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
 
-    // At minimum: zoom-out should be disabled.
     await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
-    await expect(toolbar.getByRole('button', { name: 'Zoom out' })).toBeDisabled();
-    await expect(toolbar.getByRole('button', { name: 'Zoom in' })).toBeEnabled();
+    await expect(modal.getByRole('button', { name: 'Zoom out' })).toBeDisabled();
+    await expect(modal.getByRole('button', { name: 'Zoom in' })).toBeEnabled();
 
-    // At maximum: zoom-in should be disabled.
     const max = await slider.evaluate((el) => (el as HTMLInputElement).max);
     await setSliderValue(slider, max);
     await expect(slider).toHaveValue(max);
-    await expect(toolbar.getByRole('button', { name: 'Zoom in' })).toBeDisabled();
-    await expect(toolbar.getByRole('button', { name: 'Zoom out' })).toBeEnabled();
+    await expect(modal.getByRole('button', { name: 'Zoom in' })).toBeDisabled();
+    await expect(modal.getByRole('button', { name: 'Zoom out' })).toBeEnabled();
   });
 
   test('clicking zoom-in button measurably increases card width', async ({ page }) => {
@@ -256,22 +291,22 @@ test.describe('Thumbnail size slider (toolbar)', () => {
       test.skip(true, 'No gallery cards available to measure');
     }
 
-    const toolbar = page.getByRole('toolbar', { name: 'Primary actions' });
-    const slider = toolbar.getByLabel('THUMBNAIL SIZE');
-
-    // Start at minimum step for a clear baseline.
+    const modal = await openSettings(page);
+    const slider = modal.getByLabel('THUMBNAIL SIZE');
     await setSliderValue(slider, '0');
     await expect(slider).toHaveValue('0');
+    await closeSettings(page);
 
     const firstCard = page.locator('.gallery-grid .card').first();
     const baseBox = await firstCard.boundingBox();
     expect(baseBox).not.toBeNull();
     const baseW = baseBox!.width;
 
-    const zoomIn = toolbar.getByRole('button', { name: 'Zoom in' });
+    const modal2 = await openSettings(page);
+    const zoomIn = modal2.getByRole('button', { name: 'Zoom in' });
     await zoomIn.click();
+    await closeSettings(page);
 
-    // Card width should increase after zooming in.
     await expect.poll(async () => {
       const b = await firstCard.boundingBox();
       return b ? b.width : 0;


### PR DESCRIPTION
## Bead

fringematrix5-batm: Move Thumbnail Size widget from top toolbar into Settings modal

## Summary

- Remove ThumbnailSizeSlider from top toolbar in App.tsx
- Render it inside SettingsModal using the already-wired props (thumbnailSizeIndex / onChangeThumbnailSizeIndex)
- Drop eslint-disable-next-line comments now that props are consumed
- Update unit and e2e tests accordingly

## Test plan

- [x] Local CI passes (typecheck + unit tests: 691 passed)
- [x] Slider is NOT in the toolbar (e2e verified)
- [x] Slider IS in the open Settings modal (e2e verified)
- [x] Slider updates thumbnail sizes correctly (e2e verified)
- [x] State survives modal close/reopen cycle (e2e verified)

## Follow-ups

None identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop