### PR TITLE
fringematrix5-zkhl: add client-side artist-detail cache for instant re-population

### DIFF
--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useState, type RefObject } from 'react';
-import { fetchJSON } from '../utils/fetchJSON';
+import { useCallback, useMemo, type RefObject } from 'react';
+import { useAuthorDetail } from '../hooks/useAuthorDetail';
 import { getInitialsFromName } from '../utils/author';
 import { isSafeUrl } from '../utils/isSafeUrl';
-import type { AuthorDetailResponse, ImageData } from '../types/api';
+import type { ImageData } from '../types/api';
 import { UNKNOWN_ARTIST_HANDLE, UNKNOWN_ARTIST_NAME } from '../types/api';
 import GalleryGrid, { type GalleryGridHandle } from './GalleryGrid';
 
@@ -48,47 +48,13 @@ interface Props {
  * missing handle surface as "Failed to load author".
  */
 export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: Props) {
-  const [data, setData] = useState<AuthorDetailResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { data, error } = useAuthorDetail(handle);
 
   // Whether we're viewing the synthetic "Unknown artist" page. Drives a few
   // small UI tweaks (avatar glyph, no Twitter link, dedicated empty-state
   // copy, no `@handle` in the header). Computed from the route handle —
   // matched case-insensitively to mirror the server's sentinel comparison.
   const isUnknownArtist = handle.toLowerCase() === UNKNOWN_ARTIST_HANDLE.toLowerCase();
-
-  useEffect(() => {
-    const controller = new AbortController();
-    let cancelled = false;
-    // Reset state when the handle changes so we don't briefly show stale
-    // data (or a stale error alert) from the previous request before the
-    // new one resolves.
-    setData(null);
-    setError(null);
-    (async () => {
-      try {
-        // Server :handle param accepts the raw "@..." string; we URL-encode so
-        // the leading "@" is transmitted safely as %40.
-        const encoded = encodeURIComponent(handle);
-        const res = await fetchJSON<AuthorDetailResponse>(`/api/authors/${encoded}`, {
-          signal: controller.signal,
-        });
-        if (cancelled) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (cancelled) return;
-        if (e instanceof DOMException && e.name === 'AbortError') return;
-        console.error('Failed to load author detail:', e);
-        setData(null);
-        setError('Failed to load artist');
-      }
-    })();
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [handle]);
 
   const isLoading = data === null && error === null;
 

--- a/client/src/hooks/useAuthorDetail.ts
+++ b/client/src/hooks/useAuthorDetail.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { fetchJSON } from '../utils/fetchJSON';
+import type { AuthorDetailResponse } from '../types/api';
+
+const cache = new Map<string, AuthorDetailResponse>();
+
+export function clearAuthorDetailCache(): void {
+  cache.clear();
+}
+
+export interface AuthorDetailState {
+  data: AuthorDetailResponse | null;
+  error: string | null;
+}
+
+export function useAuthorDetail(handle: string): AuthorDetailState {
+  const [data, setData] = useState<AuthorDetailResponse | null>(() => cache.get(handle) ?? null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (cache.has(handle)) {
+      setData(cache.get(handle)!);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+    setData(null);
+    setError(null);
+
+    (async () => {
+      try {
+        const encoded = encodeURIComponent(handle);
+        const res = await fetchJSON<AuthorDetailResponse>(`/api/authors/${encoded}`, {
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+        cache.set(handle, res);
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load author detail:', e);
+        setData(null);
+        setError('Failed to load artist');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [handle]);
+
+  return { data, error };
+}

--- a/client/src/hooks/useAuthorDetail.ts
+++ b/client/src/hooks/useAuthorDetail.ts
@@ -13,21 +13,24 @@ export interface AuthorDetailState {
   error: string | null;
 }
 
+interface FetchState {
+  handle: string;
+  data: AuthorDetailResponse | null;
+  error: string | null;
+}
+
 export function useAuthorDetail(handle: string): AuthorDetailState {
-  const [data, setData] = useState<AuthorDetailResponse | null>(() => cache.get(handle) ?? null);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<FetchState>({ handle, data: cache.get(handle) ?? null, error: null });
 
   useEffect(() => {
     if (cache.has(handle)) {
-      setData(cache.get(handle)!);
-      setError(null);
+      setState({ handle, data: cache.get(handle)!, error: null });
       return;
     }
 
     const controller = new AbortController();
     let cancelled = false;
-    setData(null);
-    setError(null);
+    setState({ handle, data: null, error: null });
 
     (async () => {
       try {
@@ -37,14 +40,12 @@ export function useAuthorDetail(handle: string): AuthorDetailState {
         });
         if (cancelled) return;
         cache.set(handle, res);
-        setData(res);
-        setError(null);
+        setState({ handle, data: res, error: null });
       } catch (e) {
         if (cancelled) return;
         if (e instanceof DOMException && e.name === 'AbortError') return;
         console.error('Failed to load author detail:', e);
-        setData(null);
-        setError('Failed to load artist');
+        setState({ handle, data: null, error: 'Failed to load artist' });
       }
     })();
 
@@ -54,5 +55,14 @@ export function useAuthorDetail(handle: string): AuthorDetailState {
     };
   }, [handle]);
 
-  return { data, error };
+  // Read cache synchronously during render so handle changes to a cached value
+  // take effect in the same render commit, not after an effect flush.
+  const cached = cache.get(handle) ?? null;
+  if (cached) return { data: cached, error: null };
+
+  // When the async state is for a different handle (handle just changed),
+  // return the "loading" state — no stale data or stale error shown.
+  if (state.handle !== handle) return { data: null, error: null };
+
+  return { data: state.data, error: state.error };
 }

--- a/client/test/setup.js
+++ b/client/test/setup.js
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+import { beforeEach } from 'vitest';
+import { clearAuthorDetailCache } from '../src/hooks/useAuthorDetail';
+
+beforeEach(() => {
+  clearAuthorDetailCache();
+});

--- a/client/test/useAuthorDetail.test.ts
+++ b/client/test/useAuthorDetail.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuthorDetail, clearAuthorDetailCache } from '../src/hooks/useAuthorDetail';
+
+const SAMPLE_DETAIL = {
+  author: {
+    handle: '@Zort70',
+    name: 'Sarah Proost',
+    twitterUrl: 'https://twitter.com/Zort70',
+    alternateHandles: [],
+    roles: ['artist'],
+  },
+  images: [
+    {
+      src: '/avatars/Season4/CrossTheLine/abc.jpg',
+      fileName: 'abc.jpg',
+      blobPath: 'avatars/Season4/CrossTheLine/abc.jpg',
+      campaignId: 'crosstheline',
+      confidence: 'high' as const,
+    },
+  ],
+};
+
+const SAMPLE_DETAIL_B = {
+  author: {
+    handle: '@OtherArtist',
+    name: 'Other Artist',
+    twitterUrl: null,
+    alternateHandles: [],
+    roles: ['artist'],
+  },
+  images: [],
+};
+
+function mockFetch(responseBody: unknown, status = 200) {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(responseBody), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  clearAuthorDetailCache();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('useAuthorDetail', () => {
+  it('fetches /api/authors/:handle and returns data on success', async () => {
+    const fetchSpy = mockFetch(SAMPLE_DETAIL);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useAuthorDetail('@Zort70'));
+
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+
+    expect(result.current.data?.author.name).toBe('Sarah Proost');
+    expect(result.current.error).toBeNull();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(calledUrl).toContain('/api/authors/%40Zort70');
+  });
+
+  it('fetches only once across two mounts for the same handle (cache hit on second mount)', async () => {
+    // First mount: fetches from network.
+    const fetchSpy = mockFetch(SAMPLE_DETAIL);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { result: result1, unmount } = renderHook(() => useAuthorDetail('@Zort70'));
+    await waitFor(() => {
+      expect(result1.current.data).not.toBeNull();
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    // Second mount: should hit cache, no additional fetch.
+    const { result: result2 } = renderHook(() => useAuthorDetail('@Zort70'));
+
+    // Data is available synchronously on mount (from cache initializer).
+    expect(result2.current.data?.author.name).toBe('Sarah Proost');
+    expect(result2.current.error).toBeNull();
+
+    // Give any potential async fetch time to run — it should not.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches exactly 2 times when navigating A → B → A (A served from cache on revisit)', async () => {
+    let callCount = 0;
+    const fetchSpy = vi.fn(async (url: string) => {
+      callCount += 1;
+      const body = (url as string).includes('OtherArtist') ? SAMPLE_DETAIL_B : SAMPLE_DETAIL;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    // Visit A (@Zort70) — first visit, fetches from network.
+    const { result, rerender } = renderHook(
+      ({ handle }: { handle: string }) => useAuthorDetail(handle),
+      { initialProps: { handle: '@Zort70' } },
+    );
+    await waitFor(() => {
+      expect(result.current.data).not.toBeNull();
+    });
+
+    // Navigate to B (@OtherArtist) — second fetch.
+    rerender({ handle: '@OtherArtist' });
+    await waitFor(() => {
+      expect(result.current.data?.author.handle).toBe('@OtherArtist');
+    });
+
+    // Navigate back to A — served from cache, no new fetch.
+    rerender({ handle: '@Zort70' });
+    expect(result.current.data?.author.name).toBe('Sarah Proost');
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // 2 total fetches: 1 for @Zort70 (first visit), 1 for @OtherArtist.
+    // @Zort70 revisit hits cache — no third fetch.
+    expect(callCount).toBe(2);
+  });
+
+  it('returns error state on 404', async () => {
+    globalThis.fetch = mockFetch({ error: 'not found' }, 404) as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAuthorDetail('@missing'));
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error).toMatch(/failed to load artist/i);
+    expect(result.current.data).toBeNull();
+    errSpy.mockRestore();
+  });
+});

--- a/e2e/artist-detail-cache.spec.ts
+++ b/e2e/artist-detail-cache.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { ZORT_HANDLE, ZORT_HASH, gotoZortAuthorDetail } from './helpers/author-browse';
+import { waitForLoaderToFinish } from './helpers/wireframe';
+
+/**
+ * E2E coverage for the artist-detail client-side cache (fringematrix5-zkhl).
+ *
+ * Verifies that revisiting an artist after navigating away does NOT show
+ * "Loading artist…" and that the network is hit only once across both visits.
+ *
+ * The test intercepts /api/authors/:handle with a 600ms artificial delay so
+ * that the cache vs. network paths are unambiguously distinguishable — the
+ * second visit would take ≥600ms without the cache, and renders instantly with it.
+ */
+test.describe('Artist-detail cache (fringematrix5-zkhl)', () => {
+  test('second visit renders grid immediately without "Loading artist…" and hits the network only once', async ({
+    page,
+  }) => {
+    let interceptCallCount = 0;
+    const encodedHandle = encodeURIComponent(ZORT_HANDLE);
+
+    // Intercept the artist detail API with a 600ms delay on the first call.
+    // On subsequent calls we still serve the response but also count them
+    // so we can assert that the cache was used on the second visit.
+    await page.route(`**/api/authors/${encodedHandle}`, async (route) => {
+      interceptCallCount += 1;
+      if (interceptCallCount === 1) {
+        // First visit: delay to make the cache benefit observable.
+        await new Promise((r) => setTimeout(r, 600));
+      }
+      await route.continue();
+    });
+
+    // First visit: navigate to the author detail page.
+    await page.goto(`/${ZORT_HASH}`);
+    await waitForLoaderToFinish(page);
+
+    // Wait for the grid — this proves the first fetch resolved.
+    const grid = page.locator('[data-testid="author-images-grid"]');
+    const emptyStatus = page
+      .locator('.authors-status')
+      .filter({ hasText: /no images attributed/i });
+
+    await expect
+      .poll(
+        async () =>
+          (await grid.count()) > 0 || (await emptyStatus.count()) > 0,
+        { timeout: 20_000 },
+      )
+      .toBe(true);
+
+    if ((await emptyStatus.count()) > 0 && (await grid.count()) === 0) {
+      test.skip(
+        true,
+        'No images returned for @Zort70 (BLOB_READ_WRITE_TOKEN likely missing).',
+      );
+    }
+
+    await expect(grid).toBeVisible();
+
+    // Navigate away to the all-artists page.
+    await page.click('button[aria-label="Back to artists"]');
+    await expect(page.locator('.authors-page')).toBeVisible();
+
+    // Navigate back to the same artist.
+    // We click the matching card in the authors index if available,
+    // or just navigate directly via hash.
+    await page.goto(`/${ZORT_HASH}`);
+
+    // On the second visit the grid must be visible immediately — before any
+    // "Loading artist…" status can appear (cache hit renders synchronously).
+    // We assert that the loading status is never seen by checking it stays
+    // absent throughout the navigation.
+    const loadingStatus = page.locator('.authors-status', { hasText: 'Loading artist…' });
+    await expect(loadingStatus).not.toBeVisible();
+
+    // The grid should be visible very quickly (well under the 600ms delay
+    // we imposed on the network leg).
+    await expect(grid).toBeVisible({ timeout: 1000 });
+
+    // Network was hit exactly once across both visits.
+    expect(interceptCallCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Bead

fringematrix5-zkhl: Cache artist-detail responses client-side (parity with campaign imageCache)

## Summary

- Extract `useAuthorDetail(handle)` hook with module-scope Map cache (`client/src/hooks/useAuthorDetail.ts`)
- On revisit, renders from cache immediately (no data=null flicker, no "Loading artist…")
- First visit unchanged: spinner shown, then grid
- Cache is in-memory only; page reload re-fetches
- Add `clearAuthorDetailCache()` export and global `beforeEach` in test setup for cache transparency across tests

## Test plan

- [x] Local CI passes (server: 112, client: 691, e2e: 54 passed 38 skipped)
- [x] Unit test: fetch called once across two visits to same handle (`useAuthorDetail.test.ts`)
- [x] E2E: second visit shows grid immediately, no Loading status visible (`artist-detail-cache.spec.ts`)

## Follow-ups

None identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop