### PR TITLE
fringematrix5-wivw: add Share on Reddit button to Share popover

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -483,6 +483,14 @@ export default function App() {
     return `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`;
   }, []);
 
+  const redditShareUrl = useMemo(() => {
+    const params = new URLSearchParams({
+      title: SITE_SHARE_TEXT,
+      url: SITE_URL,
+    });
+    return `https://www.reddit.com/submit?${params.toString()}`;
+  }, []);
+
   // Handler for when user dismisses the loading screen
   const handleLoadingComplete = useCallback(() => {
     setShowLoadingScreen(false);
@@ -946,6 +954,7 @@ export default function App() {
           style={shareStyle}
           threadsShareUrl={threadsShareUrl}
           blueskyShareUrl={blueskyShareUrl}
+          redditShareUrl={redditShareUrl}
           onClose={() => setIsShareOpen(false)}
         />
       )}

--- a/client/src/components/SharePopover.tsx
+++ b/client/src/components/SharePopover.tsx
@@ -4,10 +4,11 @@ interface SharePopoverProps {
   style: React.CSSProperties;
   threadsShareUrl: string;
   blueskyShareUrl: string;
+  redditShareUrl: string;
   onClose: () => void;
 }
 
-export default function SharePopover({ style, threadsShareUrl, blueskyShareUrl, onClose }: SharePopoverProps) {
+export default function SharePopover({ style, threadsShareUrl, blueskyShareUrl, redditShareUrl, onClose }: SharePopoverProps) {
   return (
     <div className="share-popover" role="dialog" aria-label="Share" aria-modal={false} style={style}>
       <div className="share-header">
@@ -36,6 +37,14 @@ export default function SharePopover({ style, threadsShareUrl, blueskyShareUrl, 
           rel="noreferrer noopener"
         >
           Share on Bluesky
+        </a>
+        <a
+          className="action-btn"
+          href={redditShareUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Share on Reddit
         </a>
       </div>
     </div>

--- a/client/test/components/SharePopover.test.tsx
+++ b/client/test/components/SharePopover.test.tsx
@@ -7,6 +7,7 @@ const DEFAULT_PROPS = {
   style: {},
   threadsShareUrl: 'https://www.threads.net/intent/post?text=Check%20out%20Fringe%20Matrix&url=https%3A%2F%2Ffringematrix.art',
   blueskyShareUrl: 'https://bsky.app/intent/compose?text=Check%20out%20Fringe%20Matrix%20https%3A%2F%2Ffringematrix.art',
+  redditShareUrl: 'https://www.reddit.com/submit?title=Check+out+Fringe+Matrix&url=https%3A%2F%2Ffringematrix.art',
   onClose: vi.fn(),
 };
 
@@ -48,6 +49,48 @@ describe('SharePopover', () => {
     it('applies the action-btn class', () => {
       render(<SharePopover {...DEFAULT_PROPS} />);
       const link = screen.getByRole('link', { name: 'Share on Bluesky' });
+      expect(link.className).toBe('action-btn');
+    });
+  });
+
+  describe('Reddit button', () => {
+    it('renders a "Share on Reddit" link', () => {
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      expect(screen.getByRole('link', { name: 'Share on Reddit' })).toBeInTheDocument();
+    });
+
+    it('has the redditShareUrl as href', () => {
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      const link = screen.getByRole('link', { name: 'Share on Reddit' }) as HTMLAnchorElement;
+      expect(link.href).toBe(DEFAULT_PROPS.redditShareUrl);
+    });
+
+    it('has target="_blank"', () => {
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      const link = screen.getByRole('link', { name: 'Share on Reddit' }) as HTMLAnchorElement;
+      expect(link.target).toBe('_blank');
+    });
+
+    it('has rel="noreferrer noopener"', () => {
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      const link = screen.getByRole('link', { name: 'Share on Reddit' }) as HTMLAnchorElement;
+      expect(link.rel).toBe('noreferrer noopener');
+    });
+
+    it('href starts with reddit.com/submit? and decoded params include SITE_URL and SITE_SHARE_TEXT', () => {
+      const siteUrl = 'https://fringematrix.art';
+      const siteShareText = 'Check out Fringe Matrix';
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      const link = screen.getByRole('link', { name: 'Share on Reddit' }) as HTMLAnchorElement;
+      expect(link.href).toMatch(/^https:\/\/www\.reddit\.com\/submit\?/);
+      const url = new URL(link.href);
+      expect(url.searchParams.get('url')).toBe(siteUrl);
+      expect(url.searchParams.get('title')).toBe(siteShareText);
+    });
+
+    it('applies the action-btn class', () => {
+      render(<SharePopover {...DEFAULT_PROPS} />);
+      const link = screen.getByRole('link', { name: 'Share on Reddit' });
       expect(link.className).toBe('action-btn');
     });
   });

--- a/e2e/share-popover.spec.ts
+++ b/e2e/share-popover.spec.ts
@@ -38,3 +38,36 @@ test('Share on Bluesky button has target="_blank" and safe rel', async ({ page }
   await expect(blueskyLink).toHaveAttribute('target', '_blank');
   await expect(blueskyLink).toHaveAttribute('rel', 'noreferrer noopener');
 });
+
+test('Share popover shows "Share on Reddit" button', async ({ page }) => {
+  await page.getByRole('button', { name: 'Share' }).click();
+  const shareDialog = page.getByRole('dialog').filter({ hasText: 'Share' });
+  await expect(shareDialog).toBeVisible();
+  await expect(shareDialog.getByRole('link', { name: 'Share on Reddit' })).toBeVisible();
+});
+
+test('Share on Reddit button href points to reddit.com/submit with SITE_URL and SITE_SHARE_TEXT params', async ({ page }) => {
+  await page.getByRole('button', { name: 'Share' }).click();
+  const shareDialog = page.getByRole('dialog').filter({ hasText: 'Share' });
+  await expect(shareDialog).toBeVisible();
+
+  const redditLink = shareDialog.getByRole('link', { name: 'Share on Reddit' });
+  await expect(redditLink).toBeVisible();
+
+  const href = await redditLink.getAttribute('href');
+  expect(href).toBeTruthy();
+  expect(href!).toMatch(/^https:\/\/www\.reddit\.com\/submit\?/);
+
+  const url = new URL(href!);
+  expect(url.searchParams.get('url')).toBe('https://fringematrix.art');
+  expect(url.searchParams.get('title')).toBe('Check out Fringe Matrix');
+});
+
+test('Share on Reddit button has target="_blank" and safe rel', async ({ page }) => {
+  await page.getByRole('button', { name: 'Share' }).click();
+  const shareDialog = page.getByRole('dialog').filter({ hasText: 'Share' });
+  const redditLink = shareDialog.getByRole('link', { name: 'Share on Reddit' });
+
+  await expect(redditLink).toHaveAttribute('target', '_blank');
+  await expect(redditLink).toHaveAttribute('rel', 'noreferrer noopener');
+});


### PR DESCRIPTION
## Bead

fringematrix5-wivw: Add "Share on Reddit" button to Share popover

## Summary

- Add redditShareUrl memo in App.tsx (reddit.com/submit with title + url params)
- Add redditShareUrl prop to SharePopoverProps
- Render Share on Reddit anchor below Bluesky button in SharePopover
- Extend unit tests for Reddit button
- Extend E2E tests for Reddit button

## Test plan

- [ ] Local CI passes (`npm run ci`)
- [ ] Share popover shows "Share on Reddit" button
- [ ] Button opens reddit.com/submit with correct title and url params
- [ ] Keyboard accessible via Tab

## Follow-ups

After this PR merges, close the parent epic: fringematrix5-ylnn

🤖 Generated with [Claude Code](https://claude.com/claude-code) via beads-loop