### PR TITLE
fringematrix5-utaj: Virtualize/window the gallery grid for large campaigns

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -590,6 +590,18 @@ export default function App() {
   // setting a source first.
   const lightboxImages = lightboxImageSource?.images ?? currentImages;
 
+  // Index whose card the windowed GalleryGrid must keep mounted regardless of
+  // scroll position, so the lightbox close/zoom animation can always read the
+  // source thumbnail's rect even when the user has paged (next/prev) to an
+  // image scrolled out of the window. Routed by the active lightbox source:
+  // author-browse mode pins the AuthorDetail grid; everything else (campaign +
+  // fallback) pins the campaign grid. -1 disables pinning when the lightbox is
+  // closed.
+  const campaignForceMountIndex =
+    isLightboxOpen && lightboxImageSource?.kind !== 'author' ? lightboxIndex : -1;
+  const authorForceMountIndex =
+    isLightboxOpen && lightboxImageSource?.kind === 'author' ? lightboxIndex : -1;
+
   // Lightbox animations are provided by the useLightboxAnimations hook
   const { openLightbox, closeLightbox, isAnimatingRef } = useLightboxAnimations({
     images: lightboxImages,
@@ -866,6 +878,8 @@ export default function App() {
           onBack={navigateToAuthorsIndex}
           onOpenImage={openLightboxForAuthor}
           gridRef={authorGridRef}
+          forceMountIndex={authorForceMountIndex}
+          thumbnailSizeKey={thumbnailSizeIndex}
         />
       )}
 
@@ -915,6 +929,8 @@ export default function App() {
               ref={galleryGridRef}
               images={currentImages}
               onImageClick={openLightboxForCampaign}
+              forceMountIndex={campaignForceMountIndex}
+              thumbnailSizeKey={thumbnailSizeIndex}
             />
           )}
         </main>

--- a/client/src/components/AuthorDetail.tsx
+++ b/client/src/components/AuthorDetail.tsx
@@ -37,6 +37,19 @@ interface Props {
    * the lightbox is in author-browse mode (lightboxImageSource.kind === 'author').
    */
   gridRef?: RefObject<GalleryGridHandle | null>;
+  /**
+   * Index whose card the windowed GalleryGrid must keep mounted regardless of
+   * scroll position, forwarded straight through to GalleryGrid. App sets this
+   * to the lightbox's current index while author-browse mode is open (else -1)
+   * so paging to a windowed-out image keeps its thumbnail measurable for the
+   * close/zoom animation. See useGridWindow / GalleryGrid.
+   */
+  forceMountIndex?: number;
+  /**
+   * Token that changes when the thumbnail-size setting changes; forwarded to
+   * GalleryGrid so the windowing hook re-measures column geometry.
+   */
+  thumbnailSizeKey?: unknown;
 }
 
 /**
@@ -47,7 +60,7 @@ interface Props {
  * Errors render an inline message rather than crashing the app — 404s from a
  * missing handle surface as "Failed to load author".
  */
-export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: Props) {
+export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef, forceMountIndex = -1, thumbnailSizeKey }: Props) {
   const { data, error } = useAuthorDetail(handle);
 
   // Whether we're viewing the synthetic "Unknown artist" page. Drives a few
@@ -222,6 +235,8 @@ export default function AuthorDetail({ handle, onBack, onOpenImage, gridRef }: P
                 isUnknownArtist ? 'Unattributed images' : `Images by ${data.author.name}`
               }
               testId="author-images-grid"
+              forceMountIndex={forceMountIndex}
+              thumbnailSizeKey={thumbnailSizeKey}
             />
           )}
         </>

--- a/client/src/components/GalleryGrid.tsx
+++ b/client/src/components/GalleryGrid.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useImperativeHandle, useRef } from 'react';
 import type { ImageData } from '../types/api';
 import ImageCard from './ImageCard';
+import { useGridWindow } from '../hooks/useGridWindow';
 
 /** Number of leading cards rendered with eager/high-priority loading. */
 export const EAGER_IMAGE_COUNT = 12;
@@ -9,10 +10,18 @@ export const EAGER_IMAGE_COUNT = 12;
 export interface GalleryGridHandle {
   /**
    * Returns the <img> element for the given image index, or null when the
-   * element is not currently mounted (e.g. image is still loading or the
-   * campaign changed).
+   * element is not currently mounted (e.g. image is still loading, the
+   * campaign changed, or the card is virtualized out of the current window).
    */
   getThumbElement: (index: number) => HTMLImageElement | null;
+  /**
+   * Scroll the given image index into the viewport so its card mounts. Used
+   * by the lightbox-open-at-index flow to guarantee a target card (which may
+   * be windowed out) is present and measurable before its thumbnail rect is
+   * read for the zoom animation. No-op when windowing is inactive (everything
+   * is already mounted) or the index is out of range.
+   */
+  scrollIndexIntoView: (index: number) => void;
 }
 
 interface GalleryGridProps {
@@ -30,34 +39,90 @@ interface GalleryGridProps {
    * grid for tests (e.g. the author-detail grid uses `author-images-grid`).
    */
   testId?: string;
+  /**
+   * Index whose card must stay mounted regardless of scroll position. Set to
+   * the lightbox's current image index while the lightbox is open (and -1
+   * otherwise) so paging next/prev to a windowed-out image still keeps that
+   * thumbnail in the DOM for the close/zoom animation. Defaults to -1.
+   */
+  forceMountIndex?: number;
+  /**
+   * Token that changes whenever the thumbnail-size setting changes. Forwarded
+   * to the windowing hook so it re-measures the column geometry (column count
+   * and row height depend on --thumbnail-min-size). Optional; defaults to a
+   * constant so non-campaign callers don't need to thread it.
+   */
+  thumbnailSizeKey?: unknown;
 }
 
 /**
- * Memoized gallery grid.
+ * Memoized, windowed gallery grid.
  *
  * App re-renders at 2.5 Hz while loadingDots ticks during image preload.
  * Wrapping this section in React.memo prevents the entire N-card VDOM diff
  * from running on every tick — React.memo's shallow prop compare means the
- * grid re-renders only when any prop (images, onImageClick, ariaLabel,
- * testId) changes identity. Keep `images` and `onImageClick` stable across
- * renders to retain the benefit; `ariaLabel`/`testId` are typically string
- * literals so they're effectively stable.
+ * grid re-renders only when any prop changes identity. Keep `images` and
+ * `onImageClick` stable across renders to retain the benefit; `ariaLabel`/
+ * `testId` are typically string literals so they're effectively stable.
  *
- * Callers are responsible for rendering their own empty-state UI (the
- * campaign view renders "No Images In Campaign" and AuthorDetail renders
- * "No images attributed to this author yet."). This keeps the grid a pure
- * list view, reusable across both call sites.
+ * Virtualization: only the cards whose rows intersect the viewport (plus an
+ * overscan margin) are rendered; the remaining vertical space is reserved with
+ * top/bottom spacer rows that span the full grid width so the layout, scrollbar
+ * and scroll position match a fully-rendered grid. See useGridWindow. In
+ * environments without real layout (jsdom unit tests) the hook reports a zero
+ * width and the grid renders every card, preserving the non-windowed contract.
+ *
+ * Callers are responsible for rendering their own empty-state UI (the campaign
+ * view renders "No Images In Campaign" and AuthorDetail renders "No images
+ * attributed to this author yet."). This keeps the grid a pure list view,
+ * reusable across both call sites.
  */
 const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridProps>(
-  function GalleryGrid({ images, onImageClick, ariaLabel, testId }, ref) {
+  function GalleryGrid(
+    { images, onImageClick, ariaLabel, testId, forceMountIndex = -1, thumbnailSizeKey },
+    ref,
+  ) {
     /** Tracks the <img> DOM element for each image index. */
     const thumbMapRef = useRef<Map<number, HTMLImageElement>>(new Map());
+    /** The grid <section> element, used to measure column geometry. */
+    const sectionRef = useRef<HTMLElement | null>(null);
+
+    const win = useGridWindow(sectionRef, images.length, thumbnailSizeKey, forceMountIndex);
 
     useImperativeHandle(ref, () => ({
       getThumbElement(index: number): HTMLImageElement | null {
         return thumbMapRef.current.get(index) ?? null;
       },
-    }), []);
+      scrollIndexIntoView(index: number): void {
+        if (index < 0 || index >= images.length) return;
+        // Already mounted: scroll the live element into view if needed.
+        const existing = thumbMapRef.current.get(index);
+        if (existing) {
+          try { existing.scrollIntoView({ block: 'nearest' }); } catch (_) { /* ignore */ }
+          return;
+        }
+        // Windowed out: estimate the row's document Y from the grid geometry
+        // and scroll the page so the row enters the viewport on the next
+        // recompute, which mounts the card.
+        const el = sectionRef.current;
+        if (!el || !win.windowed || win.columns < 1) return;
+        try {
+          const rect = el.getBoundingClientRect();
+          if (!(rect.width > 0)) return;
+          const cs = getComputedStyle(el);
+          const gap = parseFloat(cs.rowGap || cs.gap || '0') || 0;
+          const cellWidth = (rect.width - (win.columns - 1) * gap) / win.columns;
+          const rowHeight = cellWidth + gap;
+          if (!(rowHeight > 0)) return;
+          const row = Math.floor(index / win.columns);
+          const scrollY = window.scrollY || window.pageYOffset || 0;
+          const gridTop = rect.top + scrollY;
+          // Center the target row in the viewport.
+          const target = gridTop + row * rowHeight - Math.max(0, (window.innerHeight - rowHeight) / 2);
+          window.scrollTo({ top: Math.max(0, target) });
+        } catch (_) { /* ignore */ }
+      },
+    }), [images.length, win.windowed, win.columns]);
 
     /**
      * Cache of per-index callback refs so that the same function reference is
@@ -133,27 +198,62 @@ const GalleryGrid = React.memo(React.forwardRef<GalleryGridHandle, GalleryGridPr
       [],
     );
 
+    // Build the rendered slice. When windowing is inactive (no layout, or a
+    // list short enough not to bother) start/end cover the whole array, so this
+    // renders every card exactly as before.
+    const startIndex = win.windowed ? win.startIndex : 0;
+    const endIndex = win.windowed ? win.endIndex : images.length - 1;
+
+    const cards: React.ReactNode[] = [];
+    for (let i = startIndex; i <= endIndex && i < images.length; i++) {
+      const img = images[i];
+      cards.push(
+        <ImageCard
+          key={`${img.src}-${i}`}
+          image={img}
+          imgRef={setThumbRef(i)}
+          onClick={getClickCallback(i)}
+          // Eagerly load the first ~2-3 rows (above the fold) so they start
+          // downloading immediately; the rest stay native-lazy.
+          eager={i < EAGER_IMAGE_COUNT}
+        />,
+      );
+    }
+
     return (
       <section
         id="gallery"
         className="gallery-grid"
         aria-label={ariaLabel}
         data-testid={testId}
+        ref={sectionRef}
       >
-        {images.map((img, i) => (
-          <ImageCard
-            key={`${img.src}-${i}`}
-            image={img}
-            imgRef={setThumbRef(i)}
-            onClick={getClickCallback(i)}
-            // Eagerly load the first ~2-3 rows (above the fold) so they start
-            // downloading immediately; the rest stay native-lazy.
-            eager={i < EAGER_IMAGE_COUNT}
+        {win.windowed && win.topPadPx > 0 && (
+          // Spacer rows reserve the vertical space of the cards scrolled above
+          // the window. `grid-column: 1 / -1` makes it span the full row so it
+          // never consumes a card cell. aria-hidden + presentation keep it out
+          // of the accessibility tree.
+          <div
+            className="gallery-grid-spacer gallery-grid-spacer--top"
+            data-testid="gallery-grid-spacer-top"
+            aria-hidden="true"
+            role="presentation"
+            style={{ gridColumn: '1 / -1', height: `${win.topPadPx}px` }}
           />
-        ))}
+        )}
+        {cards}
+        {win.windowed && win.bottomPadPx > 0 && (
+          <div
+            className="gallery-grid-spacer gallery-grid-spacer--bottom"
+            data-testid="gallery-grid-spacer-bottom"
+            aria-hidden="true"
+            role="presentation"
+            style={{ gridColumn: '1 / -1', height: `${win.bottomPadPx}px` }}
+          />
+        )}
       </section>
     );
-  }
+  },
 ));
 
 export default GalleryGrid;

--- a/client/src/hooks/useGridWindow.ts
+++ b/client/src/hooks/useGridWindow.ts
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Windowing (virtual scrolling) for the CSS auto-fill gallery grid.
+ *
+ * The gallery uses `grid-template-columns: repeat(auto-fill, minmax(var(--thumbnail-min-size), 1fr))`
+ * so the column count is derived at render time from the rendered grid width and
+ * the current `--thumbnail-min-size`. Rather than render an ImageCard for every
+ * image (N DOM nodes scaling linearly with the campaign size), we render only
+ * the rows that intersect the viewport (plus an overscan margin) and reserve the
+ * remaining vertical space with top/bottom spacer rows so the scrollbar and
+ * scroll position stay correct.
+ *
+ * The page itself is the scroll container (no overflow scroller wraps the grid),
+ * so geometry is computed against `window.scrollY` / `window.innerHeight` and the
+ * grid section's absolute document offset.
+ *
+ * Degradation: in environments without real layout (jsdom unit tests) the grid
+ * reports a zero width and we fall back to rendering every card, so callers that
+ * don't lay out the DOM see the full, non-windowed behaviour.
+ */
+
+/** Extra rows rendered above and below the viewport to avoid blank flashes while scrolling. */
+const OVERSCAN_ROWS = 3;
+
+export interface GridWindow {
+  /** First image index that should be rendered (inclusive). */
+  startIndex: number;
+  /** Last image index that should be rendered (inclusive). */
+  endIndex: number;
+  /** Number of columns currently laid out (>= 1). */
+  columns: number;
+  /** Pixel height to reserve above the rendered window (top spacer). */
+  topPadPx: number;
+  /** Pixel height to reserve below the rendered window (bottom spacer). */
+  bottomPadPx: number;
+  /** True when windowing is active; false means "render everything" (no layout / tiny lists). */
+  windowed: boolean;
+}
+
+interface Metrics {
+  columns: number;
+  rowHeightPx: number;
+  /** Absolute document Y of the grid's content-box top. */
+  gridTopPx: number;
+  gapPx: number;
+}
+
+function fullRenderWindow(itemCount: number): GridWindow {
+  return {
+    startIndex: 0,
+    endIndex: itemCount - 1,
+    columns: 1,
+    topPadPx: 0,
+    bottomPadPx: 0,
+    windowed: false,
+  };
+}
+
+function readGapPx(el: HTMLElement): number {
+  const cs = getComputedStyle(el);
+  const gap = parseFloat(cs.rowGap || cs.gap || '0');
+  return Number.isFinite(gap) ? gap : 0;
+}
+
+/**
+ * Derive the current column count and per-row height from the grid element's
+ * rendered width and the CSS `--thumbnail-min-size`. Cells are square
+ * (aspect-ratio 1/1), so a cell's height equals its width.
+ */
+function measure(el: HTMLElement): Metrics | null {
+  const rect = el.getBoundingClientRect();
+  const width = rect.width;
+  // No layout (jsdom) or not yet measured: bail to full render.
+  if (!Number.isFinite(width) || width <= 0) return null;
+
+  const gapPx = readGapPx(el);
+
+  // --thumbnail-min-size may be set on :root; resolve via the element's own
+  // computed style so we honour any cascade. Falls back to the CSS default.
+  const minSizeRaw = getComputedStyle(el).getPropertyValue('--thumbnail-min-size').trim();
+  let minSize = parseFloat(minSizeRaw);
+  if (!Number.isFinite(minSize) || minSize <= 0) minSize = 160;
+
+  // auto-fill column count: how many minmax(minSize, 1fr) tracks fit, matching
+  // the browser's `repeat(auto-fill, ...)` math: floor((width + gap) / (min + gap)).
+  let columns = Math.floor((width + gapPx) / (minSize + gapPx));
+  if (!Number.isFinite(columns) || columns < 1) columns = 1;
+
+  // Actual cell width once columns are fixed: (width - (cols-1)*gap) / cols.
+  const cellWidth = (width - (columns - 1) * gapPx) / columns;
+  const rowHeightPx = cellWidth + gapPx; // square cell + the row gap below it
+  if (!Number.isFinite(rowHeightPx) || rowHeightPx <= 0) return null;
+
+  const scrollY = window.scrollY || window.pageYOffset || 0;
+  const gridTopPx = rect.top + scrollY;
+
+  return { columns, rowHeightPx, gridTopPx, gapPx };
+}
+
+/**
+ * Returns the current render window for `itemCount` items rendered into the
+ * grid referenced by `gridRef`. Recomputes on scroll, resize, and whenever
+ * `itemCount` or `thumbnailSizeKey` change (the latter changes column geometry).
+ *
+ * `forceIndex`, when >= 0, guarantees that index is inside the returned window
+ * even if it would otherwise be scrolled out (used to keep the lightbox's
+ * current image mounted so its thumbnail rect can be read for the zoom
+ * animation).
+ */
+export function useGridWindow(
+  gridRef: { current: HTMLElement | null },
+  itemCount: number,
+  thumbnailSizeKey: unknown,
+  forceIndex: number,
+): GridWindow {
+  const [win, setWin] = useState<GridWindow>(() => fullRenderWindow(itemCount));
+
+  // Latest forceIndex without retriggering the listener wiring on every change.
+  const forceIndexRef = useRef(forceIndex);
+  forceIndexRef.current = forceIndex;
+
+  const recompute = useCallback(() => {
+    const el = gridRef.current;
+    if (!el || itemCount <= 0) {
+      const next = fullRenderWindow(itemCount);
+      setWin(prev => (shallowEqualWindow(prev, next) ? prev : next));
+      return;
+    }
+
+    const m = measure(el);
+    if (!m) {
+      // No usable layout — render everything.
+      const next = fullRenderWindow(itemCount);
+      setWin(prev => (shallowEqualWindow(prev, next) ? prev : next));
+      return;
+    }
+
+    const { columns, rowHeightPx, gridTopPx, gapPx } = m;
+    const totalRows = Math.ceil(itemCount / columns);
+
+    // Tiny lists: not worth windowing; rendering all avoids spacer edge-cases.
+    if (totalRows <= OVERSCAN_ROWS * 2 + 1) {
+      const next: GridWindow = {
+        startIndex: 0,
+        endIndex: itemCount - 1,
+        columns,
+        topPadPx: 0,
+        bottomPadPx: 0,
+        windowed: false,
+      };
+      setWin(prev => (shallowEqualWindow(prev, next) ? prev : next));
+      return;
+    }
+
+    const viewportTop = window.scrollY || window.pageYOffset || 0;
+    const viewportHeight = window.innerHeight || 0;
+
+    // Offset of the viewport relative to the grid's top, in px.
+    const relTop = viewportTop - gridTopPx;
+    let firstVisibleRow = Math.floor(relTop / rowHeightPx) - OVERSCAN_ROWS;
+    let lastVisibleRow = Math.ceil((relTop + viewportHeight) / rowHeightPx) + OVERSCAN_ROWS;
+    if (firstVisibleRow < 0) firstVisibleRow = 0;
+    if (lastVisibleRow > totalRows - 1) lastVisibleRow = totalRows - 1;
+    if (lastVisibleRow < firstVisibleRow) lastVisibleRow = firstVisibleRow;
+
+    let startIndex = firstVisibleRow * columns;
+    let endIndex = Math.min(itemCount - 1, (lastVisibleRow + 1) * columns - 1);
+
+    // Keep a forced index (lightbox current image) mounted by expanding the
+    // window to include its whole row.
+    const fi = forceIndexRef.current;
+    if (fi >= 0 && fi < itemCount) {
+      const forcedRow = Math.floor(fi / columns);
+      const rowStart = forcedRow * columns;
+      const rowEnd = Math.min(itemCount - 1, rowStart + columns - 1);
+      if (rowStart < startIndex) startIndex = rowStart;
+      if (rowEnd > endIndex) endIndex = rowEnd;
+    }
+
+    const renderedStartRow = Math.floor(startIndex / columns);
+    const renderedEndRow = Math.floor(endIndex / columns);
+    const rowsAbove = renderedStartRow;
+    const rowsBelow = totalRows - 1 - renderedEndRow;
+
+    // Spacer heights. A full row occupies rowHeightPx (square cell + the row
+    // gap below it). The spacers stand in for the collapsed rows. Subtract one
+    // gap from the bottom spacer because no gap follows the final grid row.
+    const topPadPx = rowsAbove > 0 ? rowsAbove * rowHeightPx : 0;
+    const bottomPadPx = rowsBelow > 0 ? rowsBelow * rowHeightPx - gapPx : 0;
+
+    const next: GridWindow = {
+      startIndex,
+      endIndex,
+      columns,
+      topPadPx: Math.max(0, topPadPx),
+      bottomPadPx: Math.max(0, bottomPadPx),
+      windowed: true,
+    };
+    setWin(prev => (shallowEqualWindow(prev, next) ? prev : next));
+  }, [gridRef, itemCount]);
+
+  // Recompute on mount, item-count change, thumbnail-size change, and when the
+  // forced (lightbox) index changes.
+  useEffect(() => {
+    recompute();
+  }, [recompute, thumbnailSizeKey, forceIndex]);
+
+  // Scroll / resize listeners (passive). rAF-coalesced so a burst of scroll
+  // events triggers at most one recompute per frame.
+  useEffect(() => {
+    let scheduled = false;
+    const onChange = () => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        recompute();
+      });
+    };
+    window.addEventListener('scroll', onChange, { passive: true });
+    window.addEventListener('resize', onChange);
+
+    // ResizeObserver catches grid-width changes that aren't window resizes
+    // (e.g. layout shifts, font-load reflow).
+    let ro: ResizeObserver | null = null;
+    const el = gridRef.current;
+    if (el && typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(onChange);
+      ro.observe(el);
+    }
+    return () => {
+      window.removeEventListener('scroll', onChange);
+      window.removeEventListener('resize', onChange);
+      ro?.disconnect();
+    };
+  }, [recompute, gridRef]);
+
+  return win;
+}
+
+function shallowEqualWindow(a: GridWindow, b: GridWindow): boolean {
+  return (
+    a.startIndex === b.startIndex &&
+    a.endIndex === b.endIndex &&
+    a.columns === b.columns &&
+    a.topPadPx === b.topPadPx &&
+    a.bottomPadPx === b.bottomPadPx &&
+    a.windowed === b.windowed
+  );
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -361,6 +361,15 @@ footer.navbar {
   grid-template-columns: 1fr;
 }
 
+/* Virtual-scroll spacers: reserve the vertical space of the windowed-out rows
+   above/below the rendered slice so the scrollbar and scroll position match a
+   fully rendered grid. They span the full row (set inline via grid-column) and
+   carry no card styling (no background, no entrance animation). */
+.gallery-grid-spacer {
+  width: 100%;
+  pointer-events: none;
+}
+
 .empty-state {
   display: grid;
   justify-items: center;

--- a/client/test/GalleryGridWindowing.test.tsx
+++ b/client/test/GalleryGridWindowing.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React, { createRef } from 'react';
+import GalleryGrid, { type GalleryGridHandle } from '../src/components/GalleryGrid';
+import type { ImageData } from '../src/types/api';
+
+/**
+ * Windowing behaviour tests.
+ *
+ * jsdom performs no layout, so useGridWindow normally falls back to rendering
+ * everything. To exercise the windowing math we stub the geometry primitives
+ * the hook reads: the grid's getBoundingClientRect (width + top), the computed
+ * --thumbnail-min-size / gap, and the window viewport size. With those in place
+ * the hook activates and renders only the rows intersecting the (stubbed)
+ * viewport plus overscan.
+ */
+
+function makeImage(name: string, src = `/${name}`): ImageData {
+  return { fileName: name, src, loadedSrc: src, isLoading: false };
+}
+
+const noop = () => {};
+
+const GRID_WIDTH = 1000; // px
+const MIN_SIZE = 160; // --thumbnail-min-size
+const GAP = 10;
+const VIEWPORT_HEIGHT = 800;
+// floor((1000 + 10) / (160 + 10)) = floor(1010/170) = 5 columns
+const EXPECTED_COLUMNS = 5;
+
+let originalGBCR: typeof HTMLElement.prototype.getBoundingClientRect;
+let originalGCS: typeof window.getComputedStyle;
+
+beforeEach(() => {
+  originalGBCR = HTMLElement.prototype.getBoundingClientRect;
+  originalGCS = window.getComputedStyle;
+
+  // Grid sits at document top (top = 0 - scrollY). For simplicity keep the
+  // grid's rect.top fixed at 0 and drive the window via scrollY.
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    if ((this as HTMLElement).classList?.contains('gallery-grid')) {
+      const scrollY = window.scrollY || 0;
+      return {
+        width: GRID_WIDTH,
+        height: 5000,
+        top: 0 - scrollY,
+        left: 0,
+        right: GRID_WIDTH,
+        bottom: 5000 - scrollY,
+        x: 0,
+        y: 0 - scrollY,
+        toJSON: () => ({}),
+      } as DOMRect;
+    }
+    return {
+      width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(((el: Element) => {
+    if ((el as HTMLElement).classList?.contains('gallery-grid')) {
+      return {
+        gap: `${GAP}px`,
+        rowGap: `${GAP}px`,
+        getPropertyValue: (p: string) => (p === '--thumbnail-min-size' ? `${MIN_SIZE}px` : ''),
+      } as unknown as CSSStyleDeclaration;
+    }
+    return { gap: '0px', rowGap: '0px', getPropertyValue: () => '' } as unknown as CSSStyleDeclaration;
+  }) as typeof window.getComputedStyle);
+
+  Object.defineProperty(window, 'innerHeight', { value: VIEWPORT_HEIGHT, configurable: true });
+  window.scrollY = 0;
+});
+
+afterEach(() => {
+  HTMLElement.prototype.getBoundingClientRect = originalGBCR;
+  (window.getComputedStyle as unknown as { mockRestore?: () => void }).mockRestore?.();
+  window.getComputedStyle = originalGCS;
+  vi.restoreAllMocks();
+});
+
+describe('GalleryGrid windowing — large list renders a windowed subset', () => {
+  it('renders far fewer cards than the full list and inserts a bottom spacer', () => {
+    const total = 500;
+    const images = Array.from({ length: total }, (_, i) => makeImage(`img${i}.png`));
+    const { container } = render(<GalleryGrid images={images} onImageClick={noop} />);
+
+    const cardCount = container.querySelectorAll('.card').length;
+    // Windowing must be active: only a small fraction of 500 cards renders.
+    expect(cardCount).toBeGreaterThan(0);
+    expect(cardCount).toBeLessThan(total);
+    // Viewport 800px / row ~ (1000-4*10)/5 + 10 = 202px -> ~4 rows visible
+    // + 2*3 overscan rows = ~10 rows * 5 cols = ~50 cards. Generous upper bound.
+    expect(cardCount).toBeLessThanOrEqual(EXPECTED_COLUMNS * 14);
+
+    // At scroll top there's no top spacer but there must be a bottom spacer
+    // reserving the remaining rows.
+    expect(container.querySelector('[data-testid="gallery-grid-spacer-top"]')).toBeNull();
+    const bottom = container.querySelector('[data-testid="gallery-grid-spacer-bottom"]') as HTMLElement | null;
+    expect(bottom).not.toBeNull();
+    expect(parseFloat(bottom!.style.height)).toBeGreaterThan(0);
+  });
+
+  it('renders the first cards (index 0) at scroll top', () => {
+    const images = Array.from({ length: 500 }, (_, i) => makeImage(`img${i}.png`));
+    const ref = createRef<GalleryGridHandle>();
+    render(<GalleryGrid ref={ref} images={images} onImageClick={noop} />);
+    expect(ref.current!.getThumbElement(0)).toBeInstanceOf(HTMLImageElement);
+  });
+
+  it('does NOT mount a far-off-screen index when not forced', () => {
+    const images = Array.from({ length: 500 }, (_, i) => makeImage(`img${i}.png`));
+    const ref = createRef<GalleryGridHandle>();
+    render(<GalleryGrid ref={ref} images={images} onImageClick={noop} />);
+    // Index 499 is far below the viewport at scroll top: must be windowed out.
+    expect(ref.current!.getThumbElement(499)).toBeNull();
+  });
+});
+
+describe('GalleryGrid windowing — forceMountIndex keeps a target card mounted', () => {
+  it('mounts an otherwise-off-screen index so its thumbnail rect is readable (lightbox-open-at-index)', () => {
+    const images = Array.from({ length: 500 }, (_, i) => makeImage(`img${i}.png`));
+    const ref = createRef<GalleryGridHandle>();
+    const { rerender } = render(
+      <GalleryGrid ref={ref} images={images} onImageClick={noop} forceMountIndex={-1} />,
+    );
+
+    // Without forcing, index 480 is not mounted.
+    expect(ref.current!.getThumbElement(480)).toBeNull();
+
+    // Simulate the lightbox opening/paging to index 480 (App sets
+    // forceMountIndex). The card must now be in the DOM.
+    act(() => {
+      rerender(
+        <GalleryGrid ref={ref} images={images} onImageClick={noop} forceMountIndex={480} />,
+      );
+    });
+
+    const el = ref.current!.getThumbElement(480);
+    expect(el).toBeInstanceOf(HTMLImageElement);
+    expect(el?.src).toContain('/img480.png');
+  });
+});

--- a/e2e/gallery-virtualization.spec.ts
+++ b/e2e/gallery-virtualization.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import { waitForLoaderToFinish } from './helpers/wireframe';
+import { gotoZortAuthorDetail } from './helpers/author-browse';
+
+/**
+ * E2E coverage for gallery grid virtualization (fringematrix5-utaj).
+ *
+ * GalleryGrid windows its cards: only the rows in/near the viewport are
+ * rendered, with top/bottom spacer rows reserving the scrolled-out space. The
+ * same grid backs both the campaign gallery and the author-detail page.
+ *
+ * These tests verify:
+ *   (a) a large list renders only a windowed subset of cards (with a bottom
+ *       spacer reserving the rest), and
+ *   (b) opening the lightbox at an off-screen index (after scrolling down the
+ *       list) still works — the target card is mounted, its rect is read for
+ *       the zoom, and the lightbox shows the image with a HUD index well past
+ *       the first viewport.
+ *
+ * Data sourcing: campaign galleries need BLOB_READ_WRITE_TOKEN to be non-empty,
+ * so the campaign test skips in token-less environments. The author-detail
+ * grid for @Zort70 (~98 images) is backed by seed data and exercises the same
+ * windowing component, so the off-screen-open test runs there and only skips
+ * when the author list itself is empty / too small.
+ */
+
+const SPACER_BOTTOM = '[data-testid="gallery-grid-spacer-bottom"]';
+const SPACER_TOP = '[data-testid="gallery-grid-spacer-top"]';
+
+/** Navigate to the default gallery and wait for it to settle. */
+async function gotoGallery(page: Page) {
+  await page.goto('/');
+  await waitForLoaderToFinish(page);
+}
+
+test.describe('Gallery grid virtualization (fringematrix5-utaj)', () => {
+  test('campaign gallery renders only a windowed subset for a large campaign', async ({ page }) => {
+    await gotoGallery(page);
+
+    const cards = page.locator('.gallery-grid .card');
+    if ((await cards.count()) === 0) {
+      test.skip(true, 'No campaign images available (BLOB_READ_WRITE_TOKEN likely missing).');
+    }
+
+    // Windowing is active only when there are more rows than fit the viewport,
+    // signalled by a bottom spacer. Skip small campaigns — nothing to window.
+    const bottomSpacer = page.locator(SPACER_BOTTOM);
+    if ((await bottomSpacer.count()) === 0) {
+      test.skip(true, 'Active campaign is too small to trigger windowing.');
+    }
+
+    const spacerHeight = await bottomSpacer.evaluate((el) => el.getBoundingClientRect().height);
+    expect(spacerHeight).toBeGreaterThan(0);
+    // At scroll top there must be no top spacer.
+    await expect(page.locator(SPACER_TOP)).toHaveCount(0);
+    // The document scrolls beyond one viewport (spacer reserves unrendered rows).
+    const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+    const innerHeight = await page.evaluate(() => window.innerHeight);
+    expect(scrollHeight).toBeGreaterThan(innerHeight);
+  });
+
+  test('author grid windows a large list and opens the lightbox at an off-screen index', async ({ page }) => {
+    const total = await gotoZortAuthorDetail(page); // skips if empty
+    const grid = page.locator('[data-testid="author-images-grid"]');
+
+    // Need enough images to actually window. If the bottom spacer is absent the
+    // whole list fits the viewport — nothing to virtualize, so skip.
+    const bottomSpacer = grid.locator(SPACER_BOTTOM);
+    if ((await bottomSpacer.count()) === 0) {
+      test.skip(true, `Author list (${total}) is too small to trigger windowing.`);
+    }
+
+    // Windowed: fewer cards mounted than the author's full total.
+    const mountedAtTop = await grid.locator('.card img').count();
+    expect(mountedAtTop).toBeGreaterThan(0);
+    expect(mountedAtTop).toBeLessThan(total);
+
+    // Scroll to the bottom so the last rows mount and the early rows window out.
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    await page.waitForTimeout(200);
+    await expect(grid.locator(SPACER_TOP)).toHaveCount(1);
+
+    // Click the last currently-rendered card — an index well past the first
+    // viewport, i.e. one that was virtualized out at the start.
+    const imgs = grid.locator('.card img');
+    const n = await imgs.count();
+    expect(n).toBeGreaterThan(0);
+    const lastImg: Locator = imgs.nth(n - 1);
+    await lastImg.scrollIntoViewIfNeeded();
+    await lastImg.click();
+
+    // The lightbox opens and shows the image (not stuck invisible): proves the
+    // off-screen card's rect was readable for the open animation.
+    const lightbox = page.locator('#lightbox');
+    await expect(lightbox).toBeVisible();
+    await expect(page.locator('#lightbox-image')).toBeVisible();
+
+    // HUD index well past 1 confirms we opened at a high, off-screen index.
+    const hud = page.locator('.lightbox-hud');
+    await expect(hud).toBeVisible();
+    const text = (await hud.textContent()) ?? '';
+    const match = text.match(/(\d+)\s+OF\s+(\d+)/);
+    expect(match, `HUD text "${text}" did not match "N OF M"`).not.toBeNull();
+    const current = Number(match![1]);
+    expect(Number(match![2])).toBe(total);
+    expect(current).toBeGreaterThan(1);
+
+    // Close cleanly (exercises the close/zoom path back to the off-screen thumb,
+    // which the forceMountIndex pin keeps mounted).
+    await page.keyboard.press('Escape');
+    await expect(lightbox).toBeHidden();
+  });
+});

--- a/e2e/helpers/author-browse.ts
+++ b/e2e/helpers/author-browse.ts
@@ -19,8 +19,12 @@ export const ZORT_HASH = `#authors/${encodeURIComponent(ZORT_HANDLE)}`;
  * Navigate to the @Zort70 author detail page and wait for it to populate.
  *
  * Resolution rules:
- *   - If the gallery grid renders, returns the thumbnail count (== the
- *     count the lightbox counter should reflect).
+ *   - If the gallery grid renders, returns the author's full image count read
+ *     from the `.author-count` header (== the count the lightbox counter
+ *     should reflect). The header total is used rather than counting rendered
+ *     `.card img` thumbnails because the grid is virtualized — only the cards
+ *     in/near the viewport are mounted, so a DOM card count would undercount a
+ *     large author list.
  *   - If the page renders the explicit empty-state status instead (i.e. the
  *     backend returned 0 attributed images for @Zort70, which in practice
  *     happens when `BLOB_READ_WRITE_TOKEN` is absent and the live blob
@@ -64,5 +68,12 @@ export async function gotoZortAuthorDetail(page: Page): Promise<number> {
     );
   }
 
-  return grid.locator('.card img').count();
+  // Read the author's full image count from the header. The grid is
+  // virtualized so the number of mounted `.card img` nodes reflects only the
+  // current scroll window, not the author's total — which is what the lightbox
+  // HUD counter reports. The `.author-count` element renders "<N> image(s)".
+  const countText = (await page.locator('.author-count').first().textContent()) ?? '';
+  const m = countText.match(/(\d+)/);
+  expect(m, `author-count text "${countText}" did not contain a number`).not.toBeNull();
+  return Number(m![1]);
 }

--- a/e2e/lightbox-author-row.spec.ts
+++ b/e2e/lightbox-author-row.spec.ts
@@ -48,6 +48,25 @@ async function openLightboxForFile(page: Page, fileName: string): Promise<OpenRe
   if ((await cards.count()) === 0) return { status: 'empty' };
 
   const target = page.locator(`.gallery-grid .card img[alt="${fileName}"]`);
+  // The gallery grid is virtualized — only the cards in/near the viewport are
+  // mounted, so a target lower in the list may not be in the DOM yet. Scroll
+  // the page down in viewport-sized steps until the target card mounts or we
+  // reach the bottom, then proceed with the usual missing/opened logic.
+  if ((await target.count()) === 0) {
+    let lastScrollY = -1;
+    for (let i = 0; i < 60; i++) {
+      if ((await target.count()) > 0) break;
+      const atBottom = await page.evaluate(() => {
+        const prev = window.scrollY;
+        window.scrollBy(0, Math.round(window.innerHeight * 0.8));
+        return { prev, next: window.scrollY };
+      });
+      // Give the windowing recompute (rAF) a frame to mount the new rows.
+      await page.waitForTimeout(120);
+      if (atBottom.next === lastScrollY) break; // scroll didn't move — bottom reached
+      lastScrollY = atBottom.next;
+    }
+  }
   if ((await target.count()) === 0) {
     // Capture a sample of available alt values so the failure message points
     // straight at the likely culprit (file renamed, moved, removed).


### PR DESCRIPTION
## Bead
fringematrix5-utaj — Virtualize/window the gallery grid for large campaigns (P3, feature).

## Summary
The gallery grid (shared by the campaign view and the author-detail page) previously rendered an `ImageCard` to the DOM for **every** image in a campaign/artist — VDOM + DOM node count scaled linearly with list size. This PR windows the grid so only the rows in/near the viewport are mounted.

**Virtualizer choice: a focused, dependency-free row-based windowing hook (`useGridWindow`), not a library.** Rationale:
- The grid uses CSS `repeat(auto-fill, minmax(var(--thumbnail-min-size), 1fr))`, so column count is variable and must be derived from the rendered width and the current `--thumbnail-min-size`. The hook computes columns with the exact auto-fill math (`floor((width + gap) / (min + gap))`), derives the square cell/row height, and recomputes on scroll, resize, `ResizeObserver`, and thumbnail-size change.
- The page itself is the scroll container (no overflow scroller wraps the grid), so geometry is measured against `window.scrollY` / `window.innerHeight` and the grid's absolute document offset. A library tuned for an internal scroll element would have fought this.
- Full control over the **lightbox-open-at-index** flow (see below) was the deciding factor.

Scrolled-out rows are replaced by top/bottom spacer divs (`grid-column: 1 / -1`, `aria-hidden`) that reserve the exact pixel height of the collapsed rows, so the scrollbar and scroll position match a fully-rendered grid.

### How the lightbox-open-at-index flow is preserved
`useLightboxAnimations` reads the source thumbnail's `getBoundingClientRect` (via the grid's per-index ref-callback cache, resolved in `App.tsx`) to fly the zoom in/out. If a target card were windowed out, its rect couldn't be read.
- Opens always originate from a click on an already-mounted thumbnail, so the open rect is always available.
- For navigation (next/prev) and close while the lightbox is open, `App` passes `forceMountIndex = lightboxIndex` to the grid (routed to the campaign grid or author grid by the active lightbox source). `useGridWindow` expands the window to always include that index's whole row, so `getThumbElement(lightboxIndex)` keeps returning a live, laid-out element for the close/zoom animation — even when the user has paged far down a windowed list.
- The grid also exposes `scrollIndexIntoView(index)` on its handle for robustness/future deep-linking.
- The existing fallback cascade in `closeLightbox` (live lookup → activeGridThumbRef → lastOpenedThumbElRef → no-thumbnail backdrop-only close) is untouched.

### Preserved invariants
- `React.memo` on GalleryGrid/ImageCard, the per-index ref + click callback caches, and `EAGER_IMAGE_COUNT` (first N eager/high-priority) are all kept.
- Author view shares the same windowed grid (`forceMountIndex`/`thumbnailSizeKey` threaded through `AuthorDetail`).
- Graceful degradation: where there is no layout (jsdom unit tests) or the list is short, the hook reports zero/small geometry and the grid renders every card — preserving the prior non-windowed contract.
- On campaign switch the existing cache-pruning + `images.length` reset keeps scroll/window sane.

## Files changed
- `client/src/hooks/useGridWindow.ts` (new) — windowing math + listeners.
- `client/src/components/GalleryGrid.tsx` — render only the window, spacers, `forceMountIndex`/`thumbnailSizeKey` props, `scrollIndexIntoView` handle.
- `client/src/components/AuthorDetail.tsx` — thread `forceMountIndex`/`thumbnailSizeKey`.
- `client/src/App.tsx` — derive + pass per-grid `forceMountIndex` and `thumbnailSizeKey`.
- `client/src/styles.css` — `.gallery-grid-spacer` rule.
- `client/test/GalleryGridWindowing.test.tsx` (new) — windowed-subset render + `forceMountIndex` mounts an off-screen index.
- `e2e/gallery-virtualization.spec.ts` (new) — windowed subset + open lightbox at an off-screen index and close.
- `e2e/helpers/author-browse.ts`, `e2e/lightbox-author-row.spec.ts` — adapted existing helpers for the windowed grid (read total from header; scroll to mount a target).

## Test plan
- `npm run typecheck` — green.
- `npm test` (scripts + server 113 + client 709, incl. new windowing tests) — green.
- `npm run test:e2e` — 63 passed, 39 skipped (token-less campaign-data skips, pre-existing convention), 0 failed. The new author-grid off-screen-open e2e exercises windowing + the lightbox-open-at-index flow against ~98 real images.
- Manual smoke: large author list mounts only a subset; scrolling mounts/unmounts rows with correct scroll height; opening the lightbox on a card scrolled near the end zooms correctly and closes back to the (off-screen) thumbnail.

## Follow-ups
- The campaign-gallery virtualization e2e skips without `BLOB_READ_WRITE_TOKEN` (no campaign images locally); it will run in CI/prod where campaigns have images.
- Card entrance-stagger `:nth-child` delays only apply when no top spacer is present (i.e. at scroll top); minor cosmetic, not pursued here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
